### PR TITLE
docs: add architecture decision records

### DIFF
--- a/docs/decisions/ADR-001-clean-architecture.md
+++ b/docs/decisions/ADR-001-clean-architecture.md
@@ -1,0 +1,195 @@
+# ADR-001: Use Clean Architecture
+
+## Status
+
+Accepted
+
+## Context
+
+OpsSphere is an enterprise support operations platform designed for BPO and contact center environments.
+
+The system must support ticket management, customer management, SLA tracking, escalation workflows, internal comments, dashboards, audit history, authentication, authorization, and role-based access control across regions, countries, accounts, campaigns, supervisors, agents, managers, and viewers.
+
+Because the system contains business workflows, authorization rules, audit requirements, and operational constraints, the project needs an architecture that keeps business logic separated from technical details such as controllers, database access, frontend implementation, authentication infrastructure, logging, and external services.
+
+The project also needs to remain maintainable and testable as the platform grows through MVP, Phase 2, and future enterprise-ready capabilities.
+
+## Decision
+
+OpsSphere will use Clean Architecture as the primary backend architecture style.
+
+The backend will be organized around the following layers:
+
+```text
+Presentation
+  → Application
+    → Domain
+      ← Infrastructure
+```
+
+The dependency direction must point inward.
+
+The Domain layer must not depend on:
+
+```text
+- ASP.NET Core controllers
+- Angular frontend
+- Entity Framework Core
+- SQL Server
+- JWT infrastructure
+- Logging infrastructure
+- Email providers
+- Azure services
+- External integrations
+```
+
+The Application layer will coordinate use cases through commands, queries, handlers, validators, authorization coordination, transaction boundaries, and audit coordination.
+
+The Infrastructure layer will implement technical concerns such as persistence, database access, authentication services, token generation, logging, and future external integrations.
+
+## Rationale
+
+Clean Architecture is used because OpsSphere has business rules that should remain independent from frameworks and infrastructure.
+
+Examples of business rules include:
+
+```text
+- A ticket must be linked to a customer.
+- A ticket must be linked to an account and campaign.
+- A ticket must follow valid status transitions.
+- A ticket must be resolved before it can be closed.
+- Closed tickets cannot be modified unless reopened by an authorized role.
+- Escalated tickets must include an escalation reason.
+- Internal comments cannot be empty.
+- Users must operate within their assigned role and operational scope.
+- Critical business actions must be recorded in audit history.
+```
+
+These rules should not be hidden inside controllers, database queries, UI logic, or framework-specific code.
+
+Clean Architecture supports the main quality goals of OpsSphere:
+
+```text
+Maintainability:
+The system can evolve without mixing business logic with infrastructure details.
+
+Testability:
+Domain rules and application use cases can be tested without depending on the UI, database, or external services.
+
+Security:
+Authorization rules can be coordinated in the application layer and enforced consistently by the backend.
+
+Auditability:
+Critical workflows can consistently produce audit records as part of application use cases.
+
+Scalability readiness:
+Future modules, integrations, workers, reporting exports, and Azure services can be added without rewriting the core domain.
+
+Operational clarity:
+The architecture reflects the business model of tickets, customers, SLAs, escalations, roles, scopes, and audit history.
+```
+
+## Consequences
+
+### Positive Consequences
+
+- Business logic remains independent from ASP.NET Core controllers.
+- The domain model can focus on operational rules instead of persistence concerns.
+- Application use cases become explicit and easier to test.
+- Infrastructure details can be replaced or extended with less impact on the core system.
+- The project demonstrates enterprise-level architecture practices.
+- The backend structure supports future growth, including background jobs, notifications, reporting exports, and Azure deployment.
+- The system is better prepared for automated testing.
+
+### Negative Consequences
+
+- The initial project structure is more complex than a simple CRUD application.
+- More folders, projects, interfaces, commands, queries, and handlers may be required.
+- Developers must understand dependency direction and layer responsibilities.
+- There is a risk of overengineering if the pattern is applied too rigidly.
+- Simple features may require more files than in a traditional layered or controller-based approach.
+
+## Alternatives Considered
+
+### Simple CRUD Architecture
+
+A simple CRUD architecture would place most logic directly in controllers or services close to the API layer.
+
+Rejected because OpsSphere is not only a basic ticketing system. It includes business workflows, role-based access, scope-based visibility, SLA behavior, audit history, and operational rules that would become hard to maintain if mixed into controllers.
+
+### Traditional Layered Architecture
+
+A traditional layered architecture could separate UI, business logic, and data access.
+
+Rejected as the primary style because traditional layering often allows business logic to become dependent on infrastructure or database models. OpsSphere needs stronger protection around the Domain and Application layers.
+
+### Database-Centric Architecture
+
+A database-centric approach would rely heavily on stored procedures, database rules, or direct data access patterns.
+
+Rejected because the project needs testable business workflows in the application code, not only database-level behavior. SQL Server remains important, but it should not become the main owner of application behavior.
+
+### Microservices Architecture
+
+A microservices approach would split the platform into multiple independently deployable services.
+
+Rejected for the initial version because it would add unnecessary operational complexity. OpsSphere should start as a modular monolith using Clean Architecture and only consider service extraction if future scale or team structure justifies it.
+
+## Implementation Notes
+
+The initial backend solution should follow this structure:
+
+```text
+src/
+  OpsSphere.Api/
+    Controllers/
+    Middleware/
+    Authentication/
+    Authorization/
+    DependencyInjection/
+
+  OpsSphere.Application/
+    Common/
+    Interfaces/
+    Behaviors/
+    Features/
+      Auth/
+      Users/
+      Customers/
+      Tickets/
+      Comments/
+      SLA/
+      Dashboards/
+      Reports/
+      Audit/
+
+  OpsSphere.Domain/
+    Entities/
+    ValueObjects/
+    Enums/
+    Events/
+    Exceptions/
+    Rules/
+
+  OpsSphere.Infrastructure/
+    Persistence/
+    Identity/
+    Authentication/
+    Authorization/
+    Logging/
+    Services/
+```
+
+Controllers should remain thin.
+
+Application handlers should coordinate use cases.
+
+Domain entities and domain services should protect business invariants.
+
+Infrastructure should implement persistence, authentication, logging, and external service details.
+
+## Decision Scope
+
+This ADR applies to the backend architecture of OpsSphere.
+
+It does not define the frontend architecture, database engine, authentication mechanism, or ORM choice. Those decisions are documented in separate ADRs.

--- a/docs/decisions/ADR-002-sql-server.md
+++ b/docs/decisions/ADR-002-sql-server.md
@@ -1,0 +1,212 @@
+# ADR-002: Use SQL Server as the Primary Database
+
+## Status
+
+Accepted
+
+## Context
+
+OpsSphere needs to store structured operational data for a multinational BPO and contact center environment.
+
+The system must manage users, roles, permissions, regions, countries, accounts, campaigns, customers, tickets, ticket assignments, internal comments, SLA state, escalations, resolutions, audit history, dashboards, and reporting-ready operational data.
+
+The data model contains many relational concepts:
+
+```text
+Region
+  → Country
+    → Account
+      → Campaign
+        → Ticket
+```
+
+Tickets must also be linked to:
+
+```text
+- Customer
+- Created by user
+- Assigned agent
+- Supervisor
+- Priority
+- Status
+- SLA state
+- Comments
+- Escalations
+- Resolution
+- Audit records
+```
+
+OpsSphere also needs strong consistency for important business operations such as ticket creation, assignment, SLA tracking, status changes, user role changes, scope changes, and audit logging.
+
+Because the platform is designed as an enterprise-grade .NET application, the database choice should align with the backend stack, relational data requirements, reporting needs, and Azure-ready deployment strategy.
+
+## Decision
+
+OpsSphere will use SQL Server as the primary relational database.
+
+SQL Server will store the core operational data for:
+
+```text
+- Identity and access
+- Users
+- Roles
+- Permissions
+- User scopes
+- Regions
+- Countries
+- Accounts
+- Campaigns
+- Customers
+- Tickets
+- Ticket comments
+- Ticket assignments
+- Ticket escalations
+- Ticket status history
+- Ticket resolutions
+- SLA policies
+- Ticket SLA state
+- Audit logs
+- Reporting-ready operational views
+```
+
+Entity Framework Core will be used as the primary data access technology for the application.
+
+## Rationale
+
+SQL Server is a strong fit for OpsSphere because the system is centered around structured business records, relational integrity, operational history, and reporting-ready data.
+
+OpsSphere requires relationships between users, roles, scopes, organizational structure, customers, tickets, SLAs, comments, escalations, and audit records. A relational database makes these relationships explicit and enforceable through primary keys, foreign keys, indexes, constraints, and transactions.
+
+SQL Server also fits the selected technology stack:
+
+```text
+Backend:
+- .NET 8
+- ASP.NET Core Web API
+- Entity Framework Core
+
+Database:
+- SQL Server
+
+Cloud readiness:
+- Azure SQL
+```
+
+This makes the project easier to position as an enterprise .NET platform and keeps the architecture aligned with common senior .NET development environments.
+
+SQL Server also supports future reporting needs. OpsSphere is not intended to replace Power BI, but it should produce clean, structured operational data that can later support external reporting and business intelligence tools.
+
+## Consequences
+
+### Positive Consequences
+
+- Relational integrity can be enforced through foreign keys and constraints.
+- Ticket, customer, account, campaign, user, SLA, and audit data can be modeled clearly.
+- Transactions can protect important workflows such as ticket creation and audit logging.
+- SQL Server aligns well with .NET, Entity Framework Core, and Azure SQL.
+- The database can support indexed filtering for dashboards, queues, SLA views, and reports.
+- Structured data can later be exported or consumed by reporting tools such as Power BI.
+- SQL Server is familiar in enterprise environments and common in .NET job requirements.
+
+### Negative Consequences
+
+- SQL Server adds more setup complexity than an embedded or file-based database.
+- Local development may require Docker, SQL Server Express, LocalDB, or another SQL Server-compatible setup.
+- Schema design must be handled carefully to avoid unnecessary complexity.
+- Migrations must be managed consistently through Entity Framework Core.
+- Poor indexing or excessive joins could affect dashboard and reporting performance if the data grows.
+- SQL Server may be heavier than needed for very small prototypes.
+
+## Alternatives Considered
+
+### PostgreSQL
+
+PostgreSQL is a strong relational database and could also support the needs of OpsSphere.
+
+Rejected for this project because the selected portfolio stack is intentionally focused on enterprise .NET, SQL Server, Entity Framework Core, and Azure-ready architecture.
+
+PostgreSQL remains a valid alternative for other contexts, but SQL Server better supports the positioning of OpsSphere as a senior-level .NET enterprise project.
+
+### SQLite
+
+SQLite would be simple for local development and lightweight prototypes.
+
+Rejected because OpsSphere is intended to simulate an enterprise operations platform, not a small local application. SQLite would not represent the expected production-style database environment for this project.
+
+### MongoDB or Other NoSQL Database
+
+A document database could store flexible ticket data or event-like structures.
+
+Rejected because OpsSphere has a strongly relational domain model. Users, roles, permissions, scopes, accounts, campaigns, tickets, SLAs, assignments, comments, and audit logs require clear relationships and consistency.
+
+NoSQL may be considered in the future for specialized use cases such as event streams, search indexes, or analytics, but not as the primary database.
+
+### In-Memory Database
+
+An in-memory database could be useful for tests or temporary development scenarios.
+
+Rejected as the primary database because OpsSphere requires persistent operational data, relational integrity, audit history, and realistic enterprise database behavior.
+
+## Implementation Notes
+
+The database design should follow these principles:
+
+```text
+- Use relational integrity for core business relationships.
+- Use foreign keys for important entity relationships.
+- Use indexes for common filters and dashboard queries.
+- Preserve historical traceability.
+- Prefer deactivation or soft deletion when historical records depend on existing data.
+- Store timestamps in UTC.
+- Keep audit logs immutable where possible.
+- Use Entity Framework Core migrations to evolve the schema.
+```
+
+Initial database areas:
+
+```text
+Identity and Access
+  - Users
+  - Roles
+  - Permissions
+  - UserRoles
+  - RolePermissions
+  - UserScopes
+
+Organization Structure
+  - Regions
+  - Countries
+  - Accounts
+  - Campaigns
+  - ManagerAssignments
+  - SupervisorAssignments
+  - AgentAssignments
+
+Customer Management
+  - Customers
+
+Ticket Management
+  - Tickets
+  - TicketComments
+  - TicketAssignments
+  - TicketEscalations
+  - TicketStatusHistory
+  - TicketResolutions
+
+SLA Management
+  - SlaPolicies
+  - TicketSlaStates
+
+Audit
+  - AuditLogs
+
+Reporting Support
+  - Indexed operational fields
+  - Reporting-ready views or exports
+```
+
+## Decision Scope
+
+This ADR defines SQL Server as the primary database engine for OpsSphere.
+
+It does not define the complete physical schema, table structure, indexing strategy, or migration implementation. Those details belong in the database design documentation and implementation work.

--- a/docs/decisions/ADR-003-jwt-authentication.md
+++ b/docs/decisions/ADR-003-jwt-authentication.md
@@ -1,0 +1,194 @@
+# ADR-003: Use JWT Authentication
+
+## Status
+
+Accepted
+
+## Context
+
+OpsSphere is an internal enterprise operations platform used by Admins, Operations Managers, Supervisors, Agents, and Viewers.
+
+The platform must protect API endpoints and restrict access to operational data such as tickets, customers, users, roles, permissions, SLA state, dashboards, reports, and audit history.
+
+OpsSphere also needs to support role-based authorization and scope-based visibility.
+
+Users must only access the data and actions allowed by their role and assigned operational scope.
+
+Examples:
+
+```text
+- Admins can manage users, roles, permissions, and operational structure.
+- Operations Managers can view operational data within their assigned regions.
+- Supervisors can manage tickets within assigned accounts or campaigns.
+- Agents can work only on tickets within their assigned scope.
+- Viewers can access read-only operational information.
+```
+
+Because OpsSphere uses an Angular frontend and an ASP.NET Core Web API backend, the authentication approach must work well with a browser-based frontend calling protected API endpoints over HTTP.
+
+## Decision
+
+OpsSphere will use JWT-based authentication for API access.
+
+After a successful login, the backend will issue a JSON Web Token that the Angular frontend can include in subsequent API requests.
+
+Protected API endpoints must require a valid token.
+
+The backend will validate the token before allowing access to protected resources.
+
+Role-based authorization and scope-based authorization will be enforced by the backend.
+
+The frontend may use role and scope information to improve navigation and hide unauthorized actions, but frontend visibility must not be treated as the security boundary.
+
+## Rationale
+
+JWT authentication is a good fit for OpsSphere because it works naturally with a frontend SPA and a backend Web API.
+
+The Angular frontend can authenticate once, receive a token, and send that token with API requests.
+
+The ASP.NET Core Web API can validate the token and identify the authenticated user before applying authorization rules.
+
+This supports the runtime flow:
+
+```text
+User
+  → Angular Login Page
+  → ASP.NET Core Auth Endpoint
+  → Validate Credentials
+  → Verify Active User
+  → Load Roles and Scope
+  → Generate JWT
+  → Return Token to Frontend
+  → Frontend Stores Token
+  → User Accesses Protected Features
+```
+
+JWT also helps keep authentication separate from the frontend and business workflows.
+
+The token establishes user identity, while the application still enforces authorization through roles, permissions, and operational scope.
+
+This is important because OpsSphere must prevent unauthorized access to sensitive operational data.
+
+## Consequences
+
+### Positive Consequences
+
+- JWT works well with Angular and ASP.NET Core Web API.
+- Protected API endpoints can validate authentication consistently.
+- The backend can identify the authenticated user for authorization and audit logging.
+- The system can support role-based access control.
+- The system can support scope-based visibility checks.
+- The frontend can call APIs without depending on server-rendered sessions.
+- The approach is common in modern API-based applications.
+- The decision aligns with the selected .NET and Angular architecture.
+
+### Negative Consequences
+
+- Token handling must be implemented carefully to avoid security weaknesses.
+- Token expiration and refresh behavior must be designed clearly.
+- If a token is compromised, it may remain usable until expiration unless revocation is implemented.
+- Storing tokens in the browser introduces security considerations.
+- JWT payloads must not contain sensitive data.
+- Logout behavior is less direct than server-side session invalidation unless token revocation or short-lived tokens are used.
+- Scope and permission changes may not take effect immediately if old tokens remain valid.
+
+## Alternatives Considered
+
+### Cookie-Based Authentication
+
+Cookie-based authentication is common for server-rendered web applications.
+
+Rejected as the primary approach because OpsSphere is designed as an Angular SPA calling an ASP.NET Core Web API. JWT provides a clearer API-oriented authentication model for this architecture.
+
+Cookie authentication may still be considered in the future if the frontend and backend deployment model changes or if a same-site browser security model becomes preferable.
+
+### Server-Side Sessions
+
+Server-side sessions would allow the backend to maintain active session state.
+
+Rejected because OpsSphere does not require server-side session storage for the initial version. A stateless token approach is simpler for the Angular plus Web API model.
+
+Server-side session tracking may be considered later if stricter revocation, device management, or enterprise session controls are required.
+
+### Enterprise SSO
+
+Enterprise SSO through an identity provider would be appropriate in a real production enterprise environment.
+
+Rejected for the initial version because production-grade SSO is outside the MVP scope.
+
+OpsSphere should remain Azure-ready and integration-ready, but the initial version will use local application authentication with JWT.
+
+### API Keys
+
+API keys are useful for machine-to-machine integrations.
+
+Rejected for user authentication because OpsSphere is primarily used by internal human users with roles, permissions, and operational scopes.
+
+API keys may be considered in the future for integrations, exports, automation, or external reporting pipelines.
+
+## Implementation Notes
+
+The authentication flow should follow this structure:
+
+```text
+1. User submits login credentials from Angular.
+2. ASP.NET Core Auth endpoint receives the login request.
+3. Application layer validates credentials.
+4. System verifies that the user is active.
+5. System loads the user's role and operational scope.
+6. Token service generates a JWT.
+7. API returns the token and minimal user profile information.
+8. Angular stores the token according to the chosen security strategy.
+9. Angular sends the token with protected API requests.
+10. Backend validates the token.
+11. Backend applies role-based and scope-based authorization.
+12. Backend records audit-relevant actions with the authenticated user identity.
+```
+
+Protected endpoints must enforce:
+
+```text
+- Valid authentication token.
+- Active user status where applicable.
+- Required role.
+- Required permission.
+- Required operational scope.
+```
+
+JWT claims should be minimal.
+
+Recommended claim types may include:
+
+```text
+- User identifier
+- Email or username
+- Role
+- Scope reference when appropriate
+- Token expiration
+```
+
+JWT claims should not include sensitive operational data.
+
+Token expiration should be configured intentionally.
+
+For the MVP, a simple expiration strategy is acceptable.
+
+Future improvements may include:
+
+```text
+- Refresh tokens
+- Token revocation
+- Login audit events
+- Failed login tracking
+- Account lockout policies
+- Enterprise SSO integration
+- Azure Key Vault for signing secrets
+```
+
+## Decision Scope
+
+This ADR defines JWT as the authentication approach for OpsSphere API access.
+
+It does not define the full authorization matrix, password policy, refresh token strategy, token storage strategy, or enterprise SSO integration.
+
+Those details should be handled in security documentation and implementation-specific tasks.

--- a/docs/decisions/ADR-004-angular-frontend.md
+++ b/docs/decisions/ADR-004-angular-frontend.md
@@ -1,0 +1,209 @@
+# ADR-004: Use Angular for the Frontend
+
+## Status
+
+Accepted
+
+## Context
+
+OpsSphere needs a frontend application for internal operational users such as Admins, Operations Managers, Supervisors, Agents, and Viewers.
+
+The frontend must support enterprise-style workflows, including:
+
+```text
+- Login
+- Role-aware navigation
+- Dashboards
+- Ticket queues
+- Ticket detail views
+- Ticket creation forms
+- Customer management
+- User management
+- Operational structure management
+- SLA views
+- Escalation views
+- Audit history views
+- Reports or exports
+```
+
+The frontend must work with an ASP.NET Core Web API backend and consume protected HTTP endpoints using JWT authentication.
+
+The user interface must also support role-based and scope-aware behavior. For example, Viewers should not see write actions, Agents should only see ticket actions within their scope, and Admins should have access to administrative modules.
+
+Because OpsSphere is intended to demonstrate enterprise full stack development, the frontend technology should be mature, structured, strongly typed, and commonly used in professional .NET environments.
+
+## Decision
+
+OpsSphere will use Angular as the primary frontend framework.
+
+The frontend will be built with:
+
+```text
+- Angular
+- TypeScript
+- RxJS
+- Reactive Forms
+- Angular Router
+- Route guards
+- HTTP interceptors
+- Angular Material or Tailwind for UI structure
+```
+
+Angular will communicate with the backend through REST API calls exposed by the ASP.NET Core Web API.
+
+The frontend will use JWT authentication for protected API calls.
+
+Frontend role and scope checks may be used to improve user experience, but backend authorization remains the source of truth.
+
+## Rationale
+
+Angular is a good fit for OpsSphere because the application has enterprise-style workflows, multiple user roles, protected routes, forms, dashboards, and structured modules.
+
+OpsSphere is not a small landing page or simple static interface. It needs a frontend that can scale across multiple operational areas:
+
+```text
+- Authentication
+- Tickets
+- Customers
+- Users
+- Organization
+- SLA
+- Dashboards
+- Reports
+- Audit
+```
+
+Angular provides a strong project structure for organizing these features into modules, routes, guards, services, components, forms, and shared UI elements.
+
+TypeScript also supports maintainability by making frontend models, API contracts, and component logic easier to reason about.
+
+Angular is also common in enterprise .NET environments, which supports the portfolio goal of demonstrating senior-level full stack capability with .NET, Angular, SQL Server, and Azure-ready architecture.
+
+## Consequences
+
+### Positive Consequences
+
+- Angular provides a structured frontend architecture.
+- TypeScript improves maintainability and type safety.
+- Angular Router supports protected routes and role-aware navigation.
+- HTTP interceptors can attach JWT tokens to API requests.
+- Reactive Forms support complex form validation for tickets, users, customers, and operational structure.
+- Angular services provide a clean place to centralize API communication.
+- Angular works well with ASP.NET Core Web API.
+- The technology choice aligns with common enterprise .NET job requirements.
+- The frontend can be organized by business features instead of becoming a single large UI layer.
+
+### Negative Consequences
+
+- Angular has more initial complexity than simpler frontend libraries.
+- The project requires knowledge of Angular modules, routing, services, observables, forms, and dependency injection.
+- RxJS can introduce complexity if overused.
+- Angular may be heavier than necessary for a very small prototype.
+- UI development may take longer at the beginning because structure and patterns must be established.
+- Poor frontend organization could still lead to duplicated services, inconsistent state, or large components.
+
+## Alternatives Considered
+
+### React
+
+React is a popular frontend library and could be used to build OpsSphere.
+
+Rejected for this project because Angular better matches the enterprise .NET positioning of OpsSphere and provides a more opinionated structure out of the box.
+
+React remains a valid option for other projects, especially when more flexibility or a lighter frontend architecture is preferred.
+
+### Blazor
+
+Blazor would allow the frontend to be built using C# and .NET.
+
+Rejected for the initial version because OpsSphere is intended to demonstrate a full stack profile commonly requested in the market: ASP.NET Core Web API plus Angular.
+
+Blazor may be considered in future projects, but Angular better supports the current portfolio objective.
+
+### Razor Pages or MVC Views
+
+Server-rendered ASP.NET Core MVC or Razor Pages could simplify some backend and frontend integration.
+
+Rejected because OpsSphere is designed as a modern SPA plus API application. The frontend and backend should be separated so the API can serve Angular and future clients or integrations.
+
+### Vue
+
+Vue is simpler than Angular and can be effective for frontend applications.
+
+Rejected because Angular is more aligned with the enterprise structure and .NET full stack positioning of OpsSphere.
+
+Vue remains a valid alternative for smaller applications or teams that prefer a lighter framework.
+
+## Implementation Notes
+
+The frontend should follow a feature-oriented structure.
+
+Recommended structure:
+
+```text
+src/
+  app/
+    core/
+      auth/
+      guards/
+      interceptors/
+      services/
+
+    shared/
+      components/
+      pipes/
+      models/
+
+    features/
+      login/
+      dashboard/
+      tickets/
+      customers/
+      users/
+      organization/
+      sla/
+      audit/
+      reports/
+```
+
+The frontend should include:
+
+```text
+- Auth service for login and token handling
+- HTTP interceptor for attaching JWT tokens
+- Route guards for protected routes
+- Role-aware navigation
+- Shared API models
+- Reusable UI components
+- Reactive forms for create and update workflows
+- Feature services for API communication
+- Error handling for authorization and validation errors
+```
+
+The frontend must not be the only place where authorization is enforced.
+
+This rule must always apply:
+
+```text
+Frontend visibility improves user experience.
+Backend authorization protects the system.
+```
+
+Examples:
+
+```text
+- The frontend may hide the "Assign Ticket" button from Agents.
+- The backend must still reject unauthorized assignment requests.
+- The frontend may hide user management routes from non-Admins.
+- The backend must still reject user management API calls from non-Admins.
+- The frontend may filter navigation based on role.
+- The backend must still filter data based on role and operational scope.
+```
+
+## Decision Scope
+
+This ADR defines Angular as the primary frontend framework for OpsSphere.
+
+It does not define the final UI design system, component library, state management strategy, visual theme, or detailed screen design.
+
+Those details should be handled in frontend design and implementation tasks.

--- a/docs/decisions/ADR-005-entity-framework-core.md
+++ b/docs/decisions/ADR-005-entity-framework-core.md
@@ -1,0 +1,238 @@
+# ADR-005: Use Entity Framework Core for Data Access
+
+## Status
+
+Accepted
+
+## Context
+
+OpsSphere uses SQL Server as the primary relational database.
+
+The system must persist and query operational data related to:
+
+```text
+- Users
+- Roles
+- Permissions
+- Operational scopes
+- Regions
+- Countries
+- Accounts
+- Campaigns
+- Customers
+- Tickets
+- Ticket comments
+- Ticket assignments
+- Ticket escalations
+- Ticket status history
+- Ticket resolutions
+- SLA policies
+- Ticket SLA states
+- Audit logs
+```
+
+The backend is built with .NET 8 and ASP.NET Core Web API using Clean Architecture.
+
+Because the system has a relational domain model, strong business workflows, audit requirements, and reporting-ready data needs, the data access strategy must support:
+
+```text
+- Entity mapping
+- Relationship configuration
+- Query execution
+- Transactions
+- Migrations
+- Indexes
+- Change tracking when useful
+- Testable persistence boundaries
+```
+
+The data access approach must also fit the .NET ecosystem and work well with SQL Server.
+
+## Decision
+
+OpsSphere will use Entity Framework Core as the primary data access technology.
+
+Entity Framework Core will be used for:
+
+```text
+- Mapping domain and persistence models to SQL Server tables
+- Configuring relationships
+- Configuring indexes and constraints
+- Running database migrations
+- Querying operational data
+- Persisting changes
+- Managing transactions
+- Supporting integration tests with realistic database behavior
+```
+
+The EF Core implementation will live in the Infrastructure layer.
+
+Application and Domain layers must not depend directly on EF Core.
+
+The Application layer may depend on abstractions such as repository interfaces, unit-of-work interfaces, or application-specific data access contracts when needed.
+
+## Rationale
+
+Entity Framework Core is a strong fit for OpsSphere because it integrates naturally with .NET, ASP.NET Core, and SQL Server.
+
+OpsSphere needs a data access strategy that can handle relational entities and relationships such as:
+
+```text
+Region
+  → Country
+    → Account
+      → Campaign
+        → Ticket
+```
+
+It also needs to support relationships between tickets, customers, assigned agents, supervisors, comments, escalations, SLA state, and audit records.
+
+EF Core provides a productive way to model these relationships while keeping the database schema aligned with the application through migrations.
+
+EF Core also supports the portfolio goal of demonstrating enterprise .NET development with modern backend practices.
+
+Used correctly, EF Core can support Clean Architecture by remaining inside Infrastructure while the core business logic stays in Domain and Application layers.
+
+## Consequences
+
+### Positive Consequences
+
+- EF Core works naturally with .NET 8 and ASP.NET Core.
+- EF Core integrates well with SQL Server.
+- Migrations provide a controlled way to evolve the database schema.
+- Relationships, constraints, and indexes can be configured in code.
+- LINQ queries improve developer productivity.
+- Change tracking can simplify create, update, and delete workflows.
+- EF Core supports transaction handling for workflows such as ticket creation plus audit logging.
+- EF Core can support integration testing with Testcontainers and SQL Server.
+- The project demonstrates a common enterprise .NET skillset.
+
+### Negative Consequences
+
+- EF Core can hide inefficient queries if not used carefully.
+- Poorly designed LINQ queries may generate slow SQL.
+- Lazy loading, if enabled, can cause unexpected query behavior.
+- Developers must understand tracking vs. no-tracking queries.
+- Migrations must be managed carefully to avoid schema drift.
+- Complex reporting queries may require explicit SQL, views, projections, or optimized read models.
+- There is a risk of leaking EF Core types into Application or Domain layers if boundaries are not respected.
+
+## Alternatives Considered
+
+### Dapper
+
+Dapper is a lightweight micro-ORM that gives more direct control over SQL.
+
+Rejected as the primary data access strategy because OpsSphere has many relational entities, relationships, migrations, and CRUD-heavy operational workflows where EF Core provides more productivity.
+
+Dapper may still be considered later for performance-critical read queries, reporting views, exports, or dashboards where hand-optimized SQL is justified.
+
+### Raw ADO.NET
+
+Raw ADO.NET provides full control over database access.
+
+Rejected because it would require too much manual mapping and boilerplate for the initial version of OpsSphere.
+
+ADO.NET may be useful for very specific low-level optimizations, but it should not be the default approach.
+
+### Stored Procedure-Centric Access
+
+A stored procedure-centric approach would place much of the data access and workflow behavior inside SQL Server.
+
+Rejected because OpsSphere needs business rules and use cases to remain testable in the application code. SQL Server should store and protect data, but it should not become the main owner of application behavior.
+
+Stored procedures may be considered later for specialized reporting, data maintenance, or performance-sensitive operations.
+
+### No ORM
+
+Avoiding an ORM would maximize control but increase implementation effort.
+
+Rejected because OpsSphere is intended to demonstrate maintainable enterprise .NET development. EF Core provides the right balance between productivity, structure, and integration with SQL Server.
+
+## Implementation Notes
+
+EF Core should be implemented inside:
+
+```text
+src/
+  OpsSphere.Infrastructure/
+    Persistence/
+      OpsSphereDbContext.cs
+      Configurations/
+      Migrations/
+      SeedData/
+```
+
+Recommended configuration style:
+
+```text
+src/
+  OpsSphere.Infrastructure/
+    Persistence/
+      Configurations/
+        UserConfiguration.cs
+        RoleConfiguration.cs
+        PermissionConfiguration.cs
+        RegionConfiguration.cs
+        CountryConfiguration.cs
+        AccountConfiguration.cs
+        CampaignConfiguration.cs
+        CustomerConfiguration.cs
+        TicketConfiguration.cs
+        TicketCommentConfiguration.cs
+        TicketEscalationConfiguration.cs
+        AuditLogConfiguration.cs
+```
+
+Recommended practices:
+
+```text
+- Keep EF Core in Infrastructure.
+- Do not reference DbContext from Domain entities.
+- Do not place business rules inside EF Core configuration.
+- Use migrations for schema evolution.
+- Use explicit relationship configuration for important entities.
+- Use indexes for common filters and dashboard queries.
+- Use AsNoTracking for read-only queries when appropriate.
+- Use projections for list, dashboard, and reporting views.
+- Avoid lazy loading by default.
+- Keep audit-sensitive operations inside explicit application workflows.
+- Use transactions when a workflow must persist multiple related changes.
+```
+
+Common indexed query areas may include:
+
+```text
+- Tickets by status
+- Tickets by priority
+- Tickets by account
+- Tickets by campaign
+- Tickets by assigned agent
+- Tickets by supervisor
+- Tickets by SLA state
+- Tickets by created date
+- Audit logs by entity
+- Audit logs by user
+- Audit logs by date
+```
+
+The application should avoid returning EF Core entities directly from API endpoints.
+
+Preferred API flow:
+
+```text
+Controller
+  → Application Command or Query
+  → Handler
+  → Data access abstraction or DbContext through Infrastructure boundary
+  → DTO / Response model
+  → Controller response
+```
+
+## Decision Scope
+
+This ADR defines Entity Framework Core as the primary data access technology for OpsSphere.
+
+It does not define the final database schema, table list, migration naming convention, repository pattern usage, or query optimization strategy.
+
+Those details belong in database design, implementation tasks, and performance tuning work.


### PR DESCRIPTION
## Summary

Adds the initial Architecture Decision Records for OpsSphere, documenting the main technical decisions behind the project architecture and technology stack.

## Added / Changed

- Added ADR-001 for using Clean Architecture.
- Added ADR-002 for using SQL Server as the primary database.
- Added ADR-003 for using JWT authentication.
- Added ADR-004 for using Angular as the frontend framework.
- Added ADR-005 for using Entity Framework Core as the primary data access strategy.
- Created the `docs/decisions/` folder for architecture decision records.

## Validation

- [x] Reviewed changed files.
- [x] Confirmed scope matches the related issue.
- [x] Confirmed each ADR includes status, context, decision, rationale, consequences, and alternatives considered.
- [x] Confirmed ADRs are focused on architecture decisions, not general documentation.

## Related Issue

Closes #7