### PR TITLE
feat(auth): implement JWT authentication with login and user retrieva…

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,9 @@
 
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.5" />
@@ -18,6 +21,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -149,6 +149,33 @@ dotnet run --project src/OpsSphere.Api
 ### Frontend API Base URL
 The Angular development environment is configured in `frontend/src/environments/environment.development.ts`. The `apiBaseUrl` property should point to your locally running backend API (e.g., `http://localhost:5000/api` or `https://localhost:7024/api` per `launchSettings.json`).
 
+## Local JWT Authentication
+
+The API uses JWT bearer authentication for internal users. Local development needs these configuration values:
+
+```json
+"Jwt": {
+  "Issuer": "OpsSphere",
+  "Audience": "OpsSphere.Angular",
+  "ExpirationMinutes": 60,
+  "SigningKey": "<local-development-only-signing-key>"
+}
+```
+
+`appsettings.json` intentionally keeps `Jwt:SigningKey` blank. Use .NET user secrets, environment variables, or a clearly local-only development value. Do not commit production signing keys or real secrets. `appsettings.Development.json` contains only a fictional local signing key for developer convenience.
+
+Seeded login users are fictional and share the local/demo password `OpsSphere123!`. Passwords are hashed before persistence, and passwords, password hashes, JWT tokens, Authorization headers, signing keys, and connection strings must not be logged.
+
+Useful auth smoke checks after the API starts:
+
+```bash
+dotnet run --project src/OpsSphere.Api
+```
+
+- `POST /api/auth/login` with `agent.novabank@opssphere.local` and `OpsSphere123!` should return a bearer token.
+- `GET /api/auth/me` should return 401 without a token and the current seeded profile with a valid token.
+- `GET /api/auth/protected-smoke` should return 401 without a token and 200 with a valid token.
+
 ## Documentation Approach
 
 OpsSphere follows a practical enterprise documentation workflow inspired by:

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -4,7 +4,17 @@
     <span>{{ title }}</span>
   </div>
   <span class="toolbar-spacer"></span>
-  <button mat-stroked-button type="button" disabled>Frontend Foundation</button>
+  @if (authService.isAuthenticated()) {
+    <button mat-stroked-button type="button" (click)="logout()">
+      <mat-icon aria-hidden="true">logout</mat-icon>
+      <span>Logout</span>
+    </button>
+  } @else {
+    <a mat-stroked-button routerLink="/login">
+      <mat-icon aria-hidden="true">login</mat-icon>
+      <span>Login</span>
+    </a>
+  }
 </mat-toolbar>
 
 <main class="app-shell">

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -20,6 +20,13 @@
   flex: 1 1 auto;
 }
 
+.app-toolbar a,
+.app-toolbar button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
 .app-shell {
   width: min(1120px, calc(100% - 2rem));
   margin: 0 auto;

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,16 +1,25 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Router, RouterLink, RouterOutlet } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatToolbarModule } from '@angular/material/toolbar';
 
+import { AuthService } from './core/auth/auth.service';
+
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, MatButtonModule, MatIconModule, MatToolbarModule],
+  imports: [RouterLink, RouterOutlet, MatButtonModule, MatIconModule, MatToolbarModule],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AppComponent {
+  protected readonly authService = inject(AuthService);
   protected readonly title = 'OpsSphere';
+  private readonly router = inject(Router);
+
+  protected logout(): void {
+    this.authService.logout();
+    void this.router.navigate(['/login']);
+  }
 }

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -4,7 +4,16 @@ import { authGuard } from './core/guards/auth.guard';
 
 export const routes: Routes = [
   {
+    path: 'login',
+    loadComponent: () => import('./features/login/login.component').then((m) => m.LoginComponent)
+  },
+  {
     path: '',
+    canActivate: [authGuard],
+    loadComponent: () => import('./home-placeholder.component').then((m) => m.HomePlaceholderComponent)
+  },
+  {
+    path: 'dashboard',
     canActivate: [authGuard],
     loadComponent: () => import('./home-placeholder.component').then((m) => m.HomePlaceholderComponent)
   },

--- a/frontend/src/app/core/auth/auth.models.ts
+++ b/frontend/src/app/core/auth/auth.models.ts
@@ -1,0 +1,46 @@
+export interface ApiResponse<T> {
+  data: T;
+}
+
+export interface ApiErrorResponse {
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  accessToken: string;
+  tokenType: 'Bearer';
+  expiresIn: number;
+  user: AuthUserSummary;
+}
+
+export interface AuthUserSummary {
+  id: string;
+  email: string;
+  displayName: string;
+  roles: string[];
+}
+
+export interface CurrentUserProfile extends AuthUserSummary {
+  permissions: string[];
+  scopes: UserScope[];
+}
+
+export interface UserScope {
+  scopeType: string;
+  regionId?: string | null;
+  regionCode?: string | null;
+  countryId?: string | null;
+  countryCode?: string | null;
+  accountId?: string | null;
+  accountCode?: string | null;
+  campaignId?: string | null;
+  campaignCode?: string | null;
+}

--- a/frontend/src/app/core/auth/auth.service.spec.ts
+++ b/frontend/src/app/core/auth/auth.service.spec.ts
@@ -1,0 +1,76 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { environment } from '../../../environments/environment';
+import { AuthService } from './auth.service';
+import { TokenStorageService } from './token-storage.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let httpTesting: HttpTestingController;
+  let tokenStorage: TokenStorageService;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()]
+    });
+
+    service = TestBed.inject(AuthService);
+    httpTesting = TestBed.inject(HttpTestingController);
+    tokenStorage = TestBed.inject(TokenStorageService);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+    localStorage.clear();
+  });
+
+  it('sends login request and stores token', (done) => {
+    const token = createToken();
+
+    service.login('agent.novabank@opssphere.local', 'OpsSphere123!').subscribe((response) => {
+      expect(response.accessToken).toBe(token);
+      expect(tokenStorage.getToken()).toBe(token);
+      expect(service.isAuthenticated()).toBeTrue();
+      done();
+    });
+
+    const request = httpTesting.expectOne(`${environment.apiBaseUrl}/auth/login`);
+    expect(request.request.method).toBe('POST');
+    expect(request.request.body).toEqual({
+      email: 'agent.novabank@opssphere.local',
+      password: 'OpsSphere123!'
+    });
+    request.flush({
+      data: {
+        accessToken: token,
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        user: {
+          id: '00000000-0000-0000-0000-000000000001',
+          email: 'agent.novabank@opssphere.local',
+          displayName: 'Agent NovaBank',
+          roles: ['Agent']
+        }
+      }
+    });
+  });
+
+  it('clears token on logout', () => {
+    tokenStorage.setToken(createToken());
+
+    service.logout();
+
+    expect(tokenStorage.getToken()).toBeNull();
+    expect(service.isAuthenticated()).toBeFalse();
+  });
+});
+
+function createToken(expOffsetSeconds = 3600): string {
+  const payload = { exp: Math.floor(Date.now() / 1000) + expOffsetSeconds };
+  const encodedPayload = btoa(JSON.stringify(payload)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+  return `header.${encodedPayload}.signature`;
+}

--- a/frontend/src/app/core/auth/auth.service.ts
+++ b/frontend/src/app/core/auth/auth.service.ts
@@ -1,0 +1,61 @@
+import { computed, inject, Injectable, signal } from '@angular/core';
+import { map, tap } from 'rxjs';
+
+import { ApiClientService } from '../services/api-client.service';
+import { ApiResponse, AuthUserSummary, CurrentUserProfile, LoginRequest, LoginResponse } from './auth.models';
+import { TokenStorageService } from './token-storage.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthService {
+  private readonly apiClient = inject(ApiClientService);
+  private readonly tokenStorage = inject(TokenStorageService);
+  private readonly currentToken = signal(this.tokenStorage.getUsableToken());
+
+  readonly currentUser = signal<AuthUserSummary | null>(null);
+  readonly isAuthenticated = computed(() => Boolean(this.currentToken()));
+
+  login(email: string, password: string) {
+    const request: LoginRequest = { email, password };
+
+    return this.apiClient.post<LoginRequest, ApiResponse<LoginResponse>>('auth/login', request).pipe(
+      map((response) => response.data),
+      tap((loginResponse) => {
+        this.tokenStorage.setToken(loginResponse.accessToken);
+        this.currentToken.set(loginResponse.accessToken);
+        this.currentUser.set(loginResponse.user);
+      })
+    );
+  }
+
+  me() {
+    return this.apiClient.get<ApiResponse<CurrentUserProfile>>('auth/me').pipe(
+      map((response) => response.data),
+      tap((profile) => {
+        this.currentUser.set({
+          id: profile.id,
+          email: profile.email,
+          displayName: profile.displayName,
+          roles: profile.roles
+        });
+      })
+    );
+  }
+
+  logout(): void {
+    this.tokenStorage.clearToken();
+    this.currentToken.set(null);
+    this.currentUser.set(null);
+  }
+
+  getAccessToken(): string | null {
+    const token = this.currentToken() ?? this.tokenStorage.getUsableToken();
+    if (!token) {
+      this.logout();
+      return null;
+    }
+
+    return token;
+  }
+}

--- a/frontend/src/app/core/auth/token-storage.service.spec.ts
+++ b/frontend/src/app/core/auth/token-storage.service.spec.ts
@@ -1,0 +1,44 @@
+import { TestBed } from '@angular/core/testing';
+
+import { TokenStorageService } from './token-storage.service';
+
+describe('TokenStorageService', () => {
+  let service: TokenStorageService;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(TokenStorageService);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('stores and clears the token', () => {
+    const token = createToken();
+
+    service.setToken(token);
+
+    expect(service.getToken()).toBe(token);
+    expect(service.getUsableToken()).toBe(token);
+
+    service.clearToken();
+
+    expect(service.getToken()).toBeNull();
+  });
+
+  it('clears expired tokens when reading usable token', () => {
+    service.setToken(createToken(-60));
+
+    expect(service.getUsableToken()).toBeNull();
+    expect(service.getToken()).toBeNull();
+  });
+});
+
+function createToken(expOffsetSeconds = 3600): string {
+  const payload = { exp: Math.floor(Date.now() / 1000) + expOffsetSeconds };
+  const encodedPayload = btoa(JSON.stringify(payload)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+  return `header.${encodedPayload}.signature`;
+}

--- a/frontend/src/app/core/auth/token-storage.service.ts
+++ b/frontend/src/app/core/auth/token-storage.service.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TokenStorageService {
+  private readonly tokenKey = 'opssphere.accessToken';
+
+  getToken(): string | null {
+    return this.storage()?.getItem(this.tokenKey) ?? null;
+  }
+
+  getUsableToken(): string | null {
+    const token = this.getToken();
+    if (!this.isUsableToken(token)) {
+      this.clearToken();
+      return null;
+    }
+
+    return token;
+  }
+
+  setToken(token: string): void {
+    this.storage()?.setItem(this.tokenKey, token);
+  }
+
+  clearToken(): void {
+    this.storage()?.removeItem(this.tokenKey);
+  }
+
+  private storage(): Storage | null {
+    return typeof localStorage === 'undefined' ? null : localStorage;
+  }
+
+  private isUsableToken(token: string | null): boolean {
+    if (!token) {
+      return false;
+    }
+
+    const expiresAt = this.getTokenExpiration(token);
+    return expiresAt !== null && expiresAt > Date.now();
+  }
+
+  private getTokenExpiration(token: string): number | null {
+    const payload = token.split('.')[1];
+    if (!payload) {
+      return null;
+    }
+
+    try {
+      const paddedPayload = payload.padEnd(payload.length + ((4 - (payload.length % 4)) % 4), '=');
+      const normalizedPayload = paddedPayload.replace(/-/g, '+').replace(/_/g, '/');
+      const jsonPayload = JSON.parse(atob(normalizedPayload)) as { exp?: number };
+      return typeof jsonPayload.exp === 'number' ? jsonPayload.exp * 1000 : null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/frontend/src/app/core/guards/auth.guard.spec.ts
+++ b/frontend/src/app/core/guards/auth.guard.spec.ts
@@ -1,14 +1,41 @@
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { provideRouter, Router } from '@angular/router';
 
+import { AuthService } from '../auth/auth.service';
 import { authGuard } from './auth.guard';
 
 describe('authGuard', () => {
-  it('allows navigation while frontend auth is not implemented', () => {
+  let authService: jasmine.SpyObj<Pick<AuthService, 'getAccessToken'>>;
+
+  beforeEach(() => {
+    authService = jasmine.createSpyObj<Pick<AuthService, 'getAccessToken'>>('AuthService', ['getAccessToken']);
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        { provide: AuthService, useValue: authService }
+      ]
+    });
+  });
+
+  it('allows authenticated navigation', () => {
+    authService.getAccessToken.and.returnValue('jwt-token');
+
     const result = TestBed.runInInjectionContext(() =>
-      authGuard({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot)
+      authGuard({} as ActivatedRouteSnapshot, { url: '/dashboard' } as RouterStateSnapshot)
     );
 
     expect(result).toBeTrue();
+  });
+
+  it('redirects unauthenticated users to login', () => {
+    authService.getAccessToken.and.returnValue(null);
+    const router = TestBed.inject(Router);
+
+    const result = TestBed.runInInjectionContext(() =>
+      authGuard({} as ActivatedRouteSnapshot, { url: '/dashboard' } as RouterStateSnapshot)
+    );
+
+    expect(router.serializeUrl(result as ReturnType<Router['createUrlTree']>)).toBe('/login?returnUrl=%2Fdashboard');
   });
 });

--- a/frontend/src/app/core/guards/auth.guard.ts
+++ b/frontend/src/app/core/guards/auth.guard.ts
@@ -1,7 +1,20 @@
 import { CanActivateFn } from '@angular/router';
+import { inject } from '@angular/core';
+import { Router } from '@angular/router';
 
-export const authGuard: CanActivateFn = () => {
-  // Future work: evaluate frontend auth state for navigation UX only.
-  // Backend authorization remains the source of truth for role and scope access.
-  return true;
+import { AuthService } from '../auth/auth.service';
+
+export const authGuard: CanActivateFn = (_route, state) => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (authService.getAccessToken()) {
+    return true;
+  }
+
+  return router.createUrlTree(['/login'], {
+    queryParams: {
+      returnUrl: state.url
+    }
+  });
 };

--- a/frontend/src/app/core/interceptors/auth.interceptor.spec.ts
+++ b/frontend/src/app/core/interceptors/auth.interceptor.spec.ts
@@ -1,16 +1,60 @@
 import { HttpRequest, HttpResponse } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 
+import { TokenStorageService } from '../auth/token-storage.service';
 import { authInterceptor } from './auth.interceptor';
 
 describe('authInterceptor', () => {
-  it('passes requests through unchanged while auth is not implemented', (done) => {
+  let tokenStorage: TokenStorageService;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+    tokenStorage = TestBed.inject(TokenStorageService);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('passes API requests through unchanged when no token exists', (done) => {
     const request = new HttpRequest('GET', '/api/health');
     const next = jasmine.createSpy('next').and.returnValue(of(new HttpResponse({ status: 204 })));
 
-    authInterceptor(request, next).subscribe(() => {
+    TestBed.runInInjectionContext(() => authInterceptor(request, next)).subscribe(() => {
+      expect(next).toHaveBeenCalledOnceWith(request);
+      done();
+    });
+  });
+
+  it('attaches bearer token to API requests', (done) => {
+    tokenStorage.setToken(createToken());
+    const request = new HttpRequest('GET', '/api/auth/me');
+    const next = jasmine.createSpy('next').and.returnValue(of(new HttpResponse({ status: 200 })));
+
+    TestBed.runInInjectionContext(() => authInterceptor(request, next)).subscribe(() => {
+      const forwarded = next.calls.mostRecent().args[0] as HttpRequest<unknown>;
+      expect(forwarded.headers.get('Authorization')).toContain('Bearer ');
+      done();
+    });
+  });
+
+  it('does not attach bearer token to external requests', (done) => {
+    tokenStorage.setToken(createToken());
+    const request = new HttpRequest('GET', 'https://example.test/resource');
+    const next = jasmine.createSpy('next').and.returnValue(of(new HttpResponse({ status: 200 })));
+
+    TestBed.runInInjectionContext(() => authInterceptor(request, next)).subscribe(() => {
       expect(next).toHaveBeenCalledOnceWith(request);
       done();
     });
   });
 });
+
+function createToken(expOffsetSeconds = 3600): string {
+  const payload = { exp: Math.floor(Date.now() / 1000) + expOffsetSeconds };
+  const encodedPayload = btoa(JSON.stringify(payload)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+  return `header.${encodedPayload}.signature`;
+}

--- a/frontend/src/app/core/interceptors/auth.interceptor.ts
+++ b/frontend/src/app/core/interceptors/auth.interceptor.ts
@@ -1,8 +1,22 @@
 import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+
+import { environment } from '../../../environments/environment';
+import { TokenStorageService } from '../auth/token-storage.service';
 
 export const authInterceptor: HttpInterceptorFn = (request, next) => {
-  // Future work: attach JWT credentials when authentication is implemented.
-  // Do not treat frontend token handling or role checks as security enforcement;
-  // backend authorization remains the source of truth.
-  return next(request);
+  const token = inject(TokenStorageService).getUsableToken();
+  if (!token || !isApiRequest(request.url)) {
+    return next(request);
+  }
+
+  return next(request.clone({
+    setHeaders: {
+      Authorization: `Bearer ${token}`
+    }
+  }));
 };
+
+function isApiRequest(url: string): boolean {
+  return url.startsWith(environment.apiBaseUrl) || url.startsWith('/api/');
+}

--- a/frontend/src/app/features/login/login.component.spec.ts
+++ b/frontend/src/app/features/login/login.component.spec.ts
@@ -1,0 +1,37 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { FormGroup } from '@angular/forms';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+
+import { LoginComponent } from './login.component';
+
+describe('LoginComponent', () => {
+  let fixture: ComponentFixture<LoginComponent>;
+  let component: LoginComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LoginComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoginComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('requires email and password before submit', () => {
+    const form = (component as unknown as { form: FormGroup }).form;
+
+    expect(form.invalid).toBeTrue();
+
+    form.patchValue({ email: 'agent.novabank@opssphere.local' });
+
+    expect(form.invalid).toBeTrue();
+
+    form.patchValue({ password: 'OpsSphere123!' });
+
+    expect(form.valid).toBeTrue();
+  });
+});

--- a/frontend/src/app/features/login/login.component.ts
+++ b/frontend/src/app/features/login/login.component.ts
@@ -1,0 +1,162 @@
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { AuthService } from '../../core/auth/auth.service';
+
+@Component({
+  selector: 'app-login',
+  imports: [ReactiveFormsModule, MatButtonModule, MatFormFieldModule, MatIconModule, MatInputModule],
+  template: `
+    <section class="login" aria-labelledby="login-title">
+      <div class="login-panel">
+        <div class="login-heading">
+          <mat-icon aria-hidden="true">lock</mat-icon>
+          <div>
+            <h1 id="login-title">Sign in to OpsSphere</h1>
+            <p>Use a seeded internal account for local development.</p>
+          </div>
+        </div>
+
+        <form [formGroup]="form" (ngSubmit)="submit()" novalidate>
+          <mat-form-field appearance="outline">
+            <mat-label>Email</mat-label>
+            <input matInput type="email" autocomplete="username" formControlName="email" />
+            @if (form.controls.email.hasError('required')) {
+              <mat-error>Email is required.</mat-error>
+            }
+            @if (form.controls.email.hasError('email')) {
+              <mat-error>Enter a valid email address.</mat-error>
+            }
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
+            <mat-label>Password</mat-label>
+            <input matInput type="password" autocomplete="current-password" formControlName="password" />
+            @if (form.controls.password.hasError('required')) {
+              <mat-error>Password is required.</mat-error>
+            }
+          </mat-form-field>
+
+          @if (errorMessage()) {
+            <p class="login-error" role="alert">{{ errorMessage() }}</p>
+          }
+
+          <button mat-flat-button color="primary" type="submit" [disabled]="form.invalid || isSubmitting()">
+            <mat-icon aria-hidden="true">login</mat-icon>
+            <span>Sign in</span>
+          </button>
+        </form>
+      </div>
+    </section>
+  `,
+  styles: [`
+    .login {
+      display: grid;
+      min-height: calc(100vh - 9rem);
+      place-items: center;
+    }
+
+    .login-panel {
+      width: min(100%, 440px);
+      border: 1px solid #d8dee8;
+      border-radius: 8px;
+      padding: 1.5rem;
+      background: #ffffff;
+    }
+
+    .login-heading {
+      display: flex;
+      align-items: center;
+      gap: 0.85rem;
+      margin-bottom: 1.25rem;
+    }
+
+    .login-heading mat-icon {
+      color: #2563eb;
+    }
+
+    h1 {
+      margin: 0;
+      color: #111827;
+      font-size: 1.45rem;
+      line-height: 1.2;
+    }
+
+    p {
+      margin: 0.2rem 0 0;
+      color: #4b5563;
+    }
+
+    form,
+    mat-form-field {
+      display: block;
+      width: 100%;
+    }
+
+    .login-error {
+      margin: 0 0 1rem;
+      color: #b91c1c;
+      font-weight: 500;
+    }
+
+    button {
+      width: 100%;
+    }
+
+    button mat-icon {
+      margin-right: 0.4rem;
+    }
+  `],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class LoginComponent {
+  private readonly authService = inject(AuthService);
+  private readonly formBuilder = inject(FormBuilder);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+
+  protected readonly errorMessage = signal('');
+  protected readonly isSubmitting = signal(false);
+  protected readonly form = this.formBuilder.nonNullable.group({
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', [Validators.required]]
+  });
+
+  submit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    this.errorMessage.set('');
+    this.isSubmitting.set(true);
+    const { email, password } = this.form.getRawValue();
+
+    this.authService.login(email, password).subscribe({
+      next: () => {
+        this.form.controls.password.reset('');
+        const returnUrl = this.getSafeReturnUrl();
+        void this.router.navigateByUrl(returnUrl);
+      },
+      error: () => {
+        this.form.controls.password.reset('');
+        this.errorMessage.set('Invalid email or password.');
+        this.isSubmitting.set(false);
+      }
+    });
+  }
+
+  private getSafeReturnUrl(): string {
+    const returnUrl = this.route.snapshot.queryParamMap.get('returnUrl');
+    if (!returnUrl || !returnUrl.startsWith('/') || returnUrl.startsWith('//')) {
+      return '/dashboard';
+    }
+
+    return returnUrl;
+  }
+}

--- a/frontend/src/app/home-placeholder.component.ts
+++ b/frontend/src/app/home-placeholder.component.ts
@@ -6,10 +6,10 @@ import { MatIconModule } from '@angular/material/icon';
   imports: [MatIconModule],
   template: `
     <section class="home-placeholder" aria-labelledby="home-title">
-      <mat-icon aria-hidden="true">settings_applications</mat-icon>
-      <div>
-        <h1 id="home-title">Frontend foundation</h1>
-        <p>Angular shell, routing, Material, and core extension points are ready for future feature work.</p>
+        <mat-icon aria-hidden="true">settings_applications</mat-icon>
+        <div>
+        <h1 id="home-title">Dashboard shell</h1>
+        <p>Authenticated routing is ready for future operational workflows.</p>
       </div>
     </section>
   `,

--- a/src/OpsSphere.Api/Controllers/AuthController.cs
+++ b/src/OpsSphere.Api/Controllers/AuthController.cs
@@ -1,0 +1,91 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using OpsSphere.Application.Features.Auth;
+using OpsSphere.Application.Features.Auth.GetCurrentUser;
+using OpsSphere.Application.Features.Auth.Login;
+
+namespace OpsSphere.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public sealed class AuthController : ControllerBase
+{
+    private readonly LoginCommandHandler loginCommandHandler;
+    private readonly GetCurrentUserQueryHandler getCurrentUserQueryHandler;
+
+    public AuthController(
+        LoginCommandHandler loginCommandHandler,
+        GetCurrentUserQueryHandler getCurrentUserQueryHandler)
+    {
+        this.loginCommandHandler = loginCommandHandler;
+        this.getCurrentUserQueryHandler = getCurrentUserQueryHandler;
+    }
+
+    [AllowAnonymous]
+    [HttpPost("login")]
+    public async Task<IActionResult> Login(LoginRequest request, CancellationToken cancellationToken)
+    {
+        var result = await loginCommandHandler.HandleAsync(
+            new LoginCommand(request.Email ?? string.Empty, request.Password ?? string.Empty),
+            cancellationToken);
+
+        if (!result.Succeeded || result.Value is null)
+        {
+            return Unauthorized(Error(result.Error!));
+        }
+
+        return Ok(new ApiResponse<LoginResult>(result.Value));
+    }
+
+    [Authorize]
+    [HttpGet("me")]
+    public async Task<IActionResult> Me(CancellationToken cancellationToken)
+    {
+        var userId = GetSubjectUserId();
+        if (userId is null)
+        {
+            return Unauthorized(Error(GetCurrentUserQueryHandler.UnauthorizedCode, GetCurrentUserQueryHandler.UnauthorizedMessage));
+        }
+
+        var result = await getCurrentUserQueryHandler.HandleAsync(new GetCurrentUserQuery(userId.Value), cancellationToken);
+        if (!result.Succeeded || result.Value is null)
+        {
+            return Unauthorized(Error(result.Error!));
+        }
+
+        return Ok(new ApiResponse<CurrentUserProfile>(result.Value));
+    }
+
+    [Authorize]
+    [HttpGet("protected-smoke")]
+    public IActionResult ProtectedSmoke()
+    {
+        return Ok(new ApiResponse<ProtectedSmokeResponse>(new ProtectedSmokeResponse("ok")));
+    }
+
+    private Guid? GetSubjectUserId()
+    {
+        var subject = User.FindFirstValue(JwtRegisteredClaimNames.Sub)
+            ?? User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        return Guid.TryParse(subject, out var userId) ? userId : null;
+    }
+
+    private static ApiErrorResponse Error(AuthFailure failure) =>
+        Error(failure.Code, failure.Message);
+
+    private static ApiErrorResponse Error(string code, string message) =>
+        new(new ApiError(code, message));
+
+    public sealed record LoginRequest(string? Email, string? Password);
+
+    public sealed record ProtectedSmokeResponse(string Status);
+
+    public sealed record ApiResponse<T>(T Data);
+
+    public sealed record ApiErrorResponse(ApiError Error);
+
+    public sealed record ApiError(string Code, string Message);
+}

--- a/src/OpsSphere.Api/OpsSphere.Api.csproj
+++ b/src/OpsSphere.Api/OpsSphere.Api.csproj
@@ -6,6 +6,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/OpsSphere.Api/Program.cs
+++ b/src/OpsSphere.Api/Program.cs
@@ -1,5 +1,11 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
 using OpsSphere.Application;
 using OpsSphere.Infrastructure;
+using OpsSphere.Infrastructure.Authentication;
 using OpsSphere.Infrastructure.Persistence.SeedData;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -7,6 +13,31 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddApplication();
 builder.Services.AddInfrastructure(builder.Configuration);
 builder.Services.AddControllers();
+builder.Services
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        var jwtOptions = ReadJwtOptions(builder.Configuration);
+        var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtOptions.SigningKey));
+
+        options.MapInboundClaims = false;
+        options.RequireHttpsMetadata = !builder.Environment.IsDevelopment();
+        options.SaveToken = false;
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidIssuer = jwtOptions.Issuer,
+            ValidateAudience = true,
+            ValidAudience = jwtOptions.Audience,
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = signingKey,
+            ValidateLifetime = true,
+            ClockSkew = TimeSpan.FromMinutes(1),
+            NameClaimType = JwtRegisteredClaimNames.Sub,
+            RoleClaimType = ClaimTypes.Role
+        };
+    });
+builder.Services.AddAuthorization();
 
 var app = builder.Build();
 
@@ -22,11 +53,47 @@ if (SeedDataStartupGate.ShouldRun(app.Environment.EnvironmentName, seedDataEnabl
 
 app.UseHttpsRedirection();
 
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();
 
 app.Run();
+
+static JwtOptions ReadJwtOptions(IConfiguration configuration)
+{
+    var options = new JwtOptions
+    {
+        Issuer = configuration[$"{JwtOptions.SectionName}:Issuer"] ?? string.Empty,
+        Audience = configuration[$"{JwtOptions.SectionName}:Audience"] ?? string.Empty,
+        SigningKey = configuration[$"{JwtOptions.SectionName}:SigningKey"] ?? string.Empty,
+        ExpirationMinutes = int.TryParse(configuration[$"{JwtOptions.SectionName}:ExpirationMinutes"], out var expirationMinutes)
+            ? expirationMinutes
+            : 60
+    };
+
+    if (string.IsNullOrWhiteSpace(options.Issuer))
+    {
+        throw new InvalidOperationException("Jwt:Issuer is not configured.");
+    }
+
+    if (string.IsNullOrWhiteSpace(options.Audience))
+    {
+        throw new InvalidOperationException("Jwt:Audience is not configured.");
+    }
+
+    if (string.IsNullOrWhiteSpace(options.SigningKey))
+    {
+        throw new InvalidOperationException("Jwt:SigningKey is not configured.");
+    }
+
+    if (Encoding.UTF8.GetByteCount(options.SigningKey) < 32)
+    {
+        throw new InvalidOperationException("Jwt:SigningKey must be at least 32 bytes for local JWT validation.");
+    }
+
+    return options;
+}
 
 public partial class Program
 {

--- a/src/OpsSphere.Api/appsettings.Development.json
+++ b/src/OpsSphere.Api/appsettings.Development.json
@@ -2,7 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
     }
   },
   "ConnectionStrings": {
@@ -11,5 +12,8 @@
   },
   "SeedData": {
     "Enabled": true
+  },
+  "Jwt": {
+    "SigningKey": "local-development-only-fictional-jwt-signing-key-please-replace"
   }
 }

--- a/src/OpsSphere.Api/appsettings.json
+++ b/src/OpsSphere.Api/appsettings.json
@@ -2,8 +2,15 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
     }
+  },
+  "Jwt": {
+    "Issuer": "OpsSphere",
+    "Audience": "OpsSphere.Angular",
+    "ExpirationMinutes": 60,
+    "SigningKey": ""
   },
   "AllowedHosts": "*"
 }

--- a/src/OpsSphere.Application/Common/Interfaces/IAuthUnitOfWork.cs
+++ b/src/OpsSphere.Application/Common/Interfaces/IAuthUnitOfWork.cs
@@ -1,0 +1,6 @@
+namespace OpsSphere.Application.Common.Interfaces;
+
+public interface IAuthUnitOfWork
+{
+    Task SaveChangesAsync(CancellationToken cancellationToken);
+}

--- a/src/OpsSphere.Application/Common/Interfaces/IAuthUserReader.cs
+++ b/src/OpsSphere.Application/Common/Interfaces/IAuthUserReader.cs
@@ -1,0 +1,12 @@
+using OpsSphere.Application.Features.Auth;
+
+namespace OpsSphere.Application.Common.Interfaces;
+
+public interface IAuthUserReader
+{
+    Task<AuthUserCredentialUser?> FindCredentialUserByEmailAsync(string email, CancellationToken cancellationToken);
+
+    Task<AuthUserProfile?> GetUserProfileAsync(Guid userId, CancellationToken cancellationToken);
+
+    Task UpdateLastLoginAtAsync(Guid userId, DateTime lastLoginAt, CancellationToken cancellationToken);
+}

--- a/src/OpsSphere.Application/Common/Interfaces/IJwtTokenService.cs
+++ b/src/OpsSphere.Application/Common/Interfaces/IJwtTokenService.cs
@@ -1,0 +1,8 @@
+using OpsSphere.Application.Features.Auth;
+
+namespace OpsSphere.Application.Common.Interfaces;
+
+public interface IJwtTokenService
+{
+    JwtTokenResult CreateToken(AuthenticatedUser user);
+}

--- a/src/OpsSphere.Application/Common/Interfaces/IPasswordVerifier.cs
+++ b/src/OpsSphere.Application/Common/Interfaces/IPasswordVerifier.cs
@@ -1,0 +1,8 @@
+using OpsSphere.Application.Features.Auth;
+
+namespace OpsSphere.Application.Common.Interfaces;
+
+public interface IPasswordVerifier
+{
+    bool VerifyPassword(AuthUserCredentialUser user, string password);
+}

--- a/src/OpsSphere.Application/DependencyInjection.cs
+++ b/src/OpsSphere.Application/DependencyInjection.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
+using OpsSphere.Application.Features.Auth.GetCurrentUser;
+using OpsSphere.Application.Features.Auth.Login;
 
 namespace OpsSphere.Application;
 
@@ -6,6 +8,9 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddApplication(this IServiceCollection services)
     {
+        services.AddScoped<LoginCommandHandler>();
+        services.AddScoped<GetCurrentUserQueryHandler>();
+
         return services;
     }
 }

--- a/src/OpsSphere.Application/Features/Auth/AuthDtos.cs
+++ b/src/OpsSphere.Application/Features/Auth/AuthDtos.cs
@@ -1,0 +1,68 @@
+namespace OpsSphere.Application.Features.Auth;
+
+public sealed record AuthenticatedUser(
+    Guid Id,
+    string Email,
+    string DisplayName,
+    IReadOnlyList<string> Roles);
+
+public sealed record AuthUserCredentialUser(
+    Guid Id,
+    string Email,
+    string PasswordHash,
+    string DisplayName,
+    bool IsActive,
+    IReadOnlyList<string> ActiveRoles);
+
+public sealed record AuthUserProfile(
+    Guid Id,
+    string Email,
+    string DisplayName,
+    bool IsActive,
+    IReadOnlyList<string> Roles,
+    IReadOnlyList<string> Permissions,
+    IReadOnlyList<UserScopeDto> Scopes);
+
+public sealed record AuthUserSummary(
+    Guid Id,
+    string Email,
+    string DisplayName,
+    IReadOnlyList<string> Roles);
+
+public sealed record CurrentUserProfile(
+    Guid Id,
+    string Email,
+    string DisplayName,
+    IReadOnlyList<string> Roles,
+    IReadOnlyList<string> Permissions,
+    IReadOnlyList<UserScopeDto> Scopes);
+
+public sealed record UserScopeDto(
+    string ScopeType,
+    Guid? RegionId,
+    string? RegionCode,
+    Guid? CountryId,
+    string? CountryCode,
+    Guid? AccountId,
+    string? AccountCode,
+    Guid? CampaignId,
+    string? CampaignCode);
+
+public sealed record JwtTokenResult(string AccessToken, int ExpiresIn);
+
+public sealed record LoginResult(
+    string AccessToken,
+    string TokenType,
+    int ExpiresIn,
+    AuthUserSummary User);
+
+public sealed record AuthFailure(string Code, string Message);
+
+public sealed record AuthResult<T>(T? Value, AuthFailure? Error)
+{
+    public bool Succeeded => Error is null;
+
+    public static AuthResult<T> Success(T value) => new(value, null);
+
+    public static AuthResult<T> Failure(string code, string message) => new(default, new AuthFailure(code, message));
+}

--- a/src/OpsSphere.Application/Features/Auth/GetCurrentUser/GetCurrentUserQuery.cs
+++ b/src/OpsSphere.Application/Features/Auth/GetCurrentUser/GetCurrentUserQuery.cs
@@ -1,0 +1,3 @@
+namespace OpsSphere.Application.Features.Auth.GetCurrentUser;
+
+public sealed record GetCurrentUserQuery(Guid UserId);

--- a/src/OpsSphere.Application/Features/Auth/GetCurrentUser/GetCurrentUserQueryHandler.cs
+++ b/src/OpsSphere.Application/Features/Auth/GetCurrentUser/GetCurrentUserQueryHandler.cs
@@ -1,0 +1,34 @@
+using OpsSphere.Application.Common.Interfaces;
+
+namespace OpsSphere.Application.Features.Auth.GetCurrentUser;
+
+public sealed class GetCurrentUserQueryHandler
+{
+    public const string UnauthorizedCode = "unauthorized";
+    public const string UnauthorizedMessage = "Authentication is required.";
+
+    private readonly IAuthUserReader authUserReader;
+
+    public GetCurrentUserQueryHandler(IAuthUserReader authUserReader)
+    {
+        this.authUserReader = authUserReader;
+    }
+
+    public async Task<AuthResult<CurrentUserProfile>> HandleAsync(GetCurrentUserQuery query, CancellationToken cancellationToken)
+    {
+        var profile = await authUserReader.GetUserProfileAsync(query.UserId, cancellationToken);
+
+        if (profile is null || !profile.IsActive || profile.Roles.Count == 0)
+        {
+            return AuthResult<CurrentUserProfile>.Failure(UnauthorizedCode, UnauthorizedMessage);
+        }
+
+        return AuthResult<CurrentUserProfile>.Success(new CurrentUserProfile(
+            profile.Id,
+            profile.Email,
+            profile.DisplayName,
+            profile.Roles,
+            profile.Permissions,
+            profile.Scopes));
+    }
+}

--- a/src/OpsSphere.Application/Features/Auth/Login/LoginCommand.cs
+++ b/src/OpsSphere.Application/Features/Auth/Login/LoginCommand.cs
@@ -1,0 +1,3 @@
+namespace OpsSphere.Application.Features.Auth.Login;
+
+public sealed record LoginCommand(string Email, string Password);

--- a/src/OpsSphere.Application/Features/Auth/Login/LoginCommandHandler.cs
+++ b/src/OpsSphere.Application/Features/Auth/Login/LoginCommandHandler.cs
@@ -1,0 +1,61 @@
+using OpsSphere.Application.Common.Interfaces;
+
+namespace OpsSphere.Application.Features.Auth.Login;
+
+public sealed class LoginCommandHandler
+{
+    public const string InvalidCredentialsCode = "invalid_credentials";
+    public const string InvalidCredentialsMessage = "Invalid email or password.";
+
+    private readonly IAuthUserReader authUserReader;
+    private readonly IPasswordVerifier passwordVerifier;
+    private readonly IJwtTokenService jwtTokenService;
+    private readonly IAuthUnitOfWork unitOfWork;
+
+    public LoginCommandHandler(
+        IAuthUserReader authUserReader,
+        IPasswordVerifier passwordVerifier,
+        IJwtTokenService jwtTokenService,
+        IAuthUnitOfWork unitOfWork)
+    {
+        this.authUserReader = authUserReader;
+        this.passwordVerifier = passwordVerifier;
+        this.jwtTokenService = jwtTokenService;
+        this.unitOfWork = unitOfWork;
+    }
+
+    public async Task<AuthResult<LoginResult>> HandleAsync(LoginCommand command, CancellationToken cancellationToken)
+    {
+        var email = command.Email.Trim();
+        if (string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(command.Password))
+        {
+            return InvalidCredentials();
+        }
+
+        var user = await authUserReader.FindCredentialUserByEmailAsync(email, cancellationToken);
+        if (user is null || !user.IsActive || user.ActiveRoles.Count == 0)
+        {
+            return InvalidCredentials();
+        }
+
+        if (!passwordVerifier.VerifyPassword(user, command.Password))
+        {
+            return InvalidCredentials();
+        }
+
+        var authenticatedUser = new AuthenticatedUser(user.Id, user.Email, user.DisplayName, user.ActiveRoles);
+        var token = jwtTokenService.CreateToken(authenticatedUser);
+
+        await authUserReader.UpdateLastLoginAtAsync(user.Id, DateTime.UtcNow, cancellationToken);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return AuthResult<LoginResult>.Success(new LoginResult(
+            token.AccessToken,
+            "Bearer",
+            token.ExpiresIn,
+            new AuthUserSummary(user.Id, user.Email, user.DisplayName, user.ActiveRoles)));
+    }
+
+    private static AuthResult<LoginResult> InvalidCredentials() =>
+        AuthResult<LoginResult>.Failure(InvalidCredentialsCode, InvalidCredentialsMessage);
+}

--- a/src/OpsSphere.Infrastructure/Authentication/JwtOptions.cs
+++ b/src/OpsSphere.Infrastructure/Authentication/JwtOptions.cs
@@ -1,0 +1,11 @@
+namespace OpsSphere.Infrastructure.Authentication;
+
+public sealed class JwtOptions
+{
+    public const string SectionName = "Jwt";
+
+    public string Issuer { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string SigningKey { get; set; } = string.Empty;
+    public int ExpirationMinutes { get; set; } = 60;
+}

--- a/src/OpsSphere.Infrastructure/Authentication/JwtTokenService.cs
+++ b/src/OpsSphere.Infrastructure/Authentication/JwtTokenService.cs
@@ -1,0 +1,48 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using OpsSphere.Application.Common.Interfaces;
+using OpsSphere.Application.Features.Auth;
+
+namespace OpsSphere.Infrastructure.Authentication;
+
+internal sealed class JwtTokenService : IJwtTokenService
+{
+    private readonly JwtOptions options;
+
+    public JwtTokenService(IOptions<JwtOptions> options)
+    {
+        this.options = options.Value;
+    }
+
+    public JwtTokenResult CreateToken(AuthenticatedUser user)
+    {
+        var now = DateTime.UtcNow;
+        var expires = now.AddMinutes(options.ExpirationMinutes);
+        var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(options.SigningKey));
+        var credentials = new SigningCredentials(signingKey, SecurityAlgorithms.HmacSha256);
+
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
+            new(JwtRegisteredClaimNames.Email, user.Email),
+            new("display_name", user.DisplayName),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+            new(JwtRegisteredClaimNames.Iat, new DateTimeOffset(now).ToUnixTimeSeconds().ToString(), ClaimValueTypes.Integer64)
+        };
+
+        claims.AddRange(user.Roles.Select(role => new Claim(ClaimTypes.Role, role)));
+
+        var token = new JwtSecurityToken(
+            issuer: options.Issuer,
+            audience: options.Audience,
+            claims: claims,
+            notBefore: now,
+            expires: expires,
+            signingCredentials: credentials);
+
+        return new JwtTokenResult(new JwtSecurityTokenHandler().WriteToken(token), options.ExpirationMinutes * 60);
+    }
+}

--- a/src/OpsSphere.Infrastructure/DependencyInjection.cs
+++ b/src/OpsSphere.Infrastructure/DependencyInjection.cs
@@ -2,7 +2,10 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using OpsSphere.Application.Common.Interfaces;
 using OpsSphere.Domain.Entities;
+using OpsSphere.Infrastructure.Authentication;
+using OpsSphere.Infrastructure.Identity;
 using OpsSphere.Infrastructure.Persistence;
 using OpsSphere.Infrastructure.Persistence.SeedData;
 
@@ -20,7 +23,21 @@ public static class DependencyInjection
 
         services.Configure<SeedDataOptions>(options =>
             options.Enabled = bool.TryParse(configuration[$"{SeedDataOptions.SectionName}:Enabled"], out var enabled) && enabled);
+        services.Configure<JwtOptions>(options =>
+        {
+            options.Issuer = configuration[$"{JwtOptions.SectionName}:Issuer"] ?? string.Empty;
+            options.Audience = configuration[$"{JwtOptions.SectionName}:Audience"] ?? string.Empty;
+            options.SigningKey = configuration[$"{JwtOptions.SectionName}:SigningKey"] ?? string.Empty;
+            options.ExpirationMinutes = int.TryParse(configuration[$"{JwtOptions.SectionName}:ExpirationMinutes"], out var expirationMinutes)
+                ? expirationMinutes
+                : 60;
+        });
+
         services.AddScoped<IPasswordHasher<User>, PasswordHasher<User>>();
+        services.AddScoped<IJwtTokenService, JwtTokenService>();
+        services.AddScoped<IPasswordVerifier, PasswordVerifier>();
+        services.AddScoped<IAuthUserReader, AuthUserReader>();
+        services.AddScoped<IAuthUnitOfWork, AuthUnitOfWork>();
         services.AddScoped<OpsSphereDataSeeder>();
 
         return services;

--- a/src/OpsSphere.Infrastructure/Identity/AuthUserReader.cs
+++ b/src/OpsSphere.Infrastructure/Identity/AuthUserReader.cs
@@ -1,0 +1,112 @@
+using Microsoft.EntityFrameworkCore;
+using OpsSphere.Application.Common.Interfaces;
+using OpsSphere.Application.Features.Auth;
+using OpsSphere.Infrastructure.Persistence;
+
+namespace OpsSphere.Infrastructure.Identity;
+
+internal sealed class AuthUserReader : IAuthUserReader
+{
+    private readonly OpsSphereDbContext dbContext;
+
+    public AuthUserReader(OpsSphereDbContext dbContext)
+    {
+        this.dbContext = dbContext;
+    }
+
+    public async Task<AuthUserCredentialUser?> FindCredentialUserByEmailAsync(string email, CancellationToken cancellationToken)
+    {
+        var user = await dbContext.Users
+            .AsNoTracking()
+            .Include(u => u.UserRoles)
+                .ThenInclude(ur => ur.Role)
+            .FirstOrDefaultAsync(u => u.Email == email, cancellationToken);
+
+        if (user is null)
+        {
+            return null;
+        }
+
+        var roles = user.UserRoles
+            .Where(userRole => userRole.Role.IsActive)
+            .Select(userRole => userRole.Role.Name)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        return new AuthUserCredentialUser(user.Id, user.Email, user.PasswordHash, user.DisplayName, user.IsActive, roles);
+    }
+
+    public async Task<AuthUserProfile?> GetUserProfileAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        var user = await dbContext.Users
+            .AsNoTracking()
+            .Include(u => u.UserRoles)
+                .ThenInclude(ur => ur.Role)
+            .Include(u => u.UserScopes.Where(us => us.IsActive))
+                .ThenInclude(us => us.Region)
+            .Include(u => u.UserScopes.Where(us => us.IsActive))
+                .ThenInclude(us => us.Country)
+            .Include(u => u.UserScopes.Where(us => us.IsActive))
+                .ThenInclude(us => us.Account)
+            .Include(u => u.UserScopes.Where(us => us.IsActive))
+                .ThenInclude(us => us.Campaign)
+            .FirstOrDefaultAsync(u => u.Id == userId, cancellationToken);
+
+        if (user is null)
+        {
+            return null;
+        }
+
+        var activeRoleIds = user.UserRoles
+            .Where(userRole => userRole.Role.IsActive)
+            .Select(userRole => userRole.RoleId)
+            .Distinct()
+            .ToArray();
+
+        var roles = user.UserRoles
+            .Where(userRole => userRole.Role.IsActive)
+            .Select(userRole => userRole.Role.Name)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        var permissions = await dbContext.RolePermissions
+            .AsNoTracking()
+            .Where(rolePermission => activeRoleIds.Contains(rolePermission.RoleId) && rolePermission.Permission.IsActive)
+            .Select(rolePermission => rolePermission.Permission.Code)
+            .Distinct()
+            .OrderBy(code => code)
+            .ToArrayAsync(cancellationToken);
+
+        var scopes = user.UserScopes
+            .Where(userScope => userScope.IsActive)
+            .Select(userScope => new UserScopeDto(
+                userScope.ScopeType,
+                userScope.RegionId,
+                userScope.Region?.Code,
+                userScope.CountryId,
+                userScope.Country?.Code,
+                userScope.AccountId,
+                userScope.Account?.Code,
+                userScope.CampaignId,
+                userScope.Campaign?.Code))
+            .OrderBy(scope => scope.ScopeType, StringComparer.Ordinal)
+            .ThenBy(scope => scope.RegionCode, StringComparer.Ordinal)
+            .ThenBy(scope => scope.CountryCode, StringComparer.Ordinal)
+            .ThenBy(scope => scope.AccountCode, StringComparer.Ordinal)
+            .ThenBy(scope => scope.CampaignCode, StringComparer.Ordinal)
+            .ToArray();
+
+        return new AuthUserProfile(user.Id, user.Email, user.DisplayName, user.IsActive, roles, permissions, scopes);
+    }
+
+    public async Task UpdateLastLoginAtAsync(Guid userId, DateTime lastLoginAt, CancellationToken cancellationToken)
+    {
+        var user = await dbContext.Users.FirstOrDefaultAsync(u => u.Id == userId, cancellationToken);
+        if (user is not null)
+        {
+            user.LastLoginAt = lastLoginAt;
+        }
+    }
+}

--- a/src/OpsSphere.Infrastructure/Identity/PasswordVerifier.cs
+++ b/src/OpsSphere.Infrastructure/Identity/PasswordVerifier.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Identity;
+using OpsSphere.Application.Common.Interfaces;
+using OpsSphere.Application.Features.Auth;
+using OpsSphere.Domain.Entities;
+
+namespace OpsSphere.Infrastructure.Identity;
+
+internal sealed class PasswordVerifier : IPasswordVerifier
+{
+    private readonly IPasswordHasher<User> passwordHasher;
+
+    public PasswordVerifier(IPasswordHasher<User> passwordHasher)
+    {
+        this.passwordHasher = passwordHasher;
+    }
+
+    public bool VerifyPassword(AuthUserCredentialUser user, string password)
+    {
+        var domainUser = new User
+        {
+            Id = user.Id,
+            Email = user.Email,
+            DisplayName = user.DisplayName,
+            PasswordHash = user.PasswordHash
+        };
+
+        var result = passwordHasher.VerifyHashedPassword(domainUser, user.PasswordHash, password);
+
+        return result is PasswordVerificationResult.Success or PasswordVerificationResult.SuccessRehashNeeded;
+    }
+}

--- a/src/OpsSphere.Infrastructure/OpsSphere.Infrastructure.csproj
+++ b/src/OpsSphere.Infrastructure/OpsSphere.Infrastructure.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/OpsSphere.Infrastructure/Persistence/AuthUnitOfWork.cs
+++ b/src/OpsSphere.Infrastructure/Persistence/AuthUnitOfWork.cs
@@ -1,0 +1,16 @@
+using OpsSphere.Application.Common.Interfaces;
+
+namespace OpsSphere.Infrastructure.Persistence;
+
+internal sealed class AuthUnitOfWork : IAuthUnitOfWork
+{
+    private readonly OpsSphereDbContext dbContext;
+
+    public AuthUnitOfWork(OpsSphereDbContext dbContext)
+    {
+        this.dbContext = dbContext;
+    }
+
+    public Task SaveChangesAsync(CancellationToken cancellationToken) =>
+        dbContext.SaveChangesAsync(cancellationToken);
+}

--- a/tests/OpsSphere.IntegrationTests/Auth/AuthApiTests.cs
+++ b/tests/OpsSphere.IntegrationTests/Auth/AuthApiTests.cs
@@ -1,0 +1,341 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using OpsSphere.Domain.Entities;
+using OpsSphere.Infrastructure.Persistence;
+using OpsSphere.Infrastructure.Persistence.SeedData;
+
+namespace OpsSphere.IntegrationTests.Auth;
+
+public sealed class AuthApiTests
+{
+    private const string AgentEmail = "agent.novabank@opssphere.local";
+    private const string GenericLoginError = "Invalid email or password.";
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public async Task Login_WithValidSeededUser_ReturnsJwt()
+    {
+        await using var factory = await AuthApiFactory.CreateAsync();
+        var client = factory.CreateClient();
+
+        var result = await LoginAsync(client, AgentEmail, OpsSphereSeedData.LocalDemoPassword);
+
+        Assert.Equal(HttpStatusCode.OK, result.Response.StatusCode);
+        Assert.False(string.IsNullOrWhiteSpace(result.Body.Data.AccessToken));
+        Assert.Equal("Bearer", result.Body.Data.TokenType);
+        Assert.Equal(3600, result.Body.Data.ExpiresIn);
+        Assert.Equal(AgentEmail, result.Body.Data.User.Email);
+        Assert.Contains("Agent", result.Body.Data.User.Roles);
+    }
+
+    [Fact]
+    public async Task Login_WithInvalidPassword_ReturnsGenericError()
+    {
+        await using var factory = await AuthApiFactory.CreateAsync();
+        var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/login", new
+        {
+            email = AgentEmail,
+            password = "wrong-password"
+        });
+
+        var error = await ReadResponseAsync<ApiErrorResponse>(response);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal(GenericLoginError, error.Error.Message);
+    }
+
+    [Fact]
+    public async Task Login_WithUnknownEmail_ReturnsGenericError()
+    {
+        await using var factory = await AuthApiFactory.CreateAsync();
+        var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/login", new
+        {
+            email = "unknown@opssphere.local",
+            password = OpsSphereSeedData.LocalDemoPassword
+        });
+
+        var error = await ReadResponseAsync<ApiErrorResponse>(response);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal(GenericLoginError, error.Error.Message);
+    }
+
+    [Fact]
+    public async Task Login_WithInactiveUser_ReturnsGenericError()
+    {
+        await using var factory = await AuthApiFactory.CreateAsync();
+        await factory.DeactivateUserAsync(AgentEmail);
+        var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/login", new
+        {
+            email = AgentEmail,
+            password = OpsSphereSeedData.LocalDemoPassword
+        });
+
+        var error = await ReadResponseAsync<ApiErrorResponse>(response);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal(GenericLoginError, error.Error.Message);
+    }
+
+    [Fact]
+    public async Task Login_DoesNotRevealInactiveOrMissingUserReason()
+    {
+        await using var inactiveFactory = await AuthApiFactory.CreateAsync();
+        await inactiveFactory.DeactivateUserAsync(AgentEmail);
+        var inactiveResponse = await inactiveFactory.CreateClient().PostAsJsonAsync("/api/auth/login", new
+        {
+            email = AgentEmail,
+            password = OpsSphereSeedData.LocalDemoPassword
+        });
+        var inactiveBody = await inactiveResponse.Content.ReadAsStringAsync();
+
+        await using var missingFactory = await AuthApiFactory.CreateAsync();
+        var missingResponse = await missingFactory.CreateClient().PostAsJsonAsync("/api/auth/login", new
+        {
+            email = "missing@opssphere.local",
+            password = OpsSphereSeedData.LocalDemoPassword
+        });
+        var missingBody = await missingResponse.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.Unauthorized, inactiveResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized, missingResponse.StatusCode);
+        Assert.Equal(inactiveBody, missingBody);
+    }
+
+    [Fact]
+    public async Task GetMe_WithoutToken_Returns401()
+    {
+        await using var factory = await AuthApiFactory.CreateAsync();
+
+        var response = await factory.CreateClient().GetAsync("/api/auth/me");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetMe_WithValidToken_ReturnsCurrentUserProfile()
+    {
+        await using var factory = await AuthApiFactory.CreateAsync();
+        var client = factory.CreateClient();
+        var login = await LoginAsync(client, AgentEmail, OpsSphereSeedData.LocalDemoPassword);
+
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", login.Body.Data.AccessToken);
+        var response = await client.GetAsync("/api/auth/me");
+        var body = await ReadResponseAsync<ApiResponse<CurrentUserProfile>>(response);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(AgentEmail, body.Data.Email);
+        Assert.Contains("Agent", body.Data.Roles);
+        Assert.Contains("tickets.view", body.Data.Permissions);
+        Assert.Contains(body.Data.Scopes, scope => scope.ScopeType == "Campaign" && scope.CampaignCode == "NOVABANK-CC");
+    }
+
+    [Fact]
+    public async Task ProtectedSmoke_WithoutToken_Returns401()
+    {
+        await using var factory = await AuthApiFactory.CreateAsync();
+
+        var response = await factory.CreateClient().GetAsync("/api/auth/protected-smoke");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProtectedSmoke_WithValidToken_Returns200()
+    {
+        await using var factory = await AuthApiFactory.CreateAsync();
+        var client = factory.CreateClient();
+        var login = await LoginAsync(client, AgentEmail, OpsSphereSeedData.LocalDemoPassword);
+
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", login.Body.Data.AccessToken);
+        var response = await client.GetAsync("/api/auth/protected-smoke");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task JwtPayload_DoesNotContainSensitiveData()
+    {
+        await using var factory = await AuthApiFactory.CreateAsync();
+        var client = factory.CreateClient();
+        var login = await LoginAsync(client, AgentEmail, OpsSphereSeedData.LocalDemoPassword);
+
+        var token = new JwtSecurityTokenHandler().ReadJwtToken(login.Body.Data.AccessToken);
+
+        Assert.Contains(token.Claims, claim => claim.Type == JwtRegisteredClaimNames.Sub);
+        Assert.Contains(token.Claims, claim => claim.Type == JwtRegisteredClaimNames.Email && claim.Value == AgentEmail);
+        Assert.Contains(token.Claims, claim => claim.Type == "display_name");
+        Assert.DoesNotContain(token.Claims, claim => claim.Type.Contains("password", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(token.Claims, claim => claim.Value.Contains("password", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(token.Claims, claim => claim.Value.Contains("tickets.view", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(token.Claims, claim => claim.Type.Contains("permission", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(token.Claims, claim => claim.Type.Contains("scope", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(AuthApiFactory.JwtSigningKey, login.Body.Data.AccessToken, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Auth_DoesNotReturnPasswordHash()
+    {
+        await using var factory = await AuthApiFactory.CreateAsync();
+        var passwordHash = await factory.GetPasswordHashAsync(AgentEmail);
+        var client = factory.CreateClient();
+        var login = await LoginAsync(client, AgentEmail, OpsSphereSeedData.LocalDemoPassword);
+        var loginJson = await login.Response.Content.ReadAsStringAsync();
+
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", login.Body.Data.AccessToken);
+        var meResponse = await client.GetAsync("/api/auth/me");
+        var meJson = await meResponse.Content.ReadAsStringAsync();
+
+        Assert.DoesNotContain("passwordHash", loginJson, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("passwordHash", meJson, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(passwordHash, loginJson, StringComparison.Ordinal);
+        Assert.DoesNotContain(passwordHash, meJson, StringComparison.Ordinal);
+    }
+
+    private static async Task<LoginApiResult> LoginAsync(HttpClient client, string email, string password)
+    {
+        var response = await client.PostAsJsonAsync("/api/auth/login", new { email, password });
+        var body = await ReadResponseAsync<ApiResponse<LoginResponse>>(response);
+
+        return new LoginApiResult(response, body);
+    }
+
+    private static async Task<T> ReadResponseAsync<T>(HttpResponseMessage response)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
+
+        return value ?? throw new InvalidOperationException($"Response body could not be deserialized as {typeof(T).Name}.");
+    }
+
+    private sealed record LoginApiResult(HttpResponseMessage Response, ApiResponse<LoginResponse> Body);
+    private sealed record ApiResponse<T>(T Data);
+    private sealed record ApiErrorResponse(ApiError Error);
+    private sealed record ApiError(string Code, string Message);
+    private sealed record LoginResponse(string AccessToken, string TokenType, int ExpiresIn, AuthUserSummary User);
+    private sealed record AuthUserSummary(Guid Id, string Email, string DisplayName, IReadOnlyList<string> Roles);
+    private sealed record CurrentUserProfile(
+        Guid Id,
+        string Email,
+        string DisplayName,
+        IReadOnlyList<string> Roles,
+        IReadOnlyList<string> Permissions,
+        IReadOnlyList<UserScopeResponse> Scopes);
+    private sealed record UserScopeResponse(
+        string ScopeType,
+        Guid? RegionId,
+        string? RegionCode,
+        Guid? CountryId,
+        string? CountryCode,
+        Guid? AccountId,
+        string? AccountCode,
+        Guid? CampaignId,
+        string? CampaignCode);
+
+    private sealed class AuthApiFactory : WebApplicationFactory<Program>
+    {
+        public const string JwtSigningKey = "integration-testing-only-fictional-jwt-signing-key";
+
+        private readonly SqliteConnection connection = new("Data Source=:memory:");
+
+        public static async Task<AuthApiFactory> CreateAsync()
+        {
+            ConfigureEnvironment();
+            var factory = new AuthApiFactory();
+            await factory.connection.OpenAsync();
+            await factory.InitializeDatabaseAsync();
+
+            return factory;
+        }
+
+        public async Task DeactivateUserAsync(string email)
+        {
+            using var scope = Services.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+            var user = await dbContext.Users.SingleAsync(u => u.Email == email);
+            user.IsActive = false;
+            user.DeactivatedAt = DateTime.UtcNow;
+            await dbContext.SaveChangesAsync();
+        }
+
+        public async Task<string> GetPasswordHashAsync(string email)
+        {
+            using var scope = Services.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+            var user = await dbContext.Users.AsNoTracking().SingleAsync(u => u.Email == email);
+
+            return user.PasswordHash;
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Testing");
+            builder.ConfigureAppConfiguration((_, configuration) =>
+            {
+                configuration.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["ConnectionStrings:DefaultConnection"] = "Server=(local);Database=OpsSphereAuthTests;Trusted_Connection=True;TrustServerCertificate=True;",
+                    ["SeedData:Enabled"] = "false",
+                    ["Jwt:Issuer"] = "OpsSphere.Tests",
+                    ["Jwt:Audience"] = "OpsSphere.Tests.Angular",
+                    ["Jwt:ExpirationMinutes"] = "60",
+                    ["Jwt:SigningKey"] = JwtSigningKey
+                });
+            });
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<IDbContextOptionsConfiguration<OpsSphereDbContext>>();
+                services.RemoveAll<DbContextOptions<OpsSphereDbContext>>();
+                services.AddDbContext<OpsSphereDbContext>(options => options.UseSqlite(connection));
+            });
+        }
+
+        private static void ConfigureEnvironment()
+        {
+            Environment.SetEnvironmentVariable(
+                "ConnectionStrings__DefaultConnection",
+                "Server=(local);Database=OpsSphereAuthTests;Trusted_Connection=True;TrustServerCertificate=True;");
+            Environment.SetEnvironmentVariable("SeedData__Enabled", "false");
+            Environment.SetEnvironmentVariable("Jwt__Issuer", "OpsSphere.Tests");
+            Environment.SetEnvironmentVariable("Jwt__Audience", "OpsSphere.Tests.Angular");
+            Environment.SetEnvironmentVariable("Jwt__ExpirationMinutes", "60");
+            Environment.SetEnvironmentVariable("Jwt__SigningKey", JwtSigningKey);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await connection.DisposeAsync();
+            await base.DisposeAsync();
+        }
+
+        private async Task InitializeDatabaseAsync()
+        {
+            using var scope = Services.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+            await dbContext.Database.EnsureDeletedAsync();
+            await dbContext.Database.EnsureCreatedAsync();
+
+            var seeder = scope.ServiceProvider.GetRequiredService<OpsSphereDataSeeder>();
+            await seeder.SeedAsync();
+        }
+    }
+}

--- a/tests/OpsSphere.IntegrationTests/OpsSphere.IntegrationTests.csproj
+++ b/tests/OpsSphere.IntegrationTests/OpsSphere.IntegrationTests.csproj
@@ -9,10 +9,13 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Implements the JWT authentication foundation for OpsSphere internal users.

This PR adds backend authentication endpoints for login, current-user retrieval, and protected endpoint validation. It also introduces JWT token generation and validation, password verification, authentication application contracts/handlers, frontend authentication shell support, and tests for the core authentication flow.

## Added / Changed

- Added `AuthController` with:
  - `POST /api/auth/login`
  - `GET /api/auth/me`
  - Protected smoke endpoint for JWT validation
- Implemented JWT token generation and validation.
- Added authentication DTOs, commands, queries, and handlers.
- Introduced application interfaces for:
  - User authentication reads
  - Password verification
  - JWT token generation
  - Unit of work support where needed
- Reused seeded user password hashes from the seed data foundation.
- Added active-user validation during login.
- Ensured invalid, unknown, and inactive-user login attempts return a generic authentication error.
- Added integration tests for authentication endpoints and protected endpoint behavior.
- Updated application and infrastructure dependencies for JWT support.
- Added frontend authentication shell pieces:
  - Login route/shell
  - Auth service
  - Token storage
  - Bearer token interceptor
  - Authenticated route guard
- Updated the frontend placeholder dashboard title and description.
- Updated documentation/configuration where needed for local JWT authentication.

## Validation

- [x] Reviewed changed files.
- [x] Confirmed scope matches the related issue.
- [x] Confirmed validation expectations from `docs/implementation-guardrails.md` were met or documented.
- [x] Ran `dotnet restore`.
- [x] Ran `dotnet build`.
- [x] Ran `dotnet test`.
- [x] Ran `npm run build`.
- [x] Ran `npm run test`.
- [x] Confirmed valid seeded users can authenticate.
- [x] Confirmed invalid credentials are rejected.
- [x] Confirmed deactivated users are rejected through tests.
- [x] Confirmed `/api/auth/me` requires and accepts a valid JWT.
- [x] Confirmed protected endpoint rejects requests without a token.
- [x] Confirmed protected endpoint accepts requests with a valid token.
- [x] Confirmed JWT payload does not include sensitive password data.
- [x] Confirmed passwords, password hashes, and JWT tokens are not returned in API responses.

## Scope Confirmation

- [x] This PR contains no out-of-scope work.
- [x] This PR does not introduce unrelated source, package, migration, Docker, or GitHub Actions changes.
- [x] This PR does not implement refresh tokens, MFA, SSO, password reset, account lockout, or advanced session management.
- [x] This PR does not implement the full Sprint 7 RBAC/permission/scope authorization framework.

## Related Issue

Closes #36

## Checklist

- [x] Branch name includes the issue number.
- [x] Related issue defines scope, out of scope, acceptance criteria, and validation.
- [x] Architecture boundaries and MVP limits from `docs/implementation-guardrails.md` are respected.
- [x] Documentation is updated when behavior, architecture, setup, or validation expectations change.