### PR TITLE
docs: standardize health check endpoint convention

### DIFF
--- a/docs/15-api-design.md
+++ b/docs/15-api-design.md
@@ -73,7 +73,7 @@ The API should support the following goals:
 
 ## 3. API Base Path
 
-All API endpoints should use the following base path:
+Business API endpoints should use the following base path:
 
 ```text
 /api
@@ -84,6 +84,8 @@ Example:
 ```http
 GET /api/tickets
 ```
+
+Health check endpoints are operational endpoints and intentionally do not use the `/api` base path.
 
 ---
 
@@ -2473,12 +2475,22 @@ OperationsManager
 
 ---
 
-# 21. Health API
+# 21. Health Endpoints
+
+Health checks are operational readiness and liveness endpoints, not business API resources.
+
+They intentionally do not use the `/api` base path.
 
 ## 21.1 Health Check
 
 ```http
-GET /api/health
+GET /health
+```
+
+Optional detailed endpoint:
+
+```http
+GET /health/details
 ```
 
 Required authorization:
@@ -2634,7 +2646,8 @@ GET /api/audit-logs/entity/{entityType}/{entityId}
 ## 22.10 Health
 
 ```http
-GET /api/health
+GET /health
+GET /health/details
 ```
 
 ---


### PR DESCRIPTION
## Summary

Standardizes the OpsSphere health check endpoint convention across documentation.

## Added / Changed

- Standardized the main health check endpoint as `GET /health`.
- Standardized the optional detailed health endpoint as `GET /health/details`.
- Clarified that health checks are operational endpoints and do not use the `/api` business API base path.
- Reviewed related API, DevOps, and observability documentation for consistency.

## Validation

- [x] Reviewed changed files.
- [x] Confirmed scope matches the related issue.
- [x] Confirmed no application source code was changed.
- [x] Confirmed Markdown formatting is readable.

## Related Issue

Closes #20