### PR TITLE
Add seed data implementation for OpsSphere

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,9 +7,11 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5">
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
+    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />

--- a/README.md
+++ b/README.md
@@ -93,8 +93,58 @@ dotnet ef migrations add <MigrationName> --project src/OpsSphere.Infrastructure 
 ```
 
 > **Security:** Never commit `.env` or real passwords. Use `appsettings.Development.json` (gitignored locally), .NET user secrets, or environment variables.
-> **Seed data:** No seed data is included in this migration. The database is created schema-only.
+> **Seed data:** Fictional seed data is applied by the API at startup only when the environment is `Development` or `Testing` and `SeedData:Enabled` is `true`.
 > **Local only:** These commands apply to local development. Do not apply migrations directly to production.
+
+## Local Seed Data
+
+OpsSphere includes deterministic fictional seed data for local development, demos, and automated tests. The seed uses fixed IDs and natural keys so it can be run repeatedly without creating duplicates.
+
+Seed execution is intentionally runtime-based through Infrastructure, not EF migration `HasData`. It runs only when both conditions are true:
+
+- ASP.NET Core environment is `Development` or `Testing`
+- `SeedData:Enabled` is `true`
+
+The local demo users are:
+
+| Email | Role | Scope |
+|---|---|---|
+| `admin@opssphere.local` | Admin | Role-based administrative access |
+| `manager.latam@opssphere.local` | OperationsManager | LATAM region |
+| `supervisor.novabank@opssphere.local` | Supervisor | NOVABANK account |
+| `agent.novabank@opssphere.local` | Agent | NOVABANK-CC campaign |
+| `viewer.latam@opssphere.local` | Viewer | LATAM region |
+
+The local/demo password is `OpsSphere123!`. It is hashed before persistence and is not stored as plaintext or logged. This password is for local development and demos only.
+
+Seeded organization data is fictional:
+
+- Regions: LATAM / Latin America, NA / North America
+- Countries: MX / Mexico, CO / Colombia, CR / Costa Rica, US / United States
+- Accounts: NovaBank, Streamly, Shopora, AeroLink
+- Campaigns: Credit Card Support, Fraud Review Support, Creator Support, Account Access Support, Travel Support
+
+No production secrets, real company data, customer data, employee data, tokens, or production credentials are committed.
+
+### Local Apply Flow
+
+```bash
+docker compose up -d
+dotnet restore OpsSphere.slnx
+dotnet build OpsSphere.slnx
+dotnet ef database update --project src/OpsSphere.Infrastructure --startup-project src/OpsSphere.Api
+dotnet run --project src/OpsSphere.Api
+dotnet test OpsSphere.slnx
+```
+
+### Local Reset Flow
+
+```bash
+docker compose down -v
+docker compose up -d
+dotnet ef database update --project src/OpsSphere.Infrastructure --startup-project src/OpsSphere.Api
+dotnet run --project src/OpsSphere.Api
+```
 
 ### Frontend API Base URL
 The Angular development environment is configured in `frontend/src/environments/environment.development.ts`. The `apiBaseUrl` property should point to your locally running backend API (e.g., `http://localhost:5000/api` or `https://localhost:7024/api` per `launchSettings.json`).

--- a/src/OpsSphere.Api/Program.cs
+++ b/src/OpsSphere.Api/Program.cs
@@ -1,5 +1,6 @@
 using OpsSphere.Application;
 using OpsSphere.Infrastructure;
+using OpsSphere.Infrastructure.Persistence.SeedData;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -8,6 +9,16 @@ builder.Services.AddInfrastructure(builder.Configuration);
 builder.Services.AddControllers();
 
 var app = builder.Build();
+
+var seedDataEnabled = bool.TryParse(app.Configuration[$"{SeedDataOptions.SectionName}:Enabled"], out var parsedSeedDataEnabled) &&
+    parsedSeedDataEnabled;
+
+if (SeedDataStartupGate.ShouldRun(app.Environment.EnvironmentName, seedDataEnabled))
+{
+    using var scope = app.Services.CreateScope();
+    var seeder = scope.ServiceProvider.GetRequiredService<OpsSphereDataSeeder>();
+    await seeder.SeedAsync();
+}
 
 app.UseHttpsRedirection();
 

--- a/src/OpsSphere.Api/SeedDataStartupGate.cs
+++ b/src/OpsSphere.Api/SeedDataStartupGate.cs
@@ -1,0 +1,7 @@
+public static class SeedDataStartupGate
+{
+    public static bool ShouldRun(string environmentName, bool seedDataEnabled) =>
+        seedDataEnabled &&
+        (string.Equals(environmentName, "Development", StringComparison.OrdinalIgnoreCase) ||
+         string.Equals(environmentName, "Testing", StringComparison.OrdinalIgnoreCase));
+}

--- a/src/OpsSphere.Api/appsettings.Development.json
+++ b/src/OpsSphere.Api/appsettings.Development.json
@@ -8,5 +8,8 @@
   "ConnectionStrings": {
     "DefaultConnection": "Server=localhost,1433;Database=OpsSphereDb;User Id=sa;Password=<YOUR_LOCAL_SA_PASSWORD>;TrustServerCertificate=True;",
     "_DefaultConnection_Note": "Replace <YOUR_LOCAL_SA_PASSWORD> with the value from your local .env file. Do not commit real passwords. Use appsettings.Development.json, environment variables, or .NET user secrets locally."
+  },
+  "SeedData": {
+    "Enabled": true
   }
 }

--- a/src/OpsSphere.Infrastructure/DependencyInjection.cs
+++ b/src/OpsSphere.Infrastructure/DependencyInjection.cs
@@ -1,7 +1,10 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using OpsSphere.Domain.Entities;
 using OpsSphere.Infrastructure.Persistence;
+using OpsSphere.Infrastructure.Persistence.SeedData;
 
 namespace OpsSphere.Infrastructure;
 
@@ -14,6 +17,11 @@ public static class DependencyInjection
 
         services.AddDbContext<OpsSphereDbContext>(options =>
             options.UseSqlServer(connectionString));
+
+        services.Configure<SeedDataOptions>(options =>
+            options.Enabled = bool.TryParse(configuration[$"{SeedDataOptions.SectionName}:Enabled"], out var enabled) && enabled);
+        services.AddScoped<IPasswordHasher<User>, PasswordHasher<User>>();
+        services.AddScoped<OpsSphereDataSeeder>();
 
         return services;
     }

--- a/src/OpsSphere.Infrastructure/OpsSphere.Infrastructure.csproj
+++ b/src/OpsSphere.Infrastructure/OpsSphere.Infrastructure.csproj
@@ -11,6 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />

--- a/src/OpsSphere.Infrastructure/Persistence/Configurations/UserScopeConfiguration.cs
+++ b/src/OpsSphere.Infrastructure/Persistence/Configurations/UserScopeConfiguration.cs
@@ -21,6 +21,22 @@ internal sealed class UserScopeConfiguration : IEntityTypeConfiguration<UserScop
         builder.HasIndex(us => us.AccountId).HasDatabaseName("IX_UserScopes_AccountId");
         builder.HasIndex(us => us.CampaignId).HasDatabaseName("IX_UserScopes_CampaignId");
         builder.HasIndex(us => us.IsActive).HasDatabaseName("IX_UserScopes_IsActive");
+        builder.HasIndex(us => new { us.UserId, us.ScopeType, us.RegionId })
+            .IsUnique()
+            .HasFilter("[RegionId] IS NOT NULL")
+            .HasDatabaseName("UQ_UserScopes_User_Region");
+        builder.HasIndex(us => new { us.UserId, us.ScopeType, us.CountryId })
+            .IsUnique()
+            .HasFilter("[CountryId] IS NOT NULL")
+            .HasDatabaseName("UQ_UserScopes_User_Country");
+        builder.HasIndex(us => new { us.UserId, us.ScopeType, us.AccountId })
+            .IsUnique()
+            .HasFilter("[AccountId] IS NOT NULL")
+            .HasDatabaseName("UQ_UserScopes_User_Account");
+        builder.HasIndex(us => new { us.UserId, us.ScopeType, us.CampaignId })
+            .IsUnique()
+            .HasFilter("[CampaignId] IS NOT NULL")
+            .HasDatabaseName("UQ_UserScopes_User_Campaign");
 
         builder.HasOne(us => us.Region).WithMany(r => r.UserScopes).HasForeignKey(us => us.RegionId).OnDelete(DeleteBehavior.Restrict);
         builder.HasOne(us => us.Country).WithMany(c => c.UserScopes).HasForeignKey(us => us.CountryId).OnDelete(DeleteBehavior.Restrict);

--- a/src/OpsSphere.Infrastructure/Persistence/Migrations/20260514172504_AddUserScopeUniqueness.Designer.cs
+++ b/src/OpsSphere.Infrastructure/Persistence/Migrations/20260514172504_AddUserScopeUniqueness.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OpsSphere.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using OpsSphere.Infrastructure.Persistence;
 namespace OpsSphere.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(OpsSphereDbContext))]
-    partial class OpsSphereDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260514172504_AddUserScopeUniqueness")]
+    partial class AddUserScopeUniqueness
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OpsSphere.Infrastructure/Persistence/Migrations/20260514172504_AddUserScopeUniqueness.cs
+++ b/src/OpsSphere.Infrastructure/Persistence/Migrations/20260514172504_AddUserScopeUniqueness.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OpsSphere.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserScopeUniqueness : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "UQ_UserScopes_User_Account",
+                table: "UserScopes",
+                columns: new[] { "UserId", "ScopeType", "AccountId" },
+                unique: true,
+                filter: "[AccountId] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "UQ_UserScopes_User_Campaign",
+                table: "UserScopes",
+                columns: new[] { "UserId", "ScopeType", "CampaignId" },
+                unique: true,
+                filter: "[CampaignId] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "UQ_UserScopes_User_Country",
+                table: "UserScopes",
+                columns: new[] { "UserId", "ScopeType", "CountryId" },
+                unique: true,
+                filter: "[CountryId] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "UQ_UserScopes_User_Region",
+                table: "UserScopes",
+                columns: new[] { "UserId", "ScopeType", "RegionId" },
+                unique: true,
+                filter: "[RegionId] IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "UQ_UserScopes_User_Account",
+                table: "UserScopes");
+
+            migrationBuilder.DropIndex(
+                name: "UQ_UserScopes_User_Campaign",
+                table: "UserScopes");
+
+            migrationBuilder.DropIndex(
+                name: "UQ_UserScopes_User_Country",
+                table: "UserScopes");
+
+            migrationBuilder.DropIndex(
+                name: "UQ_UserScopes_User_Region",
+                table: "UserScopes");
+        }
+    }
+}

--- a/src/OpsSphere.Infrastructure/Persistence/SeedData/OpsSphereDataSeeder.cs
+++ b/src/OpsSphere.Infrastructure/Persistence/SeedData/OpsSphereDataSeeder.cs
@@ -1,0 +1,393 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using OpsSphere.Domain.Entities;
+
+namespace OpsSphere.Infrastructure.Persistence.SeedData;
+
+public sealed class OpsSphereDataSeeder
+{
+    private readonly OpsSphereDbContext dbContext;
+    private readonly IPasswordHasher<User> passwordHasher;
+
+    public OpsSphereDataSeeder(OpsSphereDbContext dbContext, IPasswordHasher<User> passwordHasher)
+    {
+        this.dbContext = dbContext;
+        this.passwordHasher = passwordHasher;
+    }
+
+    public async Task SeedAsync(CancellationToken cancellationToken = default)
+    {
+        await SeedRolesAsync(cancellationToken);
+        await SeedPermissionsAsync(cancellationToken);
+        await SeedRolePermissionsAsync(cancellationToken);
+        await SeedOrganizationAsync(cancellationToken);
+        await SeedUsersAsync(cancellationToken);
+        await SeedUserRolesAsync(cancellationToken);
+        await SeedUserScopesAsync(cancellationToken);
+    }
+
+    private async Task SeedRolesAsync(CancellationToken cancellationToken)
+    {
+        var existingRoles = await LoadRolesByNameAsync(cancellationToken);
+
+        foreach (var roleSeed in OpsSphereSeedData.Roles)
+        {
+            if (!existingRoles.TryGetValue(roleSeed.Name, out var role))
+            {
+                dbContext.Roles.Add(new Role
+                {
+                    Id = roleSeed.Id,
+                    Name = roleSeed.Name,
+                    Description = roleSeed.Description,
+                    IsSystemRole = true,
+                    IsActive = true
+                });
+                continue;
+            }
+
+            role.Description = roleSeed.Description;
+            role.IsSystemRole = true;
+            role.IsActive = true;
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task SeedPermissionsAsync(CancellationToken cancellationToken)
+    {
+        var existingPermissions = await LoadPermissionsByCodeAsync(cancellationToken);
+
+        foreach (var permissionSeed in OpsSphereSeedData.Permissions)
+        {
+            if (!existingPermissions.TryGetValue(permissionSeed.Code, out var permission))
+            {
+                dbContext.Permissions.Add(new Permission
+                {
+                    Id = permissionSeed.Id,
+                    Code = permissionSeed.Code,
+                    Name = permissionSeed.Name,
+                    Description = permissionSeed.Description,
+                    IsActive = true
+                });
+                continue;
+            }
+
+            permission.Name = permissionSeed.Name;
+            permission.Description = permissionSeed.Description;
+            permission.IsActive = true;
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task SeedRolePermissionsAsync(CancellationToken cancellationToken)
+    {
+        var roles = await LoadRolesByNameAsync(cancellationToken);
+        var permissions = await LoadPermissionsByCodeAsync(cancellationToken);
+        var existingMappings = await dbContext.RolePermissions
+            .Select(rp => new { rp.RoleId, rp.PermissionId })
+            .ToListAsync(cancellationToken);
+        var mappingKeys = existingMappings
+            .Select(rp => (rp.RoleId, rp.PermissionId))
+            .ToHashSet();
+
+        foreach (var (roleName, permissionCodes) in OpsSphereSeedData.RolePermissions)
+        {
+            var role = roles[roleName];
+
+            foreach (var permissionCode in permissionCodes)
+            {
+                var permission = permissions[permissionCode];
+                var key = (role.Id, permission.Id);
+
+                if (mappingKeys.Contains(key))
+                {
+                    continue;
+                }
+
+                dbContext.RolePermissions.Add(new RolePermission
+                {
+                    RoleId = role.Id,
+                    PermissionId = permission.Id
+                });
+                mappingKeys.Add(key);
+            }
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task SeedOrganizationAsync(CancellationToken cancellationToken)
+    {
+        await SeedRegionsAsync(cancellationToken);
+        await SeedCountriesAsync(cancellationToken);
+        await SeedAccountsAsync(cancellationToken);
+        await SeedCampaignsAsync(cancellationToken);
+    }
+
+    private async Task SeedRegionsAsync(CancellationToken cancellationToken)
+    {
+        var regions = await LoadRegionsByCodeAsync(cancellationToken);
+
+        foreach (var regionSeed in OpsSphereSeedData.Regions)
+        {
+            if (!regions.TryGetValue(regionSeed.Code, out var region))
+            {
+                dbContext.Regions.Add(new Region
+                {
+                    Id = regionSeed.Id,
+                    Code = regionSeed.Code,
+                    Name = regionSeed.Name,
+                    IsActive = true
+                });
+                continue;
+            }
+
+            region.Name = regionSeed.Name;
+            region.IsActive = true;
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task SeedCountriesAsync(CancellationToken cancellationToken)
+    {
+        var regions = await LoadRegionsByCodeAsync(cancellationToken);
+        var countries = await LoadCountriesByCodeAsync(cancellationToken);
+
+        foreach (var countrySeed in OpsSphereSeedData.Countries)
+        {
+            var regionId = regions[countrySeed.RegionCode].Id;
+
+            if (!countries.TryGetValue(countrySeed.Code, out var country))
+            {
+                dbContext.Countries.Add(new Country
+                {
+                    Id = countrySeed.Id,
+                    RegionId = regionId,
+                    Code = countrySeed.Code,
+                    Name = countrySeed.Name,
+                    IsActive = true
+                });
+                continue;
+            }
+
+            country.RegionId = regionId;
+            country.Name = countrySeed.Name;
+            country.IsActive = true;
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task SeedAccountsAsync(CancellationToken cancellationToken)
+    {
+        var countries = await LoadCountriesByCodeAsync(cancellationToken);
+        var accounts = await LoadAccountsByCodeAsync(cancellationToken);
+
+        foreach (var accountSeed in OpsSphereSeedData.Accounts)
+        {
+            var countryId = countries[accountSeed.CountryCode].Id;
+
+            if (!accounts.TryGetValue(accountSeed.Code, out var account))
+            {
+                dbContext.Accounts.Add(new Account
+                {
+                    Id = accountSeed.Id,
+                    CountryId = countryId,
+                    Code = accountSeed.Code,
+                    Name = accountSeed.Name,
+                    Description = accountSeed.Description,
+                    IsActive = true
+                });
+                continue;
+            }
+
+            account.CountryId = countryId;
+            account.Name = accountSeed.Name;
+            account.Description = accountSeed.Description;
+            account.IsActive = true;
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task SeedCampaignsAsync(CancellationToken cancellationToken)
+    {
+        var countries = await LoadCountriesByCodeAsync(cancellationToken);
+        var accounts = await LoadAccountsByCodeAsync(cancellationToken);
+        var campaigns = await LoadCampaignsByCodeAsync(cancellationToken);
+
+        foreach (var campaignSeed in OpsSphereSeedData.Campaigns)
+        {
+            var accountId = accounts[campaignSeed.AccountCode].Id;
+            var countryId = countries[campaignSeed.CountryCode].Id;
+
+            if (!campaigns.TryGetValue(campaignSeed.Code, out var campaign))
+            {
+                dbContext.Campaigns.Add(new Campaign
+                {
+                    Id = campaignSeed.Id,
+                    AccountId = accountId,
+                    CountryId = countryId,
+                    Code = campaignSeed.Code,
+                    Name = campaignSeed.Name,
+                    Description = campaignSeed.Description,
+                    IsActive = true
+                });
+                continue;
+            }
+
+            campaign.AccountId = accountId;
+            campaign.CountryId = countryId;
+            campaign.Name = campaignSeed.Name;
+            campaign.Description = campaignSeed.Description;
+            campaign.IsActive = true;
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task SeedUsersAsync(CancellationToken cancellationToken)
+    {
+        var users = await LoadUsersByEmailAsync(cancellationToken);
+
+        foreach (var userSeed in OpsSphereSeedData.Users)
+        {
+            if (!users.TryGetValue(userSeed.Email, out var user))
+            {
+                user = new User
+                {
+                    Id = userSeed.Id,
+                    Email = userSeed.Email,
+                    FirstName = userSeed.FirstName,
+                    LastName = userSeed.LastName,
+                    DisplayName = userSeed.DisplayName,
+                    IsActive = true
+                };
+                user.PasswordHash = passwordHasher.HashPassword(user, OpsSphereSeedData.LocalDemoPassword);
+                dbContext.Users.Add(user);
+                continue;
+            }
+
+            user.FirstName = userSeed.FirstName;
+            user.LastName = userSeed.LastName;
+            user.DisplayName = userSeed.DisplayName;
+            user.IsActive = true;
+            user.DeactivatedAt = null;
+
+            if (string.IsNullOrWhiteSpace(user.PasswordHash) ||
+                string.Equals(user.PasswordHash, OpsSphereSeedData.LocalDemoPassword, StringComparison.Ordinal))
+            {
+                user.PasswordHash = passwordHasher.HashPassword(user, OpsSphereSeedData.LocalDemoPassword);
+            }
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task SeedUserRolesAsync(CancellationToken cancellationToken)
+    {
+        var users = await LoadUsersByEmailAsync(cancellationToken);
+        var roles = await LoadRolesByNameAsync(cancellationToken);
+        var existingMappings = await dbContext.UserRoles
+            .Select(ur => new { ur.UserId, ur.RoleId })
+            .ToListAsync(cancellationToken);
+        var mappingKeys = existingMappings
+            .Select(ur => (ur.UserId, ur.RoleId))
+            .ToHashSet();
+
+        foreach (var userSeed in OpsSphereSeedData.Users)
+        {
+            var user = users[userSeed.Email];
+            var role = roles[userSeed.RoleName];
+            var key = (user.Id, role.Id);
+
+            if (mappingKeys.Contains(key))
+            {
+                continue;
+            }
+
+            dbContext.UserRoles.Add(new UserRole
+            {
+                UserId = user.Id,
+                RoleId = role.Id
+            });
+            mappingKeys.Add(key);
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task SeedUserScopesAsync(CancellationToken cancellationToken)
+    {
+        var users = await LoadUsersByEmailAsync(cancellationToken);
+        var regions = await LoadRegionsByCodeAsync(cancellationToken);
+        var countries = await LoadCountriesByCodeAsync(cancellationToken);
+        var accounts = await LoadAccountsByCodeAsync(cancellationToken);
+        var campaigns = await LoadCampaignsByCodeAsync(cancellationToken);
+
+        foreach (var scopeSeed in OpsSphereSeedData.UserScopes)
+        {
+            var user = users[scopeSeed.UserEmail];
+            var regionId = scopeSeed.RegionCode is null ? null : (Guid?)regions[scopeSeed.RegionCode].Id;
+            var countryId = scopeSeed.CountryCode is null ? null : (Guid?)countries[scopeSeed.CountryCode].Id;
+            var accountId = scopeSeed.AccountCode is null ? null : (Guid?)accounts[scopeSeed.AccountCode].Id;
+            var campaignId = scopeSeed.CampaignCode is null ? null : (Guid?)campaigns[scopeSeed.CampaignCode].Id;
+
+            var existingScope = await dbContext.UserScopes.FirstOrDefaultAsync(
+                userScope =>
+                    userScope.UserId == user.Id &&
+                    userScope.ScopeType == scopeSeed.ScopeType &&
+                    userScope.RegionId == regionId &&
+                    userScope.CountryId == countryId &&
+                    userScope.AccountId == accountId &&
+                    userScope.CampaignId == campaignId,
+                cancellationToken);
+
+            if (existingScope is null)
+            {
+                dbContext.UserScopes.Add(new UserScope
+                {
+                    Id = scopeSeed.Id,
+                    UserId = user.Id,
+                    ScopeType = scopeSeed.ScopeType,
+                    RegionId = regionId,
+                    CountryId = countryId,
+                    AccountId = accountId,
+                    CampaignId = campaignId,
+                    IsActive = true
+                });
+                continue;
+            }
+
+            existingScope.IsActive = true;
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task<Dictionary<string, Role>> LoadRolesByNameAsync(CancellationToken cancellationToken) =>
+        ToCaseInsensitiveDictionary(await dbContext.Roles.ToListAsync(cancellationToken), role => role.Name);
+
+    private async Task<Dictionary<string, Permission>> LoadPermissionsByCodeAsync(CancellationToken cancellationToken) =>
+        ToCaseInsensitiveDictionary(await dbContext.Permissions.ToListAsync(cancellationToken), permission => permission.Code);
+
+    private async Task<Dictionary<string, User>> LoadUsersByEmailAsync(CancellationToken cancellationToken) =>
+        ToCaseInsensitiveDictionary(await dbContext.Users.ToListAsync(cancellationToken), user => user.Email);
+
+    private async Task<Dictionary<string, Region>> LoadRegionsByCodeAsync(CancellationToken cancellationToken) =>
+        ToCaseInsensitiveDictionary(await dbContext.Regions.ToListAsync(cancellationToken), region => region.Code);
+
+    private async Task<Dictionary<string, Country>> LoadCountriesByCodeAsync(CancellationToken cancellationToken) =>
+        ToCaseInsensitiveDictionary(await dbContext.Countries.ToListAsync(cancellationToken), country => country.Code);
+
+    private async Task<Dictionary<string, Account>> LoadAccountsByCodeAsync(CancellationToken cancellationToken) =>
+        ToCaseInsensitiveDictionary(await dbContext.Accounts.ToListAsync(cancellationToken), account => account.Code);
+
+    private async Task<Dictionary<string, Campaign>> LoadCampaignsByCodeAsync(CancellationToken cancellationToken) =>
+        ToCaseInsensitiveDictionary(await dbContext.Campaigns.ToListAsync(cancellationToken), campaign => campaign.Code);
+
+    private static Dictionary<string, T> ToCaseInsensitiveDictionary<T>(IEnumerable<T> items, Func<T, string> keySelector) =>
+        items.ToDictionary(keySelector, StringComparer.OrdinalIgnoreCase);
+}

--- a/src/OpsSphere.Infrastructure/Persistence/SeedData/OpsSphereSeedData.cs
+++ b/src/OpsSphere.Infrastructure/Persistence/SeedData/OpsSphereSeedData.cs
@@ -1,0 +1,166 @@
+namespace OpsSphere.Infrastructure.Persistence.SeedData;
+
+public static class OpsSphereSeedData
+{
+    public const string LocalDemoPassword = "OpsSphere123!";
+
+    public static readonly IReadOnlyList<RoleSeed> Roles =
+    [
+        new(SeedIds.Roles.Admin, "Admin", "Manages platform configuration, users, roles, permissions, scopes, organization, audit, SLA policy, and reports."),
+        new(SeedIds.Roles.OperationsManager, "OperationsManager", "Oversees regional operational performance within assigned scope."),
+        new(SeedIds.Roles.Supervisor, "Supervisor", "Manages account or campaign ticket operations, assignments, escalations, SLA risk, and agents within scope."),
+        new(SeedIds.Roles.Agent, "Agent", "Handles tickets within assigned operational scope."),
+        new(SeedIds.Roles.Viewer, "Viewer", "Views operational data, dashboards, reports, and audit history in read-only mode within scope.")
+    ];
+
+    public static readonly IReadOnlyList<PermissionSeed> Permissions =
+    [
+        new(SeedIds.Permissions.UsersView, "users.view", "View Users", "View users."),
+        new(SeedIds.Permissions.UsersManage, "users.manage", "Manage Users", "Create, update, deactivate, and manage users."),
+        new(SeedIds.Permissions.RolesView, "roles.view", "View Roles", "View roles."),
+        new(SeedIds.Permissions.RolesManage, "roles.manage", "Manage Roles", "Manage roles."),
+        new(SeedIds.Permissions.PermissionsView, "permissions.view", "View Permissions", "View permissions."),
+        new(SeedIds.Permissions.PermissionsManage, "permissions.manage", "Manage Permissions", "Manage role-permission assignments."),
+        new(SeedIds.Permissions.ScopesView, "scopes.view", "View Scopes", "View user scopes."),
+        new(SeedIds.Permissions.ScopesManage, "scopes.manage", "Manage Scopes", "Assign or update user operational scopes."),
+        new(SeedIds.Permissions.OrganizationView, "organization.view", "View Organization", "View regions, countries, accounts, and campaigns."),
+        new(SeedIds.Permissions.OrganizationManage, "organization.manage", "Manage Organization", "Create, update, deactivate, or assign organization records."),
+        new(SeedIds.Permissions.RegionsManage, "regions.manage", "Manage Regions", "Manage regions."),
+        new(SeedIds.Permissions.CountriesManage, "countries.manage", "Manage Countries", "Manage countries."),
+        new(SeedIds.Permissions.AccountsManage, "accounts.manage", "Manage Accounts", "Manage accounts."),
+        new(SeedIds.Permissions.CampaignsManage, "campaigns.manage", "Manage Campaigns", "Manage campaigns."),
+        new(SeedIds.Permissions.AssignmentsManage, "assignments.manage", "Manage Assignments", "Manage manager, supervisor, agent, and viewer assignments."),
+        new(SeedIds.Permissions.CustomersView, "customers.view", "View Customers", "View customer records within scope."),
+        new(SeedIds.Permissions.CustomersCreate, "customers.create", "Create Customers", "Create customer records within scope."),
+        new(SeedIds.Permissions.CustomersUpdate, "customers.update", "Update Customers", "Update customer records within scope."),
+        new(SeedIds.Permissions.CustomersHistoryView, "customers.history.view", "View Customer History", "View customer ticket history within scope."),
+        new(SeedIds.Permissions.TicketsView, "tickets.view", "View Tickets", "View tickets within scope."),
+        new(SeedIds.Permissions.TicketsCreate, "tickets.create", "Create Tickets", "Create tickets within scope."),
+        new(SeedIds.Permissions.TicketsUpdate, "tickets.update", "Update Tickets", "Update editable ticket fields within scope."),
+        new(SeedIds.Permissions.TicketsAssign, "tickets.assign", "Assign Tickets", "Assign or reassign tickets within scope."),
+        new(SeedIds.Permissions.TicketsUpdateStatus, "tickets.update_status", "Update Ticket Status", "Update ticket status within scope."),
+        new(SeedIds.Permissions.TicketsUpdatePriority, "tickets.update_priority", "Update Ticket Priority", "Update ticket priority within scope."),
+        new(SeedIds.Permissions.TicketsComment, "tickets.comment", "Comment On Tickets", "Add internal comments within scope."),
+        new(SeedIds.Permissions.TicketsEscalate, "tickets.escalate", "Escalate Tickets", "Escalate tickets within scope."),
+        new(SeedIds.Permissions.TicketsResolve, "tickets.resolve", "Resolve Tickets", "Resolve tickets within scope."),
+        new(SeedIds.Permissions.TicketsClose, "tickets.close", "Close Tickets", "Close resolved tickets within scope."),
+        new(SeedIds.Permissions.TicketsHistoryView, "tickets.history.view", "View Ticket History", "View ticket history within scope."),
+        new(SeedIds.Permissions.TicketsReopen, "tickets.reopen", "Reopen Tickets", "Reopen closed tickets if supported."),
+        new(SeedIds.Permissions.SlaView, "sla.view", "View SLA", "View SLA state and SLA dashboards within scope."),
+        new(SeedIds.Permissions.SlaPoliciesView, "sla.policies.view", "View SLA Policies", "View SLA policies."),
+        new(SeedIds.Permissions.SlaPoliciesManage, "sla.policies.manage", "Manage SLA Policies", "Create or update SLA policies."),
+        new(SeedIds.Permissions.SlaEvaluate, "sla.evaluate", "Evaluate SLA", "Trigger or run SLA evaluation."),
+        new(SeedIds.Permissions.DashboardView, "dashboard.view", "View Dashboard", "View operational dashboards within scope."),
+        new(SeedIds.Permissions.ReportsView, "reports.view", "View Reports", "View reports within scope."),
+        new(SeedIds.Permissions.ReportsExport, "reports.export", "Export Reports", "Export reports within scope."),
+        new(SeedIds.Permissions.AuditView, "audit.view", "View Audit", "View audit history within scope."),
+        new(SeedIds.Permissions.AuditAdminView, "audit.admin_view", "View Admin Audit", "View administrative audit history."),
+        new(SeedIds.Permissions.AuditExport, "audit.export", "Export Audit", "Export audit records if enabled.")
+    ];
+
+    public static readonly IReadOnlyDictionary<string, string[]> RolePermissions = new Dictionary<string, string[]>
+    {
+        ["Admin"] =
+        [
+            "users.view", "users.manage", "roles.view", "roles.manage", "permissions.view", "permissions.manage",
+            "scopes.view", "scopes.manage", "organization.view", "organization.manage", "regions.manage",
+            "countries.manage", "accounts.manage", "campaigns.manage", "assignments.manage", "customers.view",
+            "customers.create", "customers.update", "customers.history.view", "tickets.view", "tickets.history.view",
+            "tickets.reopen", "sla.view", "sla.policies.view", "sla.policies.manage", "sla.evaluate", "dashboard.view",
+            "reports.view", "reports.export", "audit.view", "audit.admin_view", "audit.export"
+        ],
+        ["OperationsManager"] =
+        [
+            "organization.view", "customers.view", "customers.history.view", "tickets.view", "tickets.history.view",
+            "tickets.comment", "sla.view", "sla.policies.view", "dashboard.view", "reports.view", "reports.export",
+            "audit.view", "audit.export"
+        ],
+        ["Supervisor"] =
+        [
+            "organization.view", "customers.view", "customers.create", "customers.update", "customers.history.view",
+            "tickets.view", "tickets.create", "tickets.update", "tickets.assign", "tickets.update_status",
+            "tickets.update_priority", "tickets.comment", "tickets.escalate", "tickets.resolve", "tickets.close",
+            "tickets.history.view", "tickets.reopen", "sla.view", "sla.policies.view", "dashboard.view",
+            "reports.view", "reports.export", "audit.view"
+        ],
+        ["Agent"] =
+        [
+            "organization.view", "customers.view", "customers.create", "customers.update", "customers.history.view",
+            "tickets.view", "tickets.create", "tickets.update", "tickets.update_status", "tickets.update_priority",
+            "tickets.comment", "tickets.escalate", "tickets.resolve", "tickets.close", "tickets.history.view",
+            "sla.view", "dashboard.view"
+        ],
+        ["Viewer"] =
+        [
+            "organization.view", "customers.view", "customers.history.view", "tickets.view", "tickets.history.view",
+            "sla.view", "dashboard.view", "reports.view", "reports.export", "audit.view"
+        ]
+    };
+
+    public static readonly IReadOnlyList<UserSeed> Users =
+    [
+        new(SeedIds.Users.Admin, "admin@opssphere.local", "Amara", "Vale", "Amara Vale", "Admin"),
+        new(SeedIds.Users.ManagerLatam, "manager.latam@opssphere.local", "Mateo", "Rios", "Mateo Rios", "OperationsManager"),
+        new(SeedIds.Users.SupervisorNovabank, "supervisor.novabank@opssphere.local", "Lina", "Calderon", "Lina Calderon", "Supervisor"),
+        new(SeedIds.Users.AgentNovabank, "agent.novabank@opssphere.local", "Diego", "Santos", "Diego Santos", "Agent"),
+        new(SeedIds.Users.ViewerLatam, "viewer.latam@opssphere.local", "Nora", "Ellis", "Nora Ellis", "Viewer")
+    ];
+
+    public static readonly IReadOnlyList<RegionSeed> Regions =
+    [
+        new(SeedIds.Regions.Latam, "LATAM", "Latin America"),
+        new(SeedIds.Regions.NorthAmerica, "NA", "North America")
+    ];
+
+    public static readonly IReadOnlyList<CountrySeed> Countries =
+    [
+        new(SeedIds.Countries.Mexico, "MX", "Mexico", "LATAM"),
+        new(SeedIds.Countries.Colombia, "CO", "Colombia", "LATAM"),
+        new(SeedIds.Countries.CostaRica, "CR", "Costa Rica", "LATAM"),
+        new(SeedIds.Countries.UnitedStates, "US", "United States", "NA")
+    ];
+
+    public static readonly IReadOnlyList<AccountSeed> Accounts =
+    [
+        new(SeedIds.Accounts.NovaBank, "NOVABANK", "NovaBank", "MX", "Fictional banking support account for local development."),
+        new(SeedIds.Accounts.Streamly, "STREAMLY", "Streamly", "US", "Fictional streaming platform support account for local development."),
+        new(SeedIds.Accounts.Shopora, "SHOPORA", "Shopora", "CO", "Fictional commerce support account for local development."),
+        new(SeedIds.Accounts.AeroLink, "AEROLINK", "AeroLink", "CR", "Fictional travel support account for local development.")
+    ];
+
+    public static readonly IReadOnlyList<CampaignSeed> Campaigns =
+    [
+        new(SeedIds.Campaigns.NovaBankCreditCard, "NOVABANK-CC", "Credit Card Support", "NOVABANK", "MX", "Fictional credit card support campaign."),
+        new(SeedIds.Campaigns.NovaBankFraud, "NOVABANK-FRAUD", "Fraud Review Support", "NOVABANK", "MX", "Fictional fraud review support campaign."),
+        new(SeedIds.Campaigns.StreamlyCreator, "STREAMLY-CREATOR", "Creator Support", "STREAMLY", "US", "Fictional creator support campaign."),
+        new(SeedIds.Campaigns.ShoporaAccess, "SHOPORA-ACCESS", "Account Access Support", "SHOPORA", "CO", "Fictional account access support campaign."),
+        new(SeedIds.Campaigns.AeroLinkTravel, "AEROLINK-TRAVEL", "Travel Support", "AEROLINK", "CR", "Fictional travel support campaign.")
+    ];
+
+    public static readonly IReadOnlyList<UserScopeSeed> UserScopes =
+    [
+        UserScopeSeed.ForRegion(SeedIds.UserScopes.ManagerLatam, "manager.latam@opssphere.local", "LATAM"),
+        UserScopeSeed.ForAccount(SeedIds.UserScopes.SupervisorNovabank, "supervisor.novabank@opssphere.local", "NOVABANK"),
+        UserScopeSeed.ForCampaign(SeedIds.UserScopes.AgentNovabankCreditCard, "agent.novabank@opssphere.local", "NOVABANK-CC"),
+        UserScopeSeed.ForRegion(SeedIds.UserScopes.ViewerLatam, "viewer.latam@opssphere.local", "LATAM")
+    ];
+
+    public sealed record RoleSeed(Guid Id, string Name, string Description);
+    public sealed record PermissionSeed(Guid Id, string Code, string Name, string Description);
+    public sealed record UserSeed(Guid Id, string Email, string FirstName, string LastName, string DisplayName, string RoleName);
+    public sealed record RegionSeed(Guid Id, string Code, string Name);
+    public sealed record CountrySeed(Guid Id, string Code, string Name, string RegionCode);
+    public sealed record AccountSeed(Guid Id, string Code, string Name, string CountryCode, string Description);
+    public sealed record CampaignSeed(Guid Id, string Code, string Name, string AccountCode, string CountryCode, string Description);
+    public sealed record UserScopeSeed(Guid Id, string UserEmail, string ScopeType, string? RegionCode, string? CountryCode, string? AccountCode, string? CampaignCode)
+    {
+        public static UserScopeSeed ForRegion(Guid id, string userEmail, string regionCode) =>
+            new(id, userEmail, "Region", regionCode, null, null, null);
+
+        public static UserScopeSeed ForAccount(Guid id, string userEmail, string accountCode) =>
+            new(id, userEmail, "Account", null, null, accountCode, null);
+
+        public static UserScopeSeed ForCampaign(Guid id, string userEmail, string campaignCode) =>
+            new(id, userEmail, "Campaign", null, null, null, campaignCode);
+    }
+}

--- a/src/OpsSphere.Infrastructure/Persistence/SeedData/SeedDataOptions.cs
+++ b/src/OpsSphere.Infrastructure/Persistence/SeedData/SeedDataOptions.cs
@@ -1,0 +1,8 @@
+namespace OpsSphere.Infrastructure.Persistence.SeedData;
+
+public sealed class SeedDataOptions
+{
+    public const string SectionName = "SeedData";
+
+    public bool Enabled { get; set; }
+}

--- a/src/OpsSphere.Infrastructure/Persistence/SeedData/SeedIds.cs
+++ b/src/OpsSphere.Infrastructure/Persistence/SeedData/SeedIds.cs
@@ -1,0 +1,106 @@
+namespace OpsSphere.Infrastructure.Persistence.SeedData;
+
+public static class SeedIds
+{
+    public static class Roles
+    {
+        public static readonly Guid Admin = Guid.Parse("e66bb345-2b5b-4f87-b106-31091edebea9");
+        public static readonly Guid OperationsManager = Guid.Parse("1ed479f8-9720-45cb-aad9-ce94cda99dce");
+        public static readonly Guid Supervisor = Guid.Parse("f486f23d-c0a7-4b37-912f-3511d3e18a0f");
+        public static readonly Guid Agent = Guid.Parse("0d960057-6c2e-43e3-a1ed-9b219a19b6bd");
+        public static readonly Guid Viewer = Guid.Parse("aebad384-eff3-4069-886a-1621c5b21e9c");
+    }
+
+    public static class Permissions
+    {
+        public static readonly Guid UsersView = Guid.Parse("e518b7bb-dbc9-40c2-b7fc-13c7bb13b23f");
+        public static readonly Guid UsersManage = Guid.Parse("38bdf4a8-0d42-4ecd-9f40-e7c3cc541226");
+        public static readonly Guid RolesView = Guid.Parse("4733e568-a0db-4e84-b8ad-6dcc46e5488e");
+        public static readonly Guid RolesManage = Guid.Parse("8f295e14-49c1-4c2a-9d63-0e4a5a9cc9b2");
+        public static readonly Guid PermissionsView = Guid.Parse("cfbee537-28b0-4de8-b688-40c16d76e0ab");
+        public static readonly Guid PermissionsManage = Guid.Parse("f0a054d6-3159-4442-a37e-1518069c4389");
+        public static readonly Guid ScopesView = Guid.Parse("b3f01126-7532-4d53-8c0f-8bc05bd856cc");
+        public static readonly Guid ScopesManage = Guid.Parse("f7c63236-1068-42fb-8341-f91fb1a97327");
+        public static readonly Guid OrganizationView = Guid.Parse("f2d85ff0-5e8e-431f-a9ea-78dc39b7f84c");
+        public static readonly Guid OrganizationManage = Guid.Parse("1233c870-529a-4f3d-9b61-85199d93ddf8");
+        public static readonly Guid RegionsManage = Guid.Parse("00fd5a1a-e3a9-44e3-8642-f8bf3f3e9da9");
+        public static readonly Guid CountriesManage = Guid.Parse("c8973bc5-c8a8-46eb-9745-1234ac8c504f");
+        public static readonly Guid AccountsManage = Guid.Parse("6f63fb7a-88c2-4afb-9982-39a3075fd44f");
+        public static readonly Guid CampaignsManage = Guid.Parse("cd00a1bf-166a-40c1-9c55-e05e33250680");
+        public static readonly Guid AssignmentsManage = Guid.Parse("291eb57c-b84d-42a1-a87a-079a6594309b");
+        public static readonly Guid CustomersView = Guid.Parse("c01dec64-a682-41ea-b55a-33d535812ee3");
+        public static readonly Guid CustomersCreate = Guid.Parse("e79074c8-d245-46be-8401-a7820281840e");
+        public static readonly Guid CustomersUpdate = Guid.Parse("f157982a-ac66-4c80-b134-678591c013e2");
+        public static readonly Guid CustomersHistoryView = Guid.Parse("12458f20-62b5-45ad-85a6-0e975dab1434");
+        public static readonly Guid TicketsView = Guid.Parse("7fdc43ea-03b5-4efd-826f-da7c68978c61");
+        public static readonly Guid TicketsCreate = Guid.Parse("2f07dc1e-3160-4aed-9246-5a1848363a3d");
+        public static readonly Guid TicketsUpdate = Guid.Parse("2880b151-a2fa-4707-a570-7847c373ac3f");
+        public static readonly Guid TicketsAssign = Guid.Parse("19cc4d2e-ed33-4541-bd03-9cc049594c5a");
+        public static readonly Guid TicketsUpdateStatus = Guid.Parse("b2fee76e-7cc3-4f10-9577-e5a3329ebc6f");
+        public static readonly Guid TicketsUpdatePriority = Guid.Parse("22f325ae-f416-48d0-9ba8-f40828ff7eaf");
+        public static readonly Guid TicketsComment = Guid.Parse("30ca5af8-7934-4ff0-85e0-e848a73bd09b");
+        public static readonly Guid TicketsEscalate = Guid.Parse("1fae5562-1478-4dbf-bf12-c42df2c8a35d");
+        public static readonly Guid TicketsResolve = Guid.Parse("21479de7-9fbe-44d0-a6fa-80631aec147f");
+        public static readonly Guid TicketsClose = Guid.Parse("b0e0cd5a-486b-4286-8d96-e2bd3950cb74");
+        public static readonly Guid TicketsHistoryView = Guid.Parse("94403333-a65b-4455-9d2b-55d4c36570a5");
+        public static readonly Guid TicketsReopen = Guid.Parse("c2c34198-9d7a-45e8-8414-ff17b059abd9");
+        public static readonly Guid SlaView = Guid.Parse("3a566513-d148-40a7-92ca-26cbcf0eda64");
+        public static readonly Guid SlaPoliciesView = Guid.Parse("d4b944f8-1c92-4340-964c-ac55c73f0583");
+        public static readonly Guid SlaPoliciesManage = Guid.Parse("f7f32bfd-2d73-4d22-9522-2ed15b8133e7");
+        public static readonly Guid SlaEvaluate = Guid.Parse("8d10f3f8-10ba-4cdd-9bdc-e7179244fd2e");
+        public static readonly Guid DashboardView = Guid.Parse("ea4c7b44-5675-4a33-9e41-46023b6fb71a");
+        public static readonly Guid ReportsView = Guid.Parse("c40d5d7b-0ab1-41ac-a77f-517bdcfb2392");
+        public static readonly Guid ReportsExport = Guid.Parse("e77c60be-611c-4d3f-b672-97116bdde705");
+        public static readonly Guid AuditView = Guid.Parse("8dc2ff39-d9e1-4934-9ae5-fe8db683d397");
+        public static readonly Guid AuditAdminView = Guid.Parse("9ee63109-a8fb-4269-9dd8-3d8804b323a0");
+        public static readonly Guid AuditExport = Guid.Parse("70dbdb82-df99-4d97-ae78-3e9178369925");
+    }
+
+    public static class Users
+    {
+        public static readonly Guid Admin = Guid.Parse("cdf3edb1-fee0-4bad-96b6-e26b670e86aa");
+        public static readonly Guid ManagerLatam = Guid.Parse("a9b6f62c-8b2b-4906-b7e2-59ae759642e2");
+        public static readonly Guid SupervisorNovabank = Guid.Parse("69af963e-f944-450c-af3e-06fca1866f52");
+        public static readonly Guid AgentNovabank = Guid.Parse("de55f444-bea5-485e-a348-6909ea378422");
+        public static readonly Guid ViewerLatam = Guid.Parse("abfb2ab0-4b94-49cd-bebe-35ce548972ec");
+    }
+
+    public static class Regions
+    {
+        public static readonly Guid Latam = Guid.Parse("218c74bc-b109-4284-908e-6cdf4983e543");
+        public static readonly Guid NorthAmerica = Guid.Parse("7131dd68-26cf-44a5-a75e-5038167b8720");
+    }
+
+    public static class Countries
+    {
+        public static readonly Guid Mexico = Guid.Parse("fb991387-3247-4463-886b-f97154cea0b4");
+        public static readonly Guid Colombia = Guid.Parse("6e48c72b-3ae8-4646-bd86-3f46d39fd8b3");
+        public static readonly Guid CostaRica = Guid.Parse("1f8d06f3-def6-40a0-b8bd-b3a44c03f1c2");
+        public static readonly Guid UnitedStates = Guid.Parse("a82cdef6-b8ac-4c76-81c8-9cdd8410485a");
+    }
+
+    public static class Accounts
+    {
+        public static readonly Guid NovaBank = Guid.Parse("0acd2297-f9b6-46c0-a26d-18868180a1eb");
+        public static readonly Guid Streamly = Guid.Parse("00fffde5-996f-4181-8b55-045c220416c9");
+        public static readonly Guid Shopora = Guid.Parse("797da587-e74c-4f1e-b0d8-841eb056d524");
+        public static readonly Guid AeroLink = Guid.Parse("54bed65c-cecd-4c0d-a8b0-ad4483912535");
+    }
+
+    public static class Campaigns
+    {
+        public static readonly Guid NovaBankCreditCard = Guid.Parse("7942833e-9511-421c-8a19-a51dff9330e7");
+        public static readonly Guid NovaBankFraud = Guid.Parse("bd48e8c7-8acd-465f-8e30-8921fe04140d");
+        public static readonly Guid StreamlyCreator = Guid.Parse("5c93320c-3e90-4a17-9ac7-57e7d701aa67");
+        public static readonly Guid ShoporaAccess = Guid.Parse("5895a383-db7f-4ca7-b17e-62fa6a5bda0d");
+        public static readonly Guid AeroLinkTravel = Guid.Parse("ed4e4d95-45f4-47d4-811a-68c595cfe921");
+    }
+
+    public static class UserScopes
+    {
+        public static readonly Guid ManagerLatam = Guid.Parse("c616e064-8180-4aef-aa8b-cae17d68ef1d");
+        public static readonly Guid SupervisorNovabank = Guid.Parse("8d09bd50-386d-496f-9bdb-ddaea22fd0ac");
+        public static readonly Guid AgentNovabankCreditCard = Guid.Parse("156aafc5-16ac-4883-8d63-c944bce1bda7");
+        public static readonly Guid ViewerLatam = Guid.Parse("c1d256d9-9595-4dc4-84e0-234085d208a5");
+    }
+}

--- a/tests/OpsSphere.IntegrationTests/OpsSphere.IntegrationTests.csproj
+++ b/tests/OpsSphere.IntegrationTests/OpsSphere.IntegrationTests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/tests/OpsSphere.IntegrationTests/Persistence/SeedDataStartupGateTests.cs
+++ b/tests/OpsSphere.IntegrationTests/Persistence/SeedDataStartupGateTests.cs
@@ -1,0 +1,19 @@
+namespace OpsSphere.IntegrationTests.Persistence;
+
+public sealed class SeedDataStartupGateTests
+{
+    [Theory]
+    [InlineData("Development", true, true)]
+    [InlineData("Testing", true, true)]
+    [InlineData("Production", true, false)]
+    [InlineData("Staging", true, false)]
+    [InlineData("Development", false, false)]
+    [InlineData("Testing", false, false)]
+    public void ShouldRun_ShouldRequireDevelopmentOrTestingAndEnabledFlag(
+        string environmentName,
+        bool seedDataEnabled,
+        bool expected)
+    {
+        Assert.Equal(expected, global::SeedDataStartupGate.ShouldRun(environmentName, seedDataEnabled));
+    }
+}

--- a/tests/OpsSphere.IntegrationTests/Persistence/SeedDataTests.cs
+++ b/tests/OpsSphere.IntegrationTests/Persistence/SeedDataTests.cs
@@ -1,0 +1,373 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using OpsSphere.Domain.Entities;
+using OpsSphere.Infrastructure.Persistence;
+using OpsSphere.Infrastructure.Persistence.SeedData;
+
+namespace OpsSphere.IntegrationTests.Persistence;
+
+public sealed class SeedDataTests
+{
+    private static readonly string[] RequiredPermissionCodes =
+    [
+        "users.view",
+        "users.manage",
+        "roles.view",
+        "roles.manage",
+        "permissions.view",
+        "permissions.manage",
+        "scopes.view",
+        "scopes.manage",
+        "organization.view",
+        "organization.manage",
+        "regions.manage",
+        "countries.manage",
+        "accounts.manage",
+        "campaigns.manage",
+        "assignments.manage",
+        "customers.view",
+        "customers.create",
+        "customers.update",
+        "customers.history.view",
+        "tickets.view",
+        "tickets.create",
+        "tickets.update",
+        "tickets.assign",
+        "tickets.update_status",
+        "tickets.update_priority",
+        "tickets.comment",
+        "tickets.escalate",
+        "tickets.resolve",
+        "tickets.close",
+        "tickets.history.view",
+        "tickets.reopen",
+        "sla.view",
+        "sla.policies.view",
+        "sla.policies.manage",
+        "sla.evaluate",
+        "dashboard.view",
+        "reports.view",
+        "reports.export",
+        "audit.view",
+        "audit.admin_view",
+        "audit.export"
+    ];
+
+    private static readonly IReadOnlyDictionary<string, string[]> ExpectedRolePermissions = new Dictionary<string, string[]>
+    {
+        ["Admin"] =
+        [
+            "users.view", "users.manage", "roles.view", "roles.manage", "permissions.view", "permissions.manage",
+            "scopes.view", "scopes.manage", "organization.view", "organization.manage", "regions.manage",
+            "countries.manage", "accounts.manage", "campaigns.manage", "assignments.manage", "customers.view",
+            "customers.create", "customers.update", "customers.history.view", "tickets.view", "tickets.history.view",
+            "tickets.reopen", "sla.view", "sla.policies.view", "sla.policies.manage", "sla.evaluate", "dashboard.view",
+            "reports.view", "reports.export", "audit.view", "audit.admin_view", "audit.export"
+        ],
+        ["OperationsManager"] =
+        [
+            "organization.view", "customers.view", "customers.history.view", "tickets.view", "tickets.history.view",
+            "tickets.comment", "sla.view", "sla.policies.view", "dashboard.view", "reports.view", "reports.export",
+            "audit.view", "audit.export"
+        ],
+        ["Supervisor"] =
+        [
+            "organization.view", "customers.view", "customers.create", "customers.update", "customers.history.view",
+            "tickets.view", "tickets.create", "tickets.update", "tickets.assign", "tickets.update_status",
+            "tickets.update_priority", "tickets.comment", "tickets.escalate", "tickets.resolve", "tickets.close",
+            "tickets.history.view", "tickets.reopen", "sla.view", "sla.policies.view", "dashboard.view",
+            "reports.view", "reports.export", "audit.view"
+        ],
+        ["Agent"] =
+        [
+            "organization.view", "customers.view", "customers.create", "customers.update", "customers.history.view",
+            "tickets.view", "tickets.create", "tickets.update", "tickets.update_status", "tickets.update_priority",
+            "tickets.comment", "tickets.escalate", "tickets.resolve", "tickets.close", "tickets.history.view",
+            "sla.view", "dashboard.view"
+        ],
+        ["Viewer"] =
+        [
+            "organization.view", "customers.view", "customers.history.view", "tickets.view", "tickets.history.view",
+            "sla.view", "dashboard.view", "reports.view", "reports.export", "audit.view"
+        ]
+    };
+
+    [Fact]
+    public async Task SeedData_WhenApplied_ShouldCreateRequiredRoles()
+    {
+        await using var database = await SeedDatabase.CreateAsync();
+
+        var roleNames = await database.Context.Roles.Select(role => role.Name).ToListAsync();
+
+        Assert.Contains("Admin", roleNames);
+        Assert.Contains("OperationsManager", roleNames);
+        Assert.Contains("Supervisor", roleNames);
+        Assert.Contains("Agent", roleNames);
+        Assert.Contains("Viewer", roleNames);
+        Assert.All(await database.Context.Roles.ToListAsync(), role =>
+        {
+            Assert.True(role.IsSystemRole);
+            Assert.True(role.IsActive);
+        });
+    }
+
+    [Fact]
+    public async Task SeedData_WhenApplied_ShouldCreateRequiredPermissions()
+    {
+        await using var database = await SeedDatabase.CreateAsync();
+
+        var permissionCodes = await database.Context.Permissions
+            .Select(permission => permission.Code)
+            .ToListAsync();
+
+        foreach (var expectedPermissionCode in RequiredPermissionCodes)
+        {
+            Assert.Contains(expectedPermissionCode, permissionCodes);
+            Assert.Equal(expectedPermissionCode, expectedPermissionCode.ToLowerInvariant());
+            Assert.Contains(".", expectedPermissionCode);
+        }
+    }
+
+    [Fact]
+    public async Task SeedData_WhenApplied_ShouldCreateRolePermissionMappings()
+    {
+        await using var database = await SeedDatabase.CreateAsync();
+
+        var mappings = await database.Context.RolePermissions
+            .Include(rolePermission => rolePermission.Role)
+            .Include(rolePermission => rolePermission.Permission)
+            .Select(rolePermission => new
+            {
+                RoleName = rolePermission.Role.Name,
+                PermissionCode = rolePermission.Permission.Code
+            })
+            .ToListAsync();
+
+        foreach (var (roleName, permissionCodes) in ExpectedRolePermissions)
+        {
+            foreach (var permissionCode in permissionCodes)
+            {
+                Assert.Contains(mappings, mapping =>
+                    mapping.RoleName == roleName && mapping.PermissionCode == permissionCode);
+            }
+        }
+
+        Assert.DoesNotContain(mappings, mapping =>
+            mapping.RoleName == "Admin" && mapping.PermissionCode == "tickets.create");
+        Assert.DoesNotContain(mappings, mapping =>
+            mapping.RoleName == "Viewer" && mapping.PermissionCode is "tickets.create" or "tickets.update" or "tickets.close");
+        Assert.Contains(mappings, mapping =>
+            mapping.RoleName == "Supervisor" && mapping.PermissionCode == "tickets.assign");
+        Assert.Contains(mappings, mapping =>
+            mapping.RoleName == "Agent" && mapping.PermissionCode == "tickets.create");
+
+        var adminTicketOperatorPermissions = new[]
+        {
+            "tickets.create", "tickets.update", "tickets.assign", "tickets.update_status", "tickets.update_priority",
+            "tickets.comment", "tickets.escalate", "tickets.resolve", "tickets.close"
+        };
+        Assert.All(adminTicketOperatorPermissions, permissionCode =>
+            Assert.DoesNotContain(mappings, mapping => mapping.RoleName == "Admin" && mapping.PermissionCode == permissionCode));
+
+        var viewerWritePermissions = new[]
+        {
+            "users.manage", "roles.manage", "permissions.manage", "scopes.manage", "organization.manage",
+            "regions.manage", "countries.manage", "accounts.manage", "campaigns.manage", "assignments.manage",
+            "customers.create", "customers.update", "tickets.create", "tickets.update", "tickets.assign",
+            "tickets.update_status", "tickets.update_priority", "tickets.comment", "tickets.escalate",
+            "tickets.resolve", "tickets.close", "tickets.reopen", "sla.policies.manage", "sla.evaluate"
+        };
+        Assert.All(viewerWritePermissions, permissionCode =>
+            Assert.DoesNotContain(mappings, mapping => mapping.RoleName == "Viewer" && mapping.PermissionCode == permissionCode));
+
+        var operationsManagerDeniedPermissions = new[]
+        {
+            "users.manage", "roles.manage", "permissions.manage", "scopes.manage", "organization.manage",
+            "tickets.create", "tickets.update", "tickets.assign", "tickets.update_status", "tickets.update_priority",
+            "tickets.escalate", "tickets.resolve", "tickets.close", "tickets.reopen", "sla.policies.manage", "sla.evaluate"
+        };
+        Assert.All(operationsManagerDeniedPermissions, permissionCode =>
+            Assert.DoesNotContain(mappings, mapping => mapping.RoleName == "OperationsManager" && mapping.PermissionCode == permissionCode));
+    }
+
+    [Fact]
+    public async Task SeedData_WhenApplied_ShouldCreateFictionalUsersWithPasswordHashes()
+    {
+        await using var database = await SeedDatabase.CreateAsync();
+        var passwordHasher = new PasswordHasher<User>();
+
+        var users = await database.Context.Users.ToListAsync();
+
+        foreach (var expectedUser in OpsSphereSeedData.Users)
+        {
+            var user = Assert.Single(users, user => user.Email == expectedUser.Email);
+            Assert.True(user.IsActive);
+            Assert.False(string.IsNullOrWhiteSpace(user.PasswordHash));
+            Assert.NotEqual(OpsSphereSeedData.LocalDemoPassword, user.PasswordHash);
+
+            var verificationResult = passwordHasher.VerifyHashedPassword(
+                user,
+                user.PasswordHash,
+                OpsSphereSeedData.LocalDemoPassword);
+
+            Assert.True(verificationResult is PasswordVerificationResult.Success or PasswordVerificationResult.SuccessRehashNeeded);
+        }
+    }
+
+    [Fact]
+    public async Task SeedData_WhenApplied_ShouldCreateOrganizationHierarchy()
+    {
+        await using var database = await SeedDatabase.CreateAsync();
+
+        Assert.Equal(["LATAM", "NA"], await database.Context.Regions.OrderBy(region => region.Code).Select(region => region.Code).ToListAsync());
+        Assert.Equal(["CO", "CR", "MX", "US"], await database.Context.Countries.OrderBy(country => country.Code).Select(country => country.Code).ToListAsync());
+        Assert.Equal(["AEROLINK", "NOVABANK", "SHOPORA", "STREAMLY"], await database.Context.Accounts.OrderBy(account => account.Code).Select(account => account.Code).ToListAsync());
+        Assert.Equal(
+            ["AEROLINK-TRAVEL", "NOVABANK-CC", "NOVABANK-FRAUD", "SHOPORA-ACCESS", "STREAMLY-CREATOR"],
+            await database.Context.Campaigns.OrderBy(campaign => campaign.Code).Select(campaign => campaign.Code).ToListAsync());
+
+        var novaBank = await database.Context.Accounts.SingleAsync(account => account.Code == "NOVABANK");
+        var mexico = await database.Context.Countries.SingleAsync(country => country.Code == "MX");
+        Assert.Equal(mexico.Id, novaBank.CountryId);
+
+        var novaBankCreditCard = await database.Context.Campaigns.SingleAsync(campaign => campaign.Code == "NOVABANK-CC");
+        Assert.Equal(novaBank.Id, novaBankCreditCard.AccountId);
+        Assert.Equal(mexico.Id, novaBankCreditCard.CountryId);
+    }
+
+    [Fact]
+    public async Task SeedData_WhenApplied_ShouldCreateInitialUserScopes()
+    {
+        await using var database = await SeedDatabase.CreateAsync();
+
+        Assert.False(await database.Context.UserScopes
+            .AnyAsync(scope => scope.User.Email == "admin@opssphere.local"));
+
+        await AssertScopeAsync(database.Context, "manager.latam@opssphere.local", "Region", "LATAM");
+        await AssertScopeAsync(database.Context, "supervisor.novabank@opssphere.local", "Account", "NOVABANK");
+        await AssertScopeAsync(database.Context, "agent.novabank@opssphere.local", "Campaign", "NOVABANK-CC");
+        await AssertScopeAsync(database.Context, "viewer.latam@opssphere.local", "Region", "LATAM");
+    }
+
+    [Fact]
+    public async Task SeedData_WhenAppliedTwice_ShouldNotCreateDuplicates()
+    {
+        await using var database = await SeedDatabase.CreateAsync();
+        var seeder = new OpsSphereDataSeeder(database.Context, new PasswordHasher<User>());
+
+        await seeder.SeedAsync();
+
+        Assert.Equal(5, await database.Context.Roles.CountAsync());
+        Assert.Equal(RequiredPermissionCodes.Length, await database.Context.Permissions.CountAsync());
+        Assert.Equal(5, await database.Context.Users.CountAsync());
+        Assert.Equal(2, await database.Context.Regions.CountAsync());
+        Assert.Equal(4, await database.Context.Countries.CountAsync());
+        Assert.Equal(4, await database.Context.Accounts.CountAsync());
+        Assert.Equal(5, await database.Context.Campaigns.CountAsync());
+        Assert.Equal(4, await database.Context.UserScopes.CountAsync());
+
+        var expectedRolePermissionCount = ExpectedRolePermissions.Sum(mapping => mapping.Value.Length);
+        Assert.Equal(expectedRolePermissionCount, await database.Context.RolePermissions.CountAsync());
+        Assert.Equal(5, await database.Context.UserRoles.CountAsync());
+    }
+
+    [Fact]
+    public async Task SeedData_ShouldNotStorePlainTextPasswords()
+    {
+        await using var database = await SeedDatabase.CreateAsync();
+
+        var passwordHashes = await database.Context.Users.Select(user => user.PasswordHash).ToListAsync();
+
+        Assert.All(passwordHashes, hash =>
+        {
+            Assert.NotEqual(OpsSphereSeedData.LocalDemoPassword, hash);
+            Assert.DoesNotContain("OpsSphere123!", hash, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public async Task SeedData_ShouldNotContainObviousRealOrProductionSecrets()
+    {
+        await using var database = await SeedDatabase.CreateAsync();
+
+        var seededValues = new List<string>();
+        seededValues.AddRange(await database.Context.Users.Select(user => user.Email).ToListAsync());
+        seededValues.AddRange(await database.Context.Users.Select(user => user.DisplayName).ToListAsync());
+        seededValues.AddRange(await database.Context.Regions.Select(region => region.Name).ToListAsync());
+        seededValues.AddRange(await database.Context.Countries.Select(country => country.Name).ToListAsync());
+        seededValues.AddRange(await database.Context.Accounts.Select(account => account.Name).ToListAsync());
+        seededValues.AddRange(await database.Context.Accounts.Select(account => account.Description ?? string.Empty).ToListAsync());
+        seededValues.AddRange(await database.Context.Campaigns.Select(campaign => campaign.Name).ToListAsync());
+        seededValues.AddRange(await database.Context.Campaigns.Select(campaign => campaign.Description ?? string.Empty).ToListAsync());
+
+        var forbiddenMarkers = new[] { "production", "prod-", "secret", "token", "api key", "password hash" };
+
+        foreach (var value in seededValues.Where(value => !string.IsNullOrWhiteSpace(value)))
+        {
+            foreach (var marker in forbiddenMarkers)
+            {
+                Assert.DoesNotContain(marker, value, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+    }
+
+    private static async Task AssertScopeAsync(OpsSphereDbContext context, string email, string scopeType, string scopeCode)
+    {
+        var scope = await context.UserScopes
+            .Include(userScope => userScope.User)
+            .Include(userScope => userScope.Region)
+            .Include(userScope => userScope.Account)
+            .Include(userScope => userScope.Campaign)
+            .SingleAsync(userScope => userScope.User.Email == email && userScope.ScopeType == scopeType);
+
+        Assert.True(scope.IsActive);
+
+        var actualCode = scopeType switch
+        {
+            "Region" => scope.Region?.Code,
+            "Account" => scope.Account?.Code,
+            "Campaign" => scope.Campaign?.Code,
+            _ => null
+        };
+
+        Assert.Equal(scopeCode, actualCode);
+    }
+
+    private sealed class SeedDatabase : IAsyncDisposable
+    {
+        private SeedDatabase(SqliteConnection connection, OpsSphereDbContext context)
+        {
+            Connection = connection;
+            Context = context;
+        }
+
+        private SqliteConnection Connection { get; }
+
+        public OpsSphereDbContext Context { get; }
+
+        public static async Task<SeedDatabase> CreateAsync()
+        {
+            var connection = new SqliteConnection("Data Source=:memory:");
+            await connection.OpenAsync();
+
+            var options = new DbContextOptionsBuilder<OpsSphereDbContext>()
+                .UseSqlite(connection)
+                .Options;
+
+            var context = new OpsSphereDbContext(options);
+            await context.Database.EnsureCreatedAsync();
+
+            var seeder = new OpsSphereDataSeeder(context, new PasswordHasher<User>());
+            await seeder.SeedAsync();
+
+            return new SeedDatabase(connection, context);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Context.DisposeAsync();
+            await Connection.DisposeAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the fictional seed data foundation for OpsSphere local development, demos, and automated tests.

This PR introduces deterministic seed data for roles, permissions, role-permission mappings, fictional users, organization hierarchy records, and initial user scopes. It also adds seed configuration support and integration tests to verify that the seed process is repeatable and does not create duplicate records.

## Added / Changed

- Added `OpsSphereSeedData` to define deterministic fictional seed records for:
  - Roles
  - Permissions
  - Users
  - Regions
  - Countries
  - Accounts
  - Campaigns
  - User scopes
- Added `SeedIds` to centralize fixed GUIDs for deterministic seed records.
- Added `SeedDataOptions` to support seed data configuration.
- Added seed validation coverage for:
  - Required roles and permissions.
  - Role-permission mappings.
  - Fictional users.
  - User scope assignments.
  - Organization hierarchy records.
  - Idempotent seed execution.
- Added SQLite test dependency for fast relational test coverage.
- Updated local documentation for seed behavior and validation expectations.

## Validation

- [x] Reviewed changed files.
- [x] Confirmed scope matches the related issue.
- [x] Confirmed validation expectations from `docs/implementation-guardrails.md` were met or documented.
- [x] Ran `dotnet restore`.
- [x] Ran `dotnet build`.
- [x] Ran `dotnet test`.
- [x] Confirmed seed data is deterministic and repeatable.
- [x] Confirmed repeated seed execution does not create duplicate records.
- [x] Confirmed seeded users use hashed passwords.

## Scope Confirmation

- [x] This PR contains no out-of-scope work.
- [x] This PR does not introduce unrelated source, package, migration, Docker, or GitHub Actions changes.

## Related Issue

Closes #35

## Checklist

- [x] Branch name includes the issue number.
- [x] Related issue defines scope, out of scope, acceptance criteria, and validation.
- [x] Architecture boundaries and MVP limits from `docs/implementation-guardrails.md` are respected.
- [x] Documentation is updated when behavior, architecture, setup, or validation expectations change.