### PR TITLE
Add organization management repository and integration tests

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -44,6 +44,12 @@
           Users
         </a>
       }
+      @if (showOrganizationNav()) {
+        <a mat-button routerLink="/admin/organization">
+          <mat-icon aria-hidden="true">hub</mat-icon>
+          Organization
+        </a>
+      }
     </nav>
 
     <span class="toolbar-spacer"></span>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -47,6 +47,10 @@ export class AppComponent {
     this.authService.hasAnyPermission([AppPermissions.UsersView, AppPermissions.UsersManage])
   );
 
+  protected readonly showOrganizationNav = computed(() =>
+    this.authService.hasAnyPermission([AppPermissions.OrganizationView, AppPermissions.OrganizationManage])
+  );
+
   protected logout(): void {
     this.authService.logout();
     void this.router.navigate(['/login']);

--- a/frontend/src/app/app.routes.spec.ts
+++ b/frontend/src/app/app.routes.spec.ts
@@ -1,0 +1,45 @@
+import { routes } from './app.routes';
+import { AppPermissions } from './core/auth/auth-permissions';
+import { permissionGuard } from './core/guards/auth.guard';
+
+describe('app organization routes', () => {
+  it('guards organization administration routes with permissionGuard metadata', () => {
+    const organizationRoutes = routes.filter((route) => route.path?.startsWith('admin/organization'));
+
+    expect(organizationRoutes.length).toBe(6);
+    for (const route of organizationRoutes) {
+      expect(route.canActivate).toContain(permissionGuard);
+      expect(route.data?.['permissions']).toBeTruthy();
+    }
+  });
+
+  it('sets organization entity kind route data for entity manager screens', () => {
+    expect(routeData('admin/organization/regions')).toEqual({
+      permissions: [AppPermissions.OrganizationView],
+      kind: 'regions'
+    });
+    expect(routeData('admin/organization/countries')).toEqual({
+      permissions: [AppPermissions.OrganizationView],
+      kind: 'countries'
+    });
+    expect(routeData('admin/organization/accounts')).toEqual({
+      permissions: [AppPermissions.OrganizationView],
+      kind: 'accounts'
+    });
+    expect(routeData('admin/organization/campaigns')).toEqual({
+      permissions: [AppPermissions.OrganizationView],
+      kind: 'campaigns'
+    });
+  });
+
+  it('requires assignment or scope management permission for assignments screen', () => {
+    expect(routeData('admin/organization/assignments')?.['permissions']).toEqual([
+      AppPermissions.AssignmentsManage,
+      AppPermissions.ScopesManage
+    ]);
+  });
+});
+
+function routeData(path: string) {
+  return routes.find((route) => route.path === path)?.data;
+}

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -28,6 +28,58 @@ export const routes: Routes = [
     loadComponent: () => import('./features/users/admin-users.component').then((m) => m.AdminUsersComponent)
   },
   {
+    path: 'admin/organization',
+    canActivate: [permissionGuard],
+    data: {
+      permissions: [AppPermissions.OrganizationView, AppPermissions.OrganizationManage]
+    },
+    loadComponent: () => import('./features/organization/organization-admin.component').then((m) => m.OrganizationAdminComponent)
+  },
+  {
+    path: 'admin/organization/regions',
+    canActivate: [permissionGuard],
+    data: {
+      permissions: [AppPermissions.OrganizationView],
+      kind: 'regions'
+    },
+    loadComponent: () => import('./features/organization/organization-entity-manager.component').then((m) => m.OrganizationEntityManagerComponent)
+  },
+  {
+    path: 'admin/organization/countries',
+    canActivate: [permissionGuard],
+    data: {
+      permissions: [AppPermissions.OrganizationView],
+      kind: 'countries'
+    },
+    loadComponent: () => import('./features/organization/organization-entity-manager.component').then((m) => m.OrganizationEntityManagerComponent)
+  },
+  {
+    path: 'admin/organization/accounts',
+    canActivate: [permissionGuard],
+    data: {
+      permissions: [AppPermissions.OrganizationView],
+      kind: 'accounts'
+    },
+    loadComponent: () => import('./features/organization/organization-entity-manager.component').then((m) => m.OrganizationEntityManagerComponent)
+  },
+  {
+    path: 'admin/organization/campaigns',
+    canActivate: [permissionGuard],
+    data: {
+      permissions: [AppPermissions.OrganizationView],
+      kind: 'campaigns'
+    },
+    loadComponent: () => import('./features/organization/organization-entity-manager.component').then((m) => m.OrganizationEntityManagerComponent)
+  },
+  {
+    path: 'admin/organization/assignments',
+    canActivate: [permissionGuard],
+    data: {
+      permissions: [AppPermissions.AssignmentsManage, AppPermissions.ScopesManage]
+    },
+    loadComponent: () => import('./features/organization/organization-assignments.component').then((m) => m.OrganizationAssignmentsComponent)
+  },
+  {
     path: 'admin/users',
     canActivate: [permissionGuard],
     data: {

--- a/frontend/src/app/features/organization/organization-admin.component.ts
+++ b/frontend/src/app/features/organization/organization-admin.component.ts
@@ -1,0 +1,34 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+
+@Component({
+  selector: 'app-organization-admin',
+  imports: [RouterLink, MatButtonModule, MatIconModule],
+  template: `
+    <section class="org-home" aria-labelledby="org-title">
+      <header>
+        <p class="eyebrow">Administration</p>
+        <h1 id="org-title">Organization</h1>
+      </header>
+
+      <div class="actions">
+        <a mat-flat-button color="primary" routerLink="/admin/organization/regions"><mat-icon aria-hidden="true">public</mat-icon><span>Regions</span></a>
+        <a mat-stroked-button routerLink="/admin/organization/countries"><mat-icon aria-hidden="true">flag</mat-icon><span>Countries</span></a>
+        <a mat-stroked-button routerLink="/admin/organization/accounts"><mat-icon aria-hidden="true">business</mat-icon><span>Accounts</span></a>
+        <a mat-stroked-button routerLink="/admin/organization/campaigns"><mat-icon aria-hidden="true">campaign</mat-icon><span>Campaigns</span></a>
+        <a mat-stroked-button routerLink="/admin/organization/assignments"><mat-icon aria-hidden="true">assignment_ind</mat-icon><span>Assignments</span></a>
+      </div>
+    </section>
+  `,
+  styles: [`
+    .org-home { display: grid; gap: 1.25rem; }
+    h1 { margin: 0; color: #111827; font-size: 1.8rem; line-height: 1.2; }
+    .eyebrow { margin: 0 0 0.2rem; color: #5b6475; font-size: 0.8rem; font-weight: 700; text-transform: uppercase; }
+    .actions { display: flex; flex-wrap: wrap; gap: 0.75rem; }
+    a { display: inline-flex; align-items: center; gap: 0.35rem; }
+  `],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class OrganizationAdminComponent {}

--- a/frontend/src/app/features/organization/organization-assignments.component.ts
+++ b/frontend/src/app/features/organization/organization-assignments.component.ts
@@ -1,0 +1,264 @@
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { forkJoin } from 'rxjs';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSelectModule } from '@angular/material/select';
+
+import { ApiErrorParserService } from '../../core/services/api-error-parser.service';
+import { UserSummary } from '../users/user-management.models';
+import { UserManagementService } from '../users/user-management.service';
+import { Account, Campaign, Country, Region, ScopeRequest, UserScope } from './organization.models';
+import { OrganizationService } from './organization.service';
+
+@Component({
+  selector: 'app-organization-assignments',
+  imports: [ReactiveFormsModule, RouterLink, MatButtonModule, MatFormFieldModule, MatIconModule, MatSelectModule],
+  template: `
+    <section class="assignments" aria-labelledby="assignments-title">
+      <header>
+        <div>
+          <p class="eyebrow">Organization</p>
+          <h1 id="assignments-title">Assignments</h1>
+        </div>
+        <a mat-stroked-button routerLink="/admin/organization">
+          <mat-icon aria-hidden="true">arrow_back</mat-icon>
+          <span>Organization</span>
+        </a>
+      </header>
+
+      @if (errorMessage()) {
+        <p class="error" role="alert">{{ errorMessage() }}</p>
+      }
+
+      <form [formGroup]="userForm" class="user-form">
+        <mat-form-field appearance="outline">
+          <mat-label>User</mat-label>
+          <mat-select formControlName="userId" (selectionChange)="loadUserScopes()">
+            @for (user of activeUsers(); track user.id) {
+              <mat-option [value]="user.id">{{ user.displayName }} - {{ roleNames(user) }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+      </form>
+
+      @if (selectedUserId()) {
+        <form [formGroup]="scopeForm" (ngSubmit)="addScope()" class="scope-form">
+          <mat-form-field appearance="outline">
+            <mat-label>Scope</mat-label>
+            <mat-select formControlName="scopeType" (selectionChange)="scopeForm.controls.targetId.setValue('')">
+              <mat-option value="Region">Region</mat-option>
+              <mat-option value="Country">Country</mat-option>
+              <mat-option value="Account">Account</mat-option>
+              <mat-option value="Campaign">Campaign</mat-option>
+            </mat-select>
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
+            <mat-label>Target</mat-label>
+            <mat-select formControlName="targetId">
+              @for (target of targetOptions(); track target.id) {
+                <mat-option [value]="target.id">{{ target.code }} - {{ target.name }}</mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+
+          <button mat-flat-button color="primary" type="submit" [disabled]="scopeForm.invalid">
+            <mat-icon aria-hidden="true">add</mat-icon>
+            <span>Add</span>
+          </button>
+        </form>
+
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Scope</th>
+                <th>Target</th>
+                <th>Status</th>
+                <th aria-label="Actions"></th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (scope of scopes(); track scopeKey(scope)) {
+                <tr>
+                  <td>{{ scope.scopeType }}</td>
+                  <td>{{ scopeLabel(scope) }}</td>
+                  <td><span class="status" [class.inactive]="!scope.isActive">{{ scope.isActive ? 'Active' : 'Inactive' }}</span></td>
+                  <td class="row-actions">
+                    <button mat-icon-button type="button" aria-label="Remove" (click)="removeScope(scope)">
+                      <mat-icon aria-hidden="true">delete</mat-icon>
+                    </button>
+                  </td>
+                </tr>
+              } @empty {
+                <tr><td colspan="4" class="empty">No scopes assigned.</td></tr>
+              }
+            </tbody>
+          </table>
+        </div>
+
+        <div class="actions">
+          <button mat-flat-button color="primary" type="button" [disabled]="isSaving()" (click)="save()">
+            <mat-icon aria-hidden="true">save</mat-icon>
+            <span>Save</span>
+          </button>
+        </div>
+      }
+    </section>
+  `,
+  styles: [`
+    .assignments { display: grid; gap: 1rem; }
+    header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+    h1 { margin: 0; color: #111827; font-size: 1.65rem; line-height: 1.2; }
+    .eyebrow { margin: 0 0 0.2rem; color: #5b6475; font-size: 0.8rem; font-weight: 700; text-transform: uppercase; }
+    .user-form { max-width: 680px; }
+    .scope-form { display: grid; max-width: 820px; grid-template-columns: minmax(0, 1fr) minmax(0, 1.5fr) auto; align-items: center; gap: 0.75rem; }
+    .table-wrap { overflow: auto; border: 1px solid #d8dee8; border-radius: 8px; background: #fff; }
+    table { width: 100%; min-width: 680px; border-collapse: collapse; }
+    th, td { padding: 0.8rem 0.9rem; border-bottom: 1px solid #e8edf5; text-align: left; vertical-align: middle; }
+    th { color: #3d4758; font-size: 0.78rem; font-weight: 700; text-transform: uppercase; }
+    tr:last-child td { border-bottom: 0; }
+    .status { display: inline-block; min-width: 4.6rem; border-radius: 999px; padding: 0.2rem 0.55rem; background: #e8f6ef; color: #166534; text-align: center; font-size: 0.78rem; font-weight: 700; }
+    .status.inactive { background: #f2f4f7; color: #5b6475; }
+    .actions { display: flex; gap: 0.75rem; }
+    .row-actions { width: 4rem; }
+    .error, .empty { color: #b91c1c; }
+    @media (max-width: 720px) { .scope-form { grid-template-columns: 1fr; } }
+  `],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class OrganizationAssignmentsComponent {
+  private readonly formBuilder = inject(FormBuilder);
+  private readonly organization = inject(OrganizationService);
+  private readonly usersService = inject(UserManagementService);
+  private readonly errorParser = inject(ApiErrorParserService);
+
+  protected readonly users = signal<UserSummary[]>([]);
+  protected readonly regions = signal<Region[]>([]);
+  protected readonly countries = signal<Country[]>([]);
+  protected readonly accounts = signal<Account[]>([]);
+  protected readonly campaigns = signal<Campaign[]>([]);
+  protected readonly scopes = signal<UserScope[]>([]);
+  protected readonly errorMessage = signal('');
+  protected readonly isSaving = signal(false);
+
+  protected readonly activeUsers = computed(() => this.users().filter((u) => u.isActive));
+  protected readonly selectedUserId = computed(() => this.userForm.controls.userId.value);
+  protected readonly targetOptions = computed(() => {
+    const scopeType = this.scopeForm.controls.scopeType.value;
+    if (scopeType === 'Region') return this.regions().filter((item) => item.isActive);
+    if (scopeType === 'Country') return this.countries().filter((item) => item.isActive);
+    if (scopeType === 'Account') return this.accounts().filter((item) => item.isActive);
+    return this.campaigns().filter((item) => item.isActive);
+  });
+
+  protected readonly userForm = this.formBuilder.nonNullable.group({
+    userId: ['', Validators.required]
+  });
+
+  protected readonly scopeForm = this.formBuilder.nonNullable.group({
+    scopeType: ['Region', Validators.required],
+    targetId: ['', Validators.required]
+  });
+
+  constructor() {
+    forkJoin({
+      users: this.usersService.getUsers(),
+      regions: this.organization.getRegions(),
+      countries: this.organization.getCountries(),
+      accounts: this.organization.getAccounts(),
+      campaigns: this.organization.getCampaigns()
+    }).subscribe({
+      next: ({ users, regions, countries, accounts, campaigns }) => {
+        this.users.set(users);
+        this.regions.set(regions);
+        this.countries.set(countries);
+        this.accounts.set(accounts);
+        this.campaigns.set(campaigns);
+      },
+      error: (error) => this.errorMessage.set(this.errorParser.parse(error).message)
+    });
+  }
+
+  protected roleNames(user: UserSummary): string {
+    return user.roles.map((role) => role.name).join(', ') || 'Unassigned';
+  }
+
+  protected loadUserScopes(): void {
+    const userId = this.selectedUserId();
+    if (!userId) return;
+    this.organization.getUserScopes(userId).subscribe({
+      next: (assignment) => this.scopes.set(assignment.scopes.filter((scope) => scope.isActive)),
+      error: (error) => this.errorMessage.set(this.errorParser.parse(error).message)
+    });
+  }
+
+  protected addScope(): void {
+    if (this.scopeForm.invalid) return;
+    const scope = this.toScope(this.scopeForm.getRawValue().scopeType, this.scopeForm.getRawValue().targetId);
+    if (this.scopes().some((existing) => this.scopeKey(existing) === this.scopeKey(scope))) return;
+    this.scopes.set([...this.scopes(), scope]);
+  }
+
+  protected removeScope(scope: UserScope): void {
+    this.scopes.set(this.scopes().filter((existing) => this.scopeKey(existing) !== this.scopeKey(scope)));
+  }
+
+  protected save(): void {
+    const userId = this.selectedUserId();
+    if (!userId) return;
+    this.isSaving.set(true);
+    this.organization.updateUserScopes(userId, { scopes: this.scopes().map((scope) => this.toRequest(scope)) }).subscribe({
+      next: (assignment) => {
+        this.scopes.set(assignment.scopes.filter((scope) => scope.isActive));
+        this.isSaving.set(false);
+      },
+      error: (error) => {
+        this.errorMessage.set(this.errorParser.parse(error).message);
+        this.isSaving.set(false);
+      }
+    });
+  }
+
+  protected scopeKey(scope: ScopeRequest): string {
+    return `${scope.scopeType}:${scope.regionId ?? scope.countryId ?? scope.accountId ?? scope.campaignId}`;
+  }
+
+  protected scopeLabel(scope: ScopeRequest): string {
+    if (scope.scopeType === 'Region') return this.label(this.regions(), scope.regionId);
+    if (scope.scopeType === 'Country') return this.label(this.countries(), scope.countryId);
+    if (scope.scopeType === 'Account') return this.label(this.accounts(), scope.accountId);
+    return this.label(this.campaigns(), scope.campaignId);
+  }
+
+  private toScope(scopeType: string, targetId: string): UserScope {
+    return {
+      id: `${scopeType}:${targetId}`,
+      scopeType,
+      regionId: scopeType === 'Region' ? targetId : null,
+      countryId: scopeType === 'Country' ? targetId : null,
+      accountId: scopeType === 'Account' ? targetId : null,
+      campaignId: scopeType === 'Campaign' ? targetId : null,
+      isActive: true,
+      createdAt: new Date().toISOString()
+    };
+  }
+
+  private toRequest(scope: ScopeRequest): ScopeRequest {
+    return {
+      scopeType: scope.scopeType,
+      regionId: scope.regionId ?? null,
+      countryId: scope.countryId ?? null,
+      accountId: scope.accountId ?? null,
+      campaignId: scope.campaignId ?? null
+    };
+  }
+
+  private label(items: Array<Region | Country | Account | Campaign>, id?: string | null): string {
+    const item = items.find((candidate) => candidate.id === id);
+    return item ? `${item.code} - ${item.name}` : 'Unknown';
+  }
+}

--- a/frontend/src/app/features/organization/organization-entity-manager.component.ts
+++ b/frontend/src/app/features/organization/organization-entity-manager.component.ts
@@ -1,0 +1,291 @@
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { forkJoin } from 'rxjs';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+
+import { ApiErrorParserService } from '../../core/services/api-error-parser.service';
+import { Account, Campaign, Country, EntityKind, OrganizationEntity, Region } from './organization.models';
+import { OrganizationService } from './organization.service';
+
+@Component({
+  selector: 'app-organization-entity-manager',
+  imports: [ReactiveFormsModule, RouterLink, MatButtonModule, MatFormFieldModule, MatIconModule, MatInputModule, MatSelectModule],
+  template: `
+    <section class="manager" aria-labelledby="manager-title">
+      <header>
+        <div>
+          <p class="eyebrow">Organization</p>
+          <h1 id="manager-title">{{ title() }}</h1>
+        </div>
+        <a mat-stroked-button routerLink="/admin/organization">
+          <mat-icon aria-hidden="true">arrow_back</mat-icon>
+          <span>Organization</span>
+        </a>
+      </header>
+
+      @if (errorMessage()) {
+        <p class="error" role="alert">{{ errorMessage() }}</p>
+      }
+
+      <form [formGroup]="form" (ngSubmit)="submit()" novalidate>
+        @if (kind() === 'countries') {
+          <mat-form-field appearance="outline">
+            <mat-label>Region</mat-label>
+            <mat-select formControlName="regionId">
+              @for (region of activeRegions(); track region.id) {
+                <mat-option [value]="region.id">{{ region.code }} - {{ region.name }}</mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+        }
+
+        @if (kind() === 'accounts') {
+          <mat-form-field appearance="outline">
+            <mat-label>Country</mat-label>
+            <mat-select formControlName="countryId">
+              @for (country of activeCountries(); track country.id) {
+                <mat-option [value]="country.id">{{ country.code }} - {{ country.name }}</mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+        }
+
+        @if (kind() === 'campaigns') {
+          <mat-form-field appearance="outline">
+            <mat-label>Account</mat-label>
+            <mat-select formControlName="accountId" (selectionChange)="syncCampaignCountry()">
+              @for (account of activeAccounts(); track account.id) {
+                <mat-option [value]="account.id">{{ account.code }} - {{ account.name }}</mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+          <mat-form-field appearance="outline">
+            <mat-label>Country</mat-label>
+            <mat-select formControlName="countryId">
+              @for (country of activeCountries(); track country.id) {
+                <mat-option [value]="country.id">{{ country.code }} - {{ country.name }}</mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+        }
+
+        <mat-form-field appearance="outline">
+          <mat-label>Code</mat-label>
+          <input matInput autocomplete="off" formControlName="code" />
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Name</mat-label>
+          <input matInput autocomplete="off" formControlName="name" />
+        </mat-form-field>
+
+        @if (kind() === 'accounts' || kind() === 'campaigns') {
+          <mat-form-field appearance="outline">
+            <mat-label>Description</mat-label>
+            <textarea matInput rows="2" formControlName="description"></textarea>
+          </mat-form-field>
+        }
+
+        <div class="actions">
+          <button mat-flat-button color="primary" type="submit" [disabled]="form.invalid || isSaving()">
+            <mat-icon aria-hidden="true">save</mat-icon>
+            <span>{{ editingId() ? 'Update' : 'Create' }}</span>
+          </button>
+          @if (editingId()) {
+            <button mat-button type="button" (click)="resetForm()">Cancel</button>
+          }
+        </div>
+      </form>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Code</th>
+              <th>Name</th>
+              <th>Parent</th>
+              <th>Status</th>
+              <th aria-label="Actions"></th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (item of entities(); track item.id) {
+              <tr>
+                <td>{{ item.code }}</td>
+                <td>{{ item.name }}</td>
+                <td>{{ parentLabel(item) }}</td>
+                <td><span class="status" [class.inactive]="!item.isActive">{{ item.isActive ? 'Active' : 'Inactive' }}</span></td>
+                <td class="row-actions">
+                  <button mat-icon-button type="button" aria-label="Edit" (click)="edit(item)">
+                    <mat-icon aria-hidden="true">edit</mat-icon>
+                  </button>
+                  <button mat-icon-button type="button" aria-label="Deactivate" [disabled]="!item.isActive" (click)="deactivate(item)">
+                    <mat-icon aria-hidden="true">block</mat-icon>
+                  </button>
+                </td>
+              </tr>
+            } @empty {
+              <tr><td colspan="5" class="empty">No records found.</td></tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    </section>
+  `,
+  styles: [`
+    .manager { display: grid; gap: 1rem; }
+    header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+    h1 { margin: 0; color: #111827; font-size: 1.65rem; line-height: 1.2; }
+    .eyebrow { margin: 0 0 0.2rem; color: #5b6475; font-size: 0.8rem; font-weight: 700; text-transform: uppercase; }
+    form { display: grid; max-width: 760px; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.75rem; }
+    textarea { resize: vertical; }
+    .actions { display: flex; align-items: center; gap: 0.65rem; grid-column: 1 / -1; }
+    .table-wrap { overflow: auto; border: 1px solid #d8dee8; border-radius: 8px; background: #fff; }
+    table { width: 100%; min-width: 760px; border-collapse: collapse; }
+    th, td { padding: 0.8rem 0.9rem; border-bottom: 1px solid #e8edf5; text-align: left; vertical-align: middle; }
+    th { color: #3d4758; font-size: 0.78rem; font-weight: 700; text-transform: uppercase; }
+    tr:last-child td { border-bottom: 0; }
+    .status { display: inline-block; min-width: 4.6rem; border-radius: 999px; padding: 0.2rem 0.55rem; background: #e8f6ef; color: #166534; text-align: center; font-size: 0.78rem; font-weight: 700; }
+    .status.inactive { background: #f2f4f7; color: #5b6475; }
+    .row-actions { width: 7rem; white-space: nowrap; }
+    .error, .empty { color: #b91c1c; }
+    @media (max-width: 720px) { form { grid-template-columns: 1fr; } }
+  `],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class OrganizationEntityManagerComponent {
+  private readonly route = inject(ActivatedRoute);
+  private readonly formBuilder = inject(FormBuilder);
+  private readonly organization = inject(OrganizationService);
+  private readonly errorParser = inject(ApiErrorParserService);
+
+  protected readonly kind = signal<EntityKind>((this.route.snapshot.data['kind'] as EntityKind) ?? 'regions');
+  protected readonly entities = signal<OrganizationEntity[]>([]);
+  protected readonly regions = signal<Region[]>([]);
+  protected readonly countries = signal<Country[]>([]);
+  protected readonly accounts = signal<Account[]>([]);
+  protected readonly errorMessage = signal('');
+  protected readonly editingId = signal<string | null>(null);
+  protected readonly isSaving = signal(false);
+
+  protected readonly title = computed(() => {
+    const labels: Record<EntityKind, string> = { regions: 'Regions', countries: 'Countries', accounts: 'Accounts', campaigns: 'Campaigns' };
+    return labels[this.kind()];
+  });
+  protected readonly activeRegions = computed(() => this.regions().filter((r) => r.isActive));
+  protected readonly activeCountries = computed(() => this.countries().filter((c) => c.isActive));
+  protected readonly activeAccounts = computed(() => this.accounts().filter((a) => a.isActive));
+
+  protected readonly form = this.formBuilder.nonNullable.group({
+    regionId: [''],
+    countryId: [''],
+    accountId: [''],
+    code: ['', [Validators.required, Validators.maxLength(50)]],
+    name: ['', [Validators.required, Validators.maxLength(200)]],
+    description: ['', [Validators.maxLength(500)]]
+  });
+
+  constructor() {
+    this.configureValidators();
+    this.load();
+  }
+
+  protected parentLabel(item: OrganizationEntity): string {
+    if ('accountCode' in item) return `${item.accountCode} / ${item.countryCode}`;
+    if ('countryCode' in item) return item.countryCode;
+    if ('regionCode' in item) return item.regionCode;
+    return 'Root';
+  }
+
+  protected edit(item: OrganizationEntity): void {
+    this.editingId.set(item.id);
+    this.form.patchValue({
+      regionId: 'regionId' in item ? item.regionId : '',
+      countryId: 'countryId' in item ? item.countryId : '',
+      accountId: 'accountId' in item ? item.accountId : '',
+      code: item.code,
+      name: item.name,
+      description: 'description' in item ? item.description ?? '' : ''
+    });
+  }
+
+  protected resetForm(): void {
+    this.editingId.set(null);
+    this.form.reset({ regionId: '', countryId: '', accountId: '', code: '', name: '', description: '' });
+  }
+
+  protected syncCampaignCountry(): void {
+    const account = this.accounts().find((candidate) => candidate.id === this.form.controls.accountId.value);
+    if (account) this.form.controls.countryId.setValue(account.countryId);
+  }
+
+  protected submit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    this.errorMessage.set('');
+    this.isSaving.set(true);
+    const raw = this.form.getRawValue();
+    const base = { code: raw.code.trim(), name: raw.name.trim() };
+    const id = this.editingId();
+    const request$ = this.kind() === 'regions'
+      ? (id ? this.organization.updateRegion(id, base) : this.organization.createRegion(base))
+      : this.kind() === 'countries'
+        ? (id ? this.organization.updateCountry(id, { ...base, regionId: raw.regionId }) : this.organization.createCountry({ ...base, regionId: raw.regionId }))
+        : this.kind() === 'accounts'
+          ? (id ? this.organization.updateAccount(id, { ...base, countryId: raw.countryId, description: raw.description.trim() || null }) : this.organization.createAccount({ ...base, countryId: raw.countryId, description: raw.description.trim() || null }))
+          : (id ? this.organization.updateCampaign(id, { ...base, accountId: raw.accountId, countryId: raw.countryId, description: raw.description.trim() || null }) : this.organization.createCampaign({ ...base, accountId: raw.accountId, countryId: raw.countryId, description: raw.description.trim() || null }));
+
+    request$.subscribe({
+      next: () => {
+        this.resetForm();
+        this.isSaving.set(false);
+        this.load();
+      },
+      error: (error) => {
+        this.errorMessage.set(this.errorParser.parse(error).message);
+        this.isSaving.set(false);
+      }
+    });
+  }
+
+  protected deactivate(item: OrganizationEntity): void {
+    this.organization.deactivate(this.kind(), item.id).subscribe({
+      next: () => this.load(),
+      error: (error) => this.errorMessage.set(this.errorParser.parse(error).message)
+    });
+  }
+
+  private configureValidators(): void {
+    if (this.kind() === 'countries') this.form.controls.regionId.addValidators(Validators.required);
+    if (this.kind() === 'accounts') this.form.controls.countryId.addValidators(Validators.required);
+    if (this.kind() === 'campaigns') {
+      this.form.controls.accountId.addValidators(Validators.required);
+      this.form.controls.countryId.addValidators(Validators.required);
+    }
+  }
+
+  private load(): void {
+    forkJoin({
+      regions: this.organization.getRegions(),
+      countries: this.organization.getCountries(),
+      accounts: this.organization.getAccounts(),
+      campaigns: this.organization.getCampaigns()
+    }).subscribe({
+      next: ({ regions, countries, accounts, campaigns }) => {
+        this.regions.set(regions);
+        this.countries.set(countries);
+        this.accounts.set(accounts);
+        this.entities.set(this.kind() === 'regions' ? regions : this.kind() === 'countries' ? countries : this.kind() === 'accounts' ? accounts : campaigns);
+      },
+      error: (error) => this.errorMessage.set(this.errorParser.parse(error).message)
+    });
+  }
+}

--- a/frontend/src/app/features/organization/organization.models.ts
+++ b/frontend/src/app/features/organization/organization.models.ts
@@ -1,0 +1,97 @@
+import { ApiResponse } from '../../core/auth/auth.models';
+
+export type ListResponse<T> = ApiResponse<T[]>;
+export type EntityKind = 'regions' | 'countries' | 'accounts' | 'campaigns';
+
+export interface Region {
+  id: string;
+  code: string;
+  name: string;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt?: string | null;
+}
+
+export interface Country extends Region {
+  regionId: string;
+  regionCode: string;
+  regionName: string;
+}
+
+export interface Account extends Region {
+  countryId: string;
+  countryCode: string;
+  countryName: string;
+  regionId: string;
+  regionCode: string;
+  description?: string | null;
+}
+
+export interface Campaign extends Region {
+  accountId: string;
+  accountCode: string;
+  accountName: string;
+  countryId: string;
+  countryCode: string;
+  countryName: string;
+  regionId: string;
+  regionCode: string;
+  description?: string | null;
+}
+
+export type OrganizationEntity = Region | Country | Account | Campaign;
+
+export interface RegionRequest {
+  code: string;
+  name: string;
+}
+
+export interface CountryRequest extends RegionRequest {
+  regionId: string;
+}
+
+export interface AccountRequest extends RegionRequest {
+  countryId: string;
+  description?: string | null;
+}
+
+export interface CampaignRequest extends RegionRequest {
+  accountId: string;
+  countryId: string;
+  description?: string | null;
+}
+
+export interface ScopeRequest {
+  scopeType: string;
+  regionId?: string | null;
+  countryId?: string | null;
+  accountId?: string | null;
+  campaignId?: string | null;
+}
+
+export interface UserScope extends ScopeRequest {
+  id: string;
+  regionCode?: string | null;
+  regionName?: string | null;
+  countryCode?: string | null;
+  countryName?: string | null;
+  accountCode?: string | null;
+  accountName?: string | null;
+  campaignCode?: string | null;
+  campaignName?: string | null;
+  isActive: boolean;
+  createdAt: string;
+}
+
+export interface UserScopeAssignment {
+  userId: string;
+  email: string;
+  displayName: string;
+  isActive: boolean;
+  roles: string[];
+  scopes: UserScope[];
+}
+
+export interface UpdateUserScopesRequest {
+  scopes: ScopeRequest[];
+}

--- a/frontend/src/app/features/organization/organization.service.spec.ts
+++ b/frontend/src/app/features/organization/organization.service.spec.ts
@@ -1,0 +1,85 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { ApiClientService } from '../../core/services/api-client.service';
+import { OrganizationService } from './organization.service';
+
+describe('OrganizationService', () => {
+  let service: OrganizationService;
+  let apiClient: jasmine.SpyObj<Pick<ApiClientService, 'get' | 'post' | 'put'>>;
+
+  beforeEach(() => {
+    apiClient = jasmine.createSpyObj<Pick<ApiClientService, 'get' | 'post' | 'put'>>('ApiClientService', ['get', 'post', 'put']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        OrganizationService,
+        { provide: ApiClientService, useValue: apiClient }
+      ]
+    });
+
+    service = TestBed.inject(OrganizationService);
+  });
+
+  it('calls list endpoints and unwraps response data', (done) => {
+    const regions = [{ id: 'region-1', code: 'SKY', name: 'Sky Region', isActive: true, createdAt: '2026-05-14T00:00:00Z' }];
+    apiClient.get.and.returnValue(of({ data: regions }));
+
+    service.getRegions().subscribe((result) => {
+      expect(result).toEqual(regions);
+      expect(apiClient.get).toHaveBeenCalledOnceWith('regions');
+      done();
+    });
+  });
+
+  it('calls create and update endpoints for organization entities', (done) => {
+    const request = { code: 'SKY', name: 'Sky Region' };
+    const region = { id: 'region-1', ...request, isActive: true, createdAt: '2026-05-14T00:00:00Z' };
+    apiClient.post.and.returnValue(of({ data: region }));
+    apiClient.put.and.returnValue(of({ data: { ...region, name: 'Sky Operations' } }));
+
+    service.createRegion(request).subscribe((created) => {
+      expect(created).toEqual(region);
+      expect(apiClient.post).toHaveBeenCalledOnceWith('regions', request);
+
+      service.updateRegion('region-1', { code: 'SKY', name: 'Sky Operations' }).subscribe((updated) => {
+        expect(updated.name).toBe('Sky Operations');
+        expect(apiClient.put).toHaveBeenCalledWith('regions/region-1', { code: 'SKY', name: 'Sky Operations' });
+        done();
+      });
+    });
+  });
+
+  it('calls deactivate endpoint for the selected entity kind', () => {
+    apiClient.post.and.returnValue(of({}));
+
+    service.deactivate('campaigns', 'campaign-1').subscribe();
+
+    expect(apiClient.post).toHaveBeenCalledOnceWith('campaigns/campaign-1/deactivate', {});
+  });
+
+  it('calls user scope endpoints and unwraps assignments', (done) => {
+    const assignment = {
+      userId: 'user-1',
+      email: 'viewer.lunara@opssphere.test',
+      displayName: 'Viewer Lunara',
+      isActive: true,
+      roles: ['Viewer'],
+      scopes: []
+    };
+    const request = { scopes: [{ scopeType: 'Country', countryId: 'country-1' }] };
+    apiClient.get.and.returnValue(of({ data: assignment }));
+    apiClient.put.and.returnValue(of({ data: { ...assignment, scopes: request.scopes } }));
+
+    service.getUserScopes('user-1').subscribe((result) => {
+      expect(result).toEqual(assignment);
+      expect(apiClient.get).toHaveBeenCalledOnceWith('users/user-1/scopes');
+
+      service.updateUserScopes('user-1', request).subscribe((updated) => {
+        expect(updated.scopes).toEqual(request.scopes as any);
+        expect(apiClient.put).toHaveBeenCalledOnceWith('users/user-1/scopes', request);
+        done();
+      });
+    });
+  });
+});

--- a/frontend/src/app/features/organization/organization.service.ts
+++ b/frontend/src/app/features/organization/organization.service.ts
@@ -1,0 +1,86 @@
+import { Injectable, inject } from '@angular/core';
+import { map } from 'rxjs';
+
+import { ApiResponse } from '../../core/auth/auth.models';
+import { ApiClientService } from '../../core/services/api-client.service';
+import {
+  Account,
+  AccountRequest,
+  Campaign,
+  CampaignRequest,
+  Country,
+  CountryRequest,
+  EntityKind,
+  ListResponse,
+  Region,
+  RegionRequest,
+  UpdateUserScopesRequest,
+  UserScopeAssignment
+} from './organization.models';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class OrganizationService {
+  private readonly apiClient = inject(ApiClientService);
+
+  getRegions() {
+    return this.apiClient.get<ListResponse<Region>>('regions').pipe(map((response) => response.data));
+  }
+
+  getCountries() {
+    return this.apiClient.get<ListResponse<Country>>('countries').pipe(map((response) => response.data));
+  }
+
+  getAccounts() {
+    return this.apiClient.get<ListResponse<Account>>('accounts').pipe(map((response) => response.data));
+  }
+
+  getCampaigns() {
+    return this.apiClient.get<ListResponse<Campaign>>('campaigns').pipe(map((response) => response.data));
+  }
+
+  createRegion(request: RegionRequest) {
+    return this.apiClient.post<RegionRequest, ApiResponse<Region>>('regions', request).pipe(map((response) => response.data));
+  }
+
+  updateRegion(id: string, request: RegionRequest) {
+    return this.apiClient.put<RegionRequest, ApiResponse<Region>>(`regions/${id}`, request).pipe(map((response) => response.data));
+  }
+
+  createCountry(request: CountryRequest) {
+    return this.apiClient.post<CountryRequest, ApiResponse<Country>>('countries', request).pipe(map((response) => response.data));
+  }
+
+  updateCountry(id: string, request: CountryRequest) {
+    return this.apiClient.put<CountryRequest, ApiResponse<Country>>(`countries/${id}`, request).pipe(map((response) => response.data));
+  }
+
+  createAccount(request: AccountRequest) {
+    return this.apiClient.post<AccountRequest, ApiResponse<Account>>('accounts', request).pipe(map((response) => response.data));
+  }
+
+  updateAccount(id: string, request: AccountRequest) {
+    return this.apiClient.put<AccountRequest, ApiResponse<Account>>(`accounts/${id}`, request).pipe(map((response) => response.data));
+  }
+
+  createCampaign(request: CampaignRequest) {
+    return this.apiClient.post<CampaignRequest, ApiResponse<Campaign>>('campaigns', request).pipe(map((response) => response.data));
+  }
+
+  updateCampaign(id: string, request: CampaignRequest) {
+    return this.apiClient.put<CampaignRequest, ApiResponse<Campaign>>(`campaigns/${id}`, request).pipe(map((response) => response.data));
+  }
+
+  deactivate(kind: EntityKind, id: string) {
+    return this.apiClient.post<Record<string, never>, unknown>(`${kind}/${id}/deactivate`, {});
+  }
+
+  getUserScopes(userId: string) {
+    return this.apiClient.get<ApiResponse<UserScopeAssignment>>(`users/${userId}/scopes`).pipe(map((response) => response.data));
+  }
+
+  updateUserScopes(userId: string, request: UpdateUserScopesRequest) {
+    return this.apiClient.put<UpdateUserScopesRequest, ApiResponse<UserScopeAssignment>>(`users/${userId}/scopes`, request).pipe(map((response) => response.data));
+  }
+}

--- a/src/OpsSphere.Api/Controllers/OrganizationController.cs
+++ b/src/OpsSphere.Api/Controllers/OrganizationController.cs
@@ -1,0 +1,289 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using OpsSphere.Api.Common;
+using OpsSphere.Application.Features.OrganizationManagement;
+using OpsSphere.Domain.Authorization;
+
+namespace OpsSphere.Api.Controllers;
+
+[ApiController]
+[Route("api")]
+[Authorize]
+public sealed class OrganizationController : ControllerBase
+{
+    private readonly IAuthorizationService authorizationService;
+    private readonly ILogger<OrganizationController> logger;
+    private readonly GetRegionsQueryHandler getRegions;
+    private readonly GetRegionByIdQueryHandler getRegion;
+    private readonly CreateRegionCommandHandler createRegion;
+    private readonly UpdateRegionCommandHandler updateRegion;
+    private readonly DeactivateRegionCommandHandler deactivateRegion;
+    private readonly GetCountriesQueryHandler getCountries;
+    private readonly GetCountryByIdQueryHandler getCountry;
+    private readonly CreateCountryCommandHandler createCountry;
+    private readonly UpdateCountryCommandHandler updateCountry;
+    private readonly DeactivateCountryCommandHandler deactivateCountry;
+    private readonly GetAccountsQueryHandler getAccounts;
+    private readonly GetAccountByIdQueryHandler getAccount;
+    private readonly CreateAccountCommandHandler createAccount;
+    private readonly UpdateAccountCommandHandler updateAccount;
+    private readonly DeactivateAccountCommandHandler deactivateAccount;
+    private readonly GetCampaignsQueryHandler getCampaigns;
+    private readonly GetCampaignByIdQueryHandler getCampaign;
+    private readonly CreateCampaignCommandHandler createCampaign;
+    private readonly UpdateCampaignCommandHandler updateCampaign;
+    private readonly DeactivateCampaignCommandHandler deactivateCampaign;
+    private readonly GetUserScopesQueryHandler getUserScopes;
+    private readonly UpdateUserScopesCommandHandler updateUserScopes;
+
+    public OrganizationController(
+        IAuthorizationService authorizationService,
+        ILogger<OrganizationController> logger,
+        GetRegionsQueryHandler getRegions,
+        GetRegionByIdQueryHandler getRegion,
+        CreateRegionCommandHandler createRegion,
+        UpdateRegionCommandHandler updateRegion,
+        DeactivateRegionCommandHandler deactivateRegion,
+        GetCountriesQueryHandler getCountries,
+        GetCountryByIdQueryHandler getCountry,
+        CreateCountryCommandHandler createCountry,
+        UpdateCountryCommandHandler updateCountry,
+        DeactivateCountryCommandHandler deactivateCountry,
+        GetAccountsQueryHandler getAccounts,
+        GetAccountByIdQueryHandler getAccount,
+        CreateAccountCommandHandler createAccount,
+        UpdateAccountCommandHandler updateAccount,
+        DeactivateAccountCommandHandler deactivateAccount,
+        GetCampaignsQueryHandler getCampaigns,
+        GetCampaignByIdQueryHandler getCampaign,
+        CreateCampaignCommandHandler createCampaign,
+        UpdateCampaignCommandHandler updateCampaign,
+        DeactivateCampaignCommandHandler deactivateCampaign,
+        GetUserScopesQueryHandler getUserScopes,
+        UpdateUserScopesCommandHandler updateUserScopes)
+    {
+        this.authorizationService = authorizationService;
+        this.logger = logger;
+        this.getRegions = getRegions;
+        this.getRegion = getRegion;
+        this.createRegion = createRegion;
+        this.updateRegion = updateRegion;
+        this.deactivateRegion = deactivateRegion;
+        this.getCountries = getCountries;
+        this.getCountry = getCountry;
+        this.createCountry = createCountry;
+        this.updateCountry = updateCountry;
+        this.deactivateCountry = deactivateCountry;
+        this.getAccounts = getAccounts;
+        this.getAccount = getAccount;
+        this.createAccount = createAccount;
+        this.updateAccount = updateAccount;
+        this.deactivateAccount = deactivateAccount;
+        this.getCampaigns = getCampaigns;
+        this.getCampaign = getCampaign;
+        this.createCampaign = createCampaign;
+        this.updateCampaign = updateCampaign;
+        this.deactivateCampaign = deactivateCampaign;
+        this.getUserScopes = getUserScopes;
+        this.updateUserScopes = updateUserScopes;
+    }
+
+    [HttpGet("regions")]
+    [Authorize(Policy = Permissions.OrganizationView)]
+    public async Task<IActionResult> GetRegions(CancellationToken cancellationToken) =>
+        Ok(new ApiResponse<IReadOnlyList<RegionDto>>(await getRegions.HandleAsync(new GetRegionsQuery(), cancellationToken)));
+
+    [HttpGet("regions/{id:guid}")]
+    [Authorize(Policy = Permissions.OrganizationView)]
+    public async Task<IActionResult> GetRegion(Guid id, CancellationToken cancellationToken) =>
+        Ok(new ApiResponse<RegionDto>(await getRegion.HandleAsync(new GetRegionByIdQuery(id), cancellationToken)));
+
+    [HttpPost("regions")]
+    [Authorize(Policy = Permissions.RegionsManage)]
+    public async Task<IActionResult> CreateRegion(OrganizationEntityRequest request, CancellationToken cancellationToken)
+    {
+        var result = await createRegion.HandleAsync(new CreateRegionCommand(request.Code, request.Name), cancellationToken);
+        LogOrganizationChange("RegionCreated", "Region", result.Id, result.Code);
+        return CreatedAtAction(nameof(GetRegion), new { id = result.Id }, new ApiResponse<RegionDto>(result));
+    }
+
+    [HttpPut("regions/{id:guid}")]
+    [Authorize(Policy = Permissions.RegionsManage)]
+    public async Task<IActionResult> UpdateRegion(Guid id, OrganizationEntityRequest request, CancellationToken cancellationToken)
+    {
+        var result = await updateRegion.HandleAsync(new UpdateRegionCommand(id, request.Code, request.Name), cancellationToken);
+        LogOrganizationChange("RegionUpdated", "Region", result.Id, result.Code);
+        return Ok(new ApiResponse<RegionDto>(result));
+    }
+
+    [HttpPost("regions/{id:guid}/deactivate")]
+    [Authorize(Policy = Permissions.RegionsManage)]
+    public async Task<IActionResult> DeactivateRegion(Guid id, CancellationToken cancellationToken)
+    {
+        await deactivateRegion.HandleAsync(new DeactivateRegionCommand(id), cancellationToken);
+        LogOrganizationChange("RegionDeactivated", "Region", id, null);
+        return NoContent();
+    }
+
+    [HttpGet("countries")]
+    [Authorize(Policy = Permissions.OrganizationView)]
+    public async Task<IActionResult> GetCountries(CancellationToken cancellationToken) =>
+        Ok(new ApiResponse<IReadOnlyList<CountryDto>>(await getCountries.HandleAsync(new GetCountriesQuery(), cancellationToken)));
+
+    [HttpGet("countries/{id:guid}")]
+    [Authorize(Policy = Permissions.OrganizationView)]
+    public async Task<IActionResult> GetCountry(Guid id, CancellationToken cancellationToken) =>
+        Ok(new ApiResponse<CountryDto>(await getCountry.HandleAsync(new GetCountryByIdQuery(id), cancellationToken)));
+
+    [HttpPost("countries")]
+    [Authorize(Policy = Permissions.CountriesManage)]
+    public async Task<IActionResult> CreateCountry(CountryRequest request, CancellationToken cancellationToken)
+    {
+        var result = await createCountry.HandleAsync(new CreateCountryCommand(request.RegionId, request.Code, request.Name), cancellationToken);
+        LogOrganizationChange("CountryCreated", "Country", result.Id, result.Code);
+        return CreatedAtAction(nameof(GetCountry), new { id = result.Id }, new ApiResponse<CountryDto>(result));
+    }
+
+    [HttpPut("countries/{id:guid}")]
+    [Authorize(Policy = Permissions.CountriesManage)]
+    public async Task<IActionResult> UpdateCountry(Guid id, CountryRequest request, CancellationToken cancellationToken)
+    {
+        var result = await updateCountry.HandleAsync(new UpdateCountryCommand(id, request.RegionId, request.Code, request.Name), cancellationToken);
+        LogOrganizationChange("CountryUpdated", "Country", result.Id, result.Code);
+        return Ok(new ApiResponse<CountryDto>(result));
+    }
+
+    [HttpPost("countries/{id:guid}/deactivate")]
+    [Authorize(Policy = Permissions.CountriesManage)]
+    public async Task<IActionResult> DeactivateCountry(Guid id, CancellationToken cancellationToken)
+    {
+        await deactivateCountry.HandleAsync(new DeactivateCountryCommand(id), cancellationToken);
+        LogOrganizationChange("CountryDeactivated", "Country", id, null);
+        return NoContent();
+    }
+
+    [HttpGet("accounts")]
+    [Authorize(Policy = Permissions.OrganizationView)]
+    public async Task<IActionResult> GetAccounts(CancellationToken cancellationToken) =>
+        Ok(new ApiResponse<IReadOnlyList<AccountDto>>(await getAccounts.HandleAsync(new GetAccountsQuery(), cancellationToken)));
+
+    [HttpGet("accounts/{id:guid}")]
+    [Authorize(Policy = Permissions.OrganizationView)]
+    public async Task<IActionResult> GetAccount(Guid id, CancellationToken cancellationToken) =>
+        Ok(new ApiResponse<AccountDto>(await getAccount.HandleAsync(new GetAccountByIdQuery(id), cancellationToken)));
+
+    [HttpPost("accounts")]
+    [Authorize(Policy = Permissions.AccountsManage)]
+    public async Task<IActionResult> CreateAccount(AccountRequest request, CancellationToken cancellationToken)
+    {
+        var result = await createAccount.HandleAsync(new CreateAccountCommand(request.CountryId, request.Code, request.Name, request.Description), cancellationToken);
+        LogOrganizationChange("AccountCreated", "Account", result.Id, result.Code);
+        return CreatedAtAction(nameof(GetAccount), new { id = result.Id }, new ApiResponse<AccountDto>(result));
+    }
+
+    [HttpPut("accounts/{id:guid}")]
+    [Authorize(Policy = Permissions.AccountsManage)]
+    public async Task<IActionResult> UpdateAccount(Guid id, AccountRequest request, CancellationToken cancellationToken)
+    {
+        var result = await updateAccount.HandleAsync(new UpdateAccountCommand(id, request.CountryId, request.Code, request.Name, request.Description), cancellationToken);
+        LogOrganizationChange("AccountUpdated", "Account", result.Id, result.Code);
+        return Ok(new ApiResponse<AccountDto>(result));
+    }
+
+    [HttpPost("accounts/{id:guid}/deactivate")]
+    [Authorize(Policy = Permissions.AccountsManage)]
+    public async Task<IActionResult> DeactivateAccount(Guid id, CancellationToken cancellationToken)
+    {
+        await deactivateAccount.HandleAsync(new DeactivateAccountCommand(id), cancellationToken);
+        LogOrganizationChange("AccountDeactivated", "Account", id, null);
+        return NoContent();
+    }
+
+    [HttpGet("campaigns")]
+    [Authorize(Policy = Permissions.OrganizationView)]
+    public async Task<IActionResult> GetCampaigns(CancellationToken cancellationToken) =>
+        Ok(new ApiResponse<IReadOnlyList<CampaignDto>>(await getCampaigns.HandleAsync(new GetCampaignsQuery(), cancellationToken)));
+
+    [HttpGet("campaigns/{id:guid}")]
+    [Authorize(Policy = Permissions.OrganizationView)]
+    public async Task<IActionResult> GetCampaign(Guid id, CancellationToken cancellationToken) =>
+        Ok(new ApiResponse<CampaignDto>(await getCampaign.HandleAsync(new GetCampaignByIdQuery(id), cancellationToken)));
+
+    [HttpPost("campaigns")]
+    [Authorize(Policy = Permissions.CampaignsManage)]
+    public async Task<IActionResult> CreateCampaign(CampaignRequest request, CancellationToken cancellationToken)
+    {
+        var result = await createCampaign.HandleAsync(new CreateCampaignCommand(request.AccountId, request.CountryId, request.Code, request.Name, request.Description), cancellationToken);
+        LogOrganizationChange("CampaignCreated", "Campaign", result.Id, result.Code);
+        return CreatedAtAction(nameof(GetCampaign), new { id = result.Id }, new ApiResponse<CampaignDto>(result));
+    }
+
+    [HttpPut("campaigns/{id:guid}")]
+    [Authorize(Policy = Permissions.CampaignsManage)]
+    public async Task<IActionResult> UpdateCampaign(Guid id, CampaignRequest request, CancellationToken cancellationToken)
+    {
+        var result = await updateCampaign.HandleAsync(new UpdateCampaignCommand(id, request.AccountId, request.CountryId, request.Code, request.Name, request.Description), cancellationToken);
+        LogOrganizationChange("CampaignUpdated", "Campaign", result.Id, result.Code);
+        return Ok(new ApiResponse<CampaignDto>(result));
+    }
+
+    [HttpPost("campaigns/{id:guid}/deactivate")]
+    [Authorize(Policy = Permissions.CampaignsManage)]
+    public async Task<IActionResult> DeactivateCampaign(Guid id, CancellationToken cancellationToken)
+    {
+        await deactivateCampaign.HandleAsync(new DeactivateCampaignCommand(id), cancellationToken);
+        LogOrganizationChange("CampaignDeactivated", "Campaign", id, null);
+        return NoContent();
+    }
+
+    [HttpGet("users/{id:guid}/scopes")]
+    public async Task<IActionResult> GetUserScopes(Guid id, CancellationToken cancellationToken)
+    {
+        if (!await IsAuthorizedForAnyAsync([Permissions.ScopesView, Permissions.AssignmentsManage]))
+        {
+            return Forbid();
+        }
+
+        return Ok(new ApiResponse<UserScopeAssignmentDto>(await getUserScopes.HandleAsync(new GetUserScopesQuery(id), cancellationToken)));
+    }
+
+    [HttpPut("users/{id:guid}/scopes")]
+    public async Task<IActionResult> UpdateUserScopes(Guid id, UpdateUserScopesRequest request, CancellationToken cancellationToken)
+    {
+        if (!await IsAuthorizedForAnyAsync([Permissions.AssignmentsManage, Permissions.ScopesManage]))
+        {
+            return Forbid();
+        }
+
+        var result = await updateUserScopes.HandleAsync(new UpdateUserScopesCommand(id, request.Scopes), cancellationToken);
+        logger.LogInformation("Organization assignment change. Action={Action} TargetUserId={TargetUserId} ScopeCount={ScopeCount}", "UserScopesUpdated", id, result.Scopes.Count);
+        return Ok(new ApiResponse<UserScopeAssignmentDto>(result));
+    }
+
+    private async Task<bool> IsAuthorizedForAnyAsync(IReadOnlyCollection<string> policies)
+    {
+        foreach (var policy in policies)
+        {
+            if ((await authorizationService.AuthorizeAsync(User, policy)).Succeeded)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void LogOrganizationChange(string action, string entityType, Guid entityId, string? code) =>
+        logger.LogInformation(
+            "Organization governance change. Action={Action} EntityType={EntityType} EntityId={EntityId} Code={Code}",
+            action,
+            entityType,
+            entityId,
+            code);
+
+    public sealed record OrganizationEntityRequest(string? Code, string? Name);
+    public sealed record CountryRequest(Guid RegionId, string? Code, string? Name);
+    public sealed record AccountRequest(Guid CountryId, string? Code, string? Name, string? Description);
+    public sealed record CampaignRequest(Guid AccountId, Guid CountryId, string? Code, string? Name, string? Description);
+    public sealed record UpdateUserScopesRequest(IReadOnlyCollection<UserScopeUpsertDto>? Scopes);
+}

--- a/src/OpsSphere.Application/Common/Interfaces/IOrganizationManagementRepository.cs
+++ b/src/OpsSphere.Application/Common/Interfaces/IOrganizationManagementRepository.cs
@@ -1,0 +1,60 @@
+using OpsSphere.Application.Features.OrganizationManagement;
+
+namespace OpsSphere.Application.Common.Interfaces;
+
+public interface IOrganizationManagementRepository
+{
+    Task<IReadOnlyList<RegionDto>> GetRegionsAsync(CancellationToken cancellationToken);
+    Task<RegionDto?> GetRegionByIdAsync(Guid id, CancellationToken cancellationToken);
+    Task<RegionSnapshot?> GetRegionSnapshotAsync(Guid id, CancellationToken cancellationToken);
+    Task<bool> RegionCodeExistsAsync(string code, Guid? excludingId, CancellationToken cancellationToken);
+    Task AddRegionAsync(OrganizationEntityCreateModel model, CancellationToken cancellationToken);
+    Task UpdateRegionAsync(Guid id, string code, string name, CancellationToken cancellationToken);
+    Task<bool> HasActiveCountriesAsync(Guid regionId, CancellationToken cancellationToken);
+    Task DeactivateRegionAsync(Guid id, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<CountryDto>> GetCountriesAsync(CancellationToken cancellationToken);
+    Task<CountryDto?> GetCountryByIdAsync(Guid id, CancellationToken cancellationToken);
+    Task<CountrySnapshot?> GetCountrySnapshotAsync(Guid id, CancellationToken cancellationToken);
+    Task<bool> CountryCodeExistsAsync(string code, Guid? excludingId, CancellationToken cancellationToken);
+    Task AddCountryAsync(CountryCreateModel model, CancellationToken cancellationToken);
+    Task UpdateCountryAsync(Guid id, Guid regionId, string code, string name, CancellationToken cancellationToken);
+    Task<bool> HasActiveAccountsOrCampaignsAsync(Guid countryId, CancellationToken cancellationToken);
+    Task DeactivateCountryAsync(Guid id, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<AccountDto>> GetAccountsAsync(CancellationToken cancellationToken);
+    Task<AccountDto?> GetAccountByIdAsync(Guid id, CancellationToken cancellationToken);
+    Task<AccountSnapshot?> GetAccountSnapshotAsync(Guid id, CancellationToken cancellationToken);
+    Task<bool> AccountCodeExistsAsync(string code, Guid? excludingId, CancellationToken cancellationToken);
+    Task AddAccountAsync(AccountCreateModel model, CancellationToken cancellationToken);
+    Task UpdateAccountAsync(Guid id, Guid countryId, string code, string name, string? description, CancellationToken cancellationToken);
+    Task<bool> HasActiveCampaignsAsync(Guid accountId, CancellationToken cancellationToken);
+    Task DeactivateAccountAsync(Guid id, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<CampaignDto>> GetCampaignsAsync(CancellationToken cancellationToken);
+    Task<CampaignDto?> GetCampaignByIdAsync(Guid id, CancellationToken cancellationToken);
+    Task<CampaignSnapshot?> GetCampaignSnapshotAsync(Guid id, CancellationToken cancellationToken);
+    Task<bool> CampaignCodeExistsAsync(string code, Guid? excludingId, CancellationToken cancellationToken);
+    Task AddCampaignAsync(CampaignCreateModel model, CancellationToken cancellationToken);
+    Task UpdateCampaignAsync(Guid id, Guid accountId, Guid countryId, string code, string name, string? description, CancellationToken cancellationToken);
+    Task DeactivateCampaignAsync(Guid id, CancellationToken cancellationToken);
+
+    Task<UserScopeAssignmentDto?> GetUserScopesAsync(Guid userId, CancellationToken cancellationToken);
+    Task<UserScopeValidationUser?> GetScopeAssignmentUserAsync(Guid userId, CancellationToken cancellationToken);
+    Task<IReadOnlyList<string>> GetMissingOrInactiveScopeTargetsAsync(IReadOnlyCollection<UserScopeUpsertDto> scopes, CancellationToken cancellationToken);
+    Task<IReadOnlyList<UserScopeChange>> ReplaceUserScopesAsync(Guid userId, IReadOnlyCollection<UserScopeUpsertDto> scopes, Guid? actorUserId, CancellationToken cancellationToken);
+
+    Task SaveChangesAsync(CancellationToken cancellationToken);
+}
+
+public sealed record OrganizationEntityCreateModel(Guid Id, string Code, string Name);
+public sealed record CountryCreateModel(Guid Id, Guid RegionId, string Code, string Name);
+public sealed record AccountCreateModel(Guid Id, Guid CountryId, string Code, string Name, string? Description);
+public sealed record CampaignCreateModel(Guid Id, Guid AccountId, Guid CountryId, string Code, string Name, string? Description);
+
+public sealed record RegionSnapshot(Guid Id, string Code, string Name, bool IsActive);
+public sealed record CountrySnapshot(Guid Id, Guid RegionId, string Code, string Name, bool IsActive);
+public sealed record AccountSnapshot(Guid Id, Guid CountryId, string Code, string Name, string? Description, bool IsActive);
+public sealed record CampaignSnapshot(Guid Id, Guid AccountId, Guid CountryId, string Code, string Name, string? Description, bool IsActive);
+public sealed record UserScopeValidationUser(Guid Id, bool IsActive, IReadOnlyList<string> Roles);
+public sealed record UserScopeChange(string Action, UserScopeDto Scope);

--- a/src/OpsSphere.Application/DependencyInjection.cs
+++ b/src/OpsSphere.Application/DependencyInjection.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using OpsSphere.Application.Features.Auth.GetCurrentUser;
 using OpsSphere.Application.Features.Auth.Login;
+using OpsSphere.Application.Features.OrganizationManagement;
 using OpsSphere.Application.Features.UserManagement;
 
 namespace OpsSphere.Application;
@@ -19,6 +20,28 @@ public static class DependencyInjection
         services.AddScoped<UpdateUserRolesCommandHandler>();
         services.AddScoped<GetRolesQueryHandler>();
         services.AddScoped<GetPermissionsQueryHandler>();
+        services.AddScoped<GetRegionsQueryHandler>();
+        services.AddScoped<GetRegionByIdQueryHandler>();
+        services.AddScoped<CreateRegionCommandHandler>();
+        services.AddScoped<UpdateRegionCommandHandler>();
+        services.AddScoped<DeactivateRegionCommandHandler>();
+        services.AddScoped<GetCountriesQueryHandler>();
+        services.AddScoped<GetCountryByIdQueryHandler>();
+        services.AddScoped<CreateCountryCommandHandler>();
+        services.AddScoped<UpdateCountryCommandHandler>();
+        services.AddScoped<DeactivateCountryCommandHandler>();
+        services.AddScoped<GetAccountsQueryHandler>();
+        services.AddScoped<GetAccountByIdQueryHandler>();
+        services.AddScoped<CreateAccountCommandHandler>();
+        services.AddScoped<UpdateAccountCommandHandler>();
+        services.AddScoped<DeactivateAccountCommandHandler>();
+        services.AddScoped<GetCampaignsQueryHandler>();
+        services.AddScoped<GetCampaignByIdQueryHandler>();
+        services.AddScoped<CreateCampaignCommandHandler>();
+        services.AddScoped<UpdateCampaignCommandHandler>();
+        services.AddScoped<DeactivateCampaignCommandHandler>();
+        services.AddScoped<GetUserScopesQueryHandler>();
+        services.AddScoped<UpdateUserScopesCommandHandler>();
 
         return services;
     }

--- a/src/OpsSphere.Application/Features/OrganizationManagement/OrganizationManagementCommands.cs
+++ b/src/OpsSphere.Application/Features/OrganizationManagement/OrganizationManagementCommands.cs
@@ -1,0 +1,35 @@
+namespace OpsSphere.Application.Features.OrganizationManagement;
+
+public sealed record GetRegionsQuery;
+public sealed record GetRegionByIdQuery(Guid Id);
+public sealed record CreateRegionCommand(string? Code, string? Name);
+public sealed record UpdateRegionCommand(Guid Id, string? Code, string? Name);
+public sealed record DeactivateRegionCommand(Guid Id);
+
+public sealed record GetCountriesQuery;
+public sealed record GetCountryByIdQuery(Guid Id);
+public sealed record CreateCountryCommand(Guid RegionId, string? Code, string? Name);
+public sealed record UpdateCountryCommand(Guid Id, Guid RegionId, string? Code, string? Name);
+public sealed record DeactivateCountryCommand(Guid Id);
+
+public sealed record GetAccountsQuery;
+public sealed record GetAccountByIdQuery(Guid Id);
+public sealed record CreateAccountCommand(Guid CountryId, string? Code, string? Name, string? Description);
+public sealed record UpdateAccountCommand(Guid Id, Guid CountryId, string? Code, string? Name, string? Description);
+public sealed record DeactivateAccountCommand(Guid Id);
+
+public sealed record GetCampaignsQuery;
+public sealed record GetCampaignByIdQuery(Guid Id);
+public sealed record CreateCampaignCommand(Guid AccountId, Guid CountryId, string? Code, string? Name, string? Description);
+public sealed record UpdateCampaignCommand(Guid Id, Guid AccountId, Guid CountryId, string? Code, string? Name, string? Description);
+public sealed record DeactivateCampaignCommand(Guid Id);
+
+public sealed record GetUserScopesQuery(Guid UserId);
+public sealed record UpdateUserScopesCommand(Guid UserId, IReadOnlyCollection<UserScopeUpsertDto>? Scopes);
+
+public sealed record UserScopeUpsertDto(
+    string? ScopeType,
+    Guid? RegionId,
+    Guid? CountryId,
+    Guid? AccountId,
+    Guid? CampaignId);

--- a/src/OpsSphere.Application/Features/OrganizationManagement/OrganizationManagementDtos.cs
+++ b/src/OpsSphere.Application/Features/OrganizationManagement/OrganizationManagementDtos.cs
@@ -1,0 +1,65 @@
+namespace OpsSphere.Application.Features.OrganizationManagement;
+
+public sealed record RegionDto(Guid Id, string Code, string Name, bool IsActive, DateTime CreatedAt, DateTime? UpdatedAt);
+
+public sealed record CountryDto(
+    Guid Id,
+    Guid RegionId,
+    string RegionCode,
+    string RegionName,
+    string Code,
+    string Name,
+    bool IsActive,
+    DateTime CreatedAt,
+    DateTime? UpdatedAt);
+
+public sealed record AccountDto(
+    Guid Id,
+    Guid CountryId,
+    string CountryCode,
+    string CountryName,
+    Guid RegionId,
+    string RegionCode,
+    string Code,
+    string Name,
+    string? Description,
+    bool IsActive,
+    DateTime CreatedAt,
+    DateTime? UpdatedAt);
+
+public sealed record CampaignDto(
+    Guid Id,
+    Guid AccountId,
+    string AccountCode,
+    string AccountName,
+    Guid CountryId,
+    string CountryCode,
+    string CountryName,
+    Guid RegionId,
+    string RegionCode,
+    string Code,
+    string Name,
+    string? Description,
+    bool IsActive,
+    DateTime CreatedAt,
+    DateTime? UpdatedAt);
+
+public sealed record UserScopeAssignmentDto(Guid UserId, string Email, string DisplayName, bool IsActive, IReadOnlyList<string> Roles, IReadOnlyList<UserScopeDto> Scopes);
+
+public sealed record UserScopeDto(
+    Guid Id,
+    string ScopeType,
+    Guid? RegionId,
+    string? RegionCode,
+    string? RegionName,
+    Guid? CountryId,
+    string? CountryCode,
+    string? CountryName,
+    Guid? AccountId,
+    string? AccountCode,
+    string? AccountName,
+    Guid? CampaignId,
+    string? CampaignCode,
+    string? CampaignName,
+    bool IsActive,
+    DateTime CreatedAt);

--- a/src/OpsSphere.Application/Features/OrganizationManagement/OrganizationManagementHandlers.cs
+++ b/src/OpsSphere.Application/Features/OrganizationManagement/OrganizationManagementHandlers.cs
@@ -1,0 +1,368 @@
+using System.Text.Json;
+using OpsSphere.Application.Common.Exceptions;
+using OpsSphere.Application.Common.Interfaces;
+using OpsSphere.Domain.Authorization;
+
+namespace OpsSphere.Application.Features.OrganizationManagement;
+
+public sealed class GetRegionsQueryHandler(IOrganizationManagementRepository repository)
+{
+    public Task<IReadOnlyList<RegionDto>> HandleAsync(GetRegionsQuery query, CancellationToken cancellationToken) =>
+        repository.GetRegionsAsync(cancellationToken);
+}
+
+public sealed class GetRegionByIdQueryHandler(IOrganizationManagementRepository repository)
+{
+    public async Task<RegionDto> HandleAsync(GetRegionByIdQuery query, CancellationToken cancellationToken) =>
+        await repository.GetRegionByIdAsync(query.Id, cancellationToken) ?? throw new NotFoundException("Region", query.Id);
+}
+
+public sealed class CreateRegionCommandHandler(IOrganizationManagementRepository repository, IAuditWriter auditWriter)
+{
+    public async Task<RegionDto> HandleAsync(CreateRegionCommand command, CancellationToken cancellationToken)
+    {
+        var (code, name) = await OrganizationValidation.NormalizeCodeNameAsync(command.Code, command.Name, "region", null, repository.RegionCodeExistsAsync, cancellationToken);
+        var id = Guid.NewGuid();
+        await repository.AddRegionAsync(new OrganizationEntityCreateModel(id, code, name), cancellationToken);
+        await auditWriter.WriteAsync("RegionCreated", "Region", id, null, OrganizationAuditJson.Serialize(new { code, name, IsActive = true }), cancellationToken);
+        await repository.SaveChangesAsync(cancellationToken);
+        return await repository.GetRegionByIdAsync(id, cancellationToken) ?? throw new NotFoundException("Region", id);
+    }
+}
+
+public sealed class UpdateRegionCommandHandler(IOrganizationManagementRepository repository, IAuditWriter auditWriter)
+{
+    public async Task<RegionDto> HandleAsync(UpdateRegionCommand command, CancellationToken cancellationToken)
+    {
+        var existing = await repository.GetRegionSnapshotAsync(command.Id, cancellationToken) ?? throw new NotFoundException("Region", command.Id);
+        var (code, name) = await OrganizationValidation.NormalizeCodeNameAsync(command.Code, command.Name, "region", command.Id, repository.RegionCodeExistsAsync, cancellationToken);
+        await repository.UpdateRegionAsync(command.Id, code, name, cancellationToken);
+        await auditWriter.WriteAsync("RegionUpdated", "Region", command.Id, OrganizationAuditJson.Serialize(existing), OrganizationAuditJson.Serialize(new { code, name, existing.IsActive }), cancellationToken);
+        await repository.SaveChangesAsync(cancellationToken);
+        return await repository.GetRegionByIdAsync(command.Id, cancellationToken) ?? throw new NotFoundException("Region", command.Id);
+    }
+}
+
+public sealed class DeactivateRegionCommandHandler(IOrganizationManagementRepository repository, IAuditWriter auditWriter)
+{
+    public async Task HandleAsync(DeactivateRegionCommand command, CancellationToken cancellationToken)
+    {
+        var existing = await repository.GetRegionSnapshotAsync(command.Id, cancellationToken) ?? throw new NotFoundException("Region", command.Id);
+        if (!existing.IsActive) return;
+        if (await repository.HasActiveCountriesAsync(command.Id, cancellationToken)) throw new BusinessRuleException("Region cannot be deactivated while active countries exist.");
+        await repository.DeactivateRegionAsync(command.Id, cancellationToken);
+        await auditWriter.WriteAsync("RegionDeactivated", "Region", command.Id, OrganizationAuditJson.Serialize(new { existing.IsActive }), OrganizationAuditJson.Serialize(new { IsActive = false }), cancellationToken);
+        await repository.SaveChangesAsync(cancellationToken);
+    }
+}
+
+public sealed class GetCountriesQueryHandler(IOrganizationManagementRepository repository)
+{
+    public Task<IReadOnlyList<CountryDto>> HandleAsync(GetCountriesQuery query, CancellationToken cancellationToken) => repository.GetCountriesAsync(cancellationToken);
+}
+
+public sealed class GetCountryByIdQueryHandler(IOrganizationManagementRepository repository)
+{
+    public async Task<CountryDto> HandleAsync(GetCountryByIdQuery query, CancellationToken cancellationToken) =>
+        await repository.GetCountryByIdAsync(query.Id, cancellationToken) ?? throw new NotFoundException("Country", query.Id);
+}
+
+public sealed class CreateCountryCommandHandler(IOrganizationManagementRepository repository, IAuditWriter auditWriter)
+{
+    public async Task<CountryDto> HandleAsync(CreateCountryCommand command, CancellationToken cancellationToken)
+    {
+        var parent = await repository.GetRegionSnapshotAsync(command.RegionId, cancellationToken) ?? throw new ValidationException("regionId", "Region must exist.");
+        if (!parent.IsActive) throw new ValidationException("regionId", "Country parent region must be active.");
+        var (code, name) = await OrganizationValidation.NormalizeCodeNameAsync(command.Code, command.Name, "country", null, repository.CountryCodeExistsAsync, cancellationToken);
+        var id = Guid.NewGuid();
+        await repository.AddCountryAsync(new CountryCreateModel(id, command.RegionId, code, name), cancellationToken);
+        await auditWriter.WriteAsync("CountryCreated", "Country", id, null, OrganizationAuditJson.Serialize(new { command.RegionId, code, name, IsActive = true }), cancellationToken);
+        await repository.SaveChangesAsync(cancellationToken);
+        return await repository.GetCountryByIdAsync(id, cancellationToken) ?? throw new NotFoundException("Country", id);
+    }
+}
+
+public sealed class UpdateCountryCommandHandler(IOrganizationManagementRepository repository, IAuditWriter auditWriter)
+{
+    public async Task<CountryDto> HandleAsync(UpdateCountryCommand command, CancellationToken cancellationToken)
+    {
+        var existing = await repository.GetCountrySnapshotAsync(command.Id, cancellationToken) ?? throw new NotFoundException("Country", command.Id);
+        var parent = await repository.GetRegionSnapshotAsync(command.RegionId, cancellationToken) ?? throw new ValidationException("regionId", "Region must exist.");
+        if (!parent.IsActive) throw new ValidationException("regionId", "Country parent region must be active.");
+        var (code, name) = await OrganizationValidation.NormalizeCodeNameAsync(command.Code, command.Name, "country", command.Id, repository.CountryCodeExistsAsync, cancellationToken);
+        await repository.UpdateCountryAsync(command.Id, command.RegionId, code, name, cancellationToken);
+        await auditWriter.WriteAsync("CountryUpdated", "Country", command.Id, OrganizationAuditJson.Serialize(existing), OrganizationAuditJson.Serialize(new { command.RegionId, code, name, existing.IsActive }), cancellationToken);
+        await repository.SaveChangesAsync(cancellationToken);
+        return await repository.GetCountryByIdAsync(command.Id, cancellationToken) ?? throw new NotFoundException("Country", command.Id);
+    }
+}
+
+public sealed class DeactivateCountryCommandHandler(IOrganizationManagementRepository repository, IAuditWriter auditWriter)
+{
+    public async Task HandleAsync(DeactivateCountryCommand command, CancellationToken cancellationToken)
+    {
+        var existing = await repository.GetCountrySnapshotAsync(command.Id, cancellationToken) ?? throw new NotFoundException("Country", command.Id);
+        if (!existing.IsActive) return;
+        if (await repository.HasActiveAccountsOrCampaignsAsync(command.Id, cancellationToken)) throw new BusinessRuleException("Country cannot be deactivated while active accounts or campaigns exist.");
+        await repository.DeactivateCountryAsync(command.Id, cancellationToken);
+        await auditWriter.WriteAsync("CountryDeactivated", "Country", command.Id, OrganizationAuditJson.Serialize(new { existing.IsActive }), OrganizationAuditJson.Serialize(new { IsActive = false }), cancellationToken);
+        await repository.SaveChangesAsync(cancellationToken);
+    }
+}
+
+public sealed class GetAccountsQueryHandler(IOrganizationManagementRepository repository)
+{
+    public Task<IReadOnlyList<AccountDto>> HandleAsync(GetAccountsQuery query, CancellationToken cancellationToken) => repository.GetAccountsAsync(cancellationToken);
+}
+
+public sealed class GetAccountByIdQueryHandler(IOrganizationManagementRepository repository)
+{
+    public async Task<AccountDto> HandleAsync(GetAccountByIdQuery query, CancellationToken cancellationToken) =>
+        await repository.GetAccountByIdAsync(query.Id, cancellationToken) ?? throw new NotFoundException("Account", query.Id);
+}
+
+public sealed class CreateAccountCommandHandler(IOrganizationManagementRepository repository, IAuditWriter auditWriter)
+{
+    public async Task<AccountDto> HandleAsync(CreateAccountCommand command, CancellationToken cancellationToken)
+    {
+        var country = await repository.GetCountrySnapshotAsync(command.CountryId, cancellationToken) ?? throw new ValidationException("countryId", "Country must exist.");
+        if (!country.IsActive) throw new ValidationException("countryId", "Account parent country must be active.");
+        var (code, name) = await OrganizationValidation.NormalizeCodeNameAsync(command.Code, command.Name, "account", null, repository.AccountCodeExistsAsync, cancellationToken);
+        var description = OrganizationValidation.NormalizeDescription(command.Description);
+        var id = Guid.NewGuid();
+        await repository.AddAccountAsync(new AccountCreateModel(id, command.CountryId, code, name, description), cancellationToken);
+        await auditWriter.WriteAsync("AccountCreated", "Account", id, null, OrganizationAuditJson.Serialize(new { command.CountryId, code, name, description, IsActive = true }), cancellationToken);
+        await repository.SaveChangesAsync(cancellationToken);
+        return await repository.GetAccountByIdAsync(id, cancellationToken) ?? throw new NotFoundException("Account", id);
+    }
+}
+
+public sealed class UpdateAccountCommandHandler(IOrganizationManagementRepository repository, IAuditWriter auditWriter)
+{
+    public async Task<AccountDto> HandleAsync(UpdateAccountCommand command, CancellationToken cancellationToken)
+    {
+        var existing = await repository.GetAccountSnapshotAsync(command.Id, cancellationToken) ?? throw new NotFoundException("Account", command.Id);
+        var country = await repository.GetCountrySnapshotAsync(command.CountryId, cancellationToken) ?? throw new ValidationException("countryId", "Country must exist.");
+        if (!country.IsActive) throw new ValidationException("countryId", "Account parent country must be active.");
+        var (code, name) = await OrganizationValidation.NormalizeCodeNameAsync(command.Code, command.Name, "account", command.Id, repository.AccountCodeExistsAsync, cancellationToken);
+        var description = OrganizationValidation.NormalizeDescription(command.Description);
+        await repository.UpdateAccountAsync(command.Id, command.CountryId, code, name, description, cancellationToken);
+        await auditWriter.WriteAsync("AccountUpdated", "Account", command.Id, OrganizationAuditJson.Serialize(existing), OrganizationAuditJson.Serialize(new { command.CountryId, code, name, description, existing.IsActive }), cancellationToken);
+        await repository.SaveChangesAsync(cancellationToken);
+        return await repository.GetAccountByIdAsync(command.Id, cancellationToken) ?? throw new NotFoundException("Account", command.Id);
+    }
+}
+
+public sealed class DeactivateAccountCommandHandler(IOrganizationManagementRepository repository, IAuditWriter auditWriter)
+{
+    public async Task HandleAsync(DeactivateAccountCommand command, CancellationToken cancellationToken)
+    {
+        var existing = await repository.GetAccountSnapshotAsync(command.Id, cancellationToken) ?? throw new NotFoundException("Account", command.Id);
+        if (!existing.IsActive) return;
+        if (await repository.HasActiveCampaignsAsync(command.Id, cancellationToken)) throw new BusinessRuleException("Account cannot be deactivated while active campaigns exist.");
+        await repository.DeactivateAccountAsync(command.Id, cancellationToken);
+        await auditWriter.WriteAsync("AccountDeactivated", "Account", command.Id, OrganizationAuditJson.Serialize(new { existing.IsActive }), OrganizationAuditJson.Serialize(new { IsActive = false }), cancellationToken);
+        await repository.SaveChangesAsync(cancellationToken);
+    }
+}
+
+public sealed class GetCampaignsQueryHandler(IOrganizationManagementRepository repository)
+{
+    public Task<IReadOnlyList<CampaignDto>> HandleAsync(GetCampaignsQuery query, CancellationToken cancellationToken) => repository.GetCampaignsAsync(cancellationToken);
+}
+
+public sealed class GetCampaignByIdQueryHandler(IOrganizationManagementRepository repository)
+{
+    public async Task<CampaignDto> HandleAsync(GetCampaignByIdQuery query, CancellationToken cancellationToken) =>
+        await repository.GetCampaignByIdAsync(query.Id, cancellationToken) ?? throw new NotFoundException("Campaign", query.Id);
+}
+
+public sealed class CreateCampaignCommandHandler(IOrganizationManagementRepository repository, IAuditWriter auditWriter)
+{
+    public async Task<CampaignDto> HandleAsync(CreateCampaignCommand command, CancellationToken cancellationToken)
+    {
+        var (account, country) = await ValidateCampaignParentsAsync(command.AccountId, command.CountryId, cancellationToken);
+        var (code, name) = await OrganizationValidation.NormalizeCodeNameAsync(command.Code, command.Name, "campaign", null, repository.CampaignCodeExistsAsync, cancellationToken);
+        var description = OrganizationValidation.NormalizeDescription(command.Description);
+        var id = Guid.NewGuid();
+        await repository.AddCampaignAsync(new CampaignCreateModel(id, command.AccountId, command.CountryId, code, name, description), cancellationToken);
+        await auditWriter.WriteAsync("CampaignCreated", "Campaign", id, null, OrganizationAuditJson.Serialize(new { command.AccountId, command.CountryId, code, name, description, IsActive = true }), cancellationToken);
+        await repository.SaveChangesAsync(cancellationToken);
+        return await repository.GetCampaignByIdAsync(id, cancellationToken) ?? throw new NotFoundException("Campaign", id);
+
+        async Task<(AccountSnapshot Account, CountrySnapshot Country)> ValidateCampaignParentsAsync(Guid accountId, Guid countryId, CancellationToken ct)
+        {
+            var account = await repository.GetAccountSnapshotAsync(accountId, ct) ?? throw new ValidationException("accountId", "Account must exist.");
+            var country = await repository.GetCountrySnapshotAsync(countryId, ct) ?? throw new ValidationException("countryId", "Country must exist.");
+            if (!account.IsActive) throw new ValidationException("accountId", "Campaign parent account must be active.");
+            if (!country.IsActive) throw new ValidationException("countryId", "Campaign country must be active.");
+            if (account.CountryId != countryId) throw new ValidationException("countryId", "Campaign country must match the account country.");
+            return (account, country);
+        }
+    }
+}
+
+public sealed class UpdateCampaignCommandHandler(IOrganizationManagementRepository repository, IAuditWriter auditWriter)
+{
+    public async Task<CampaignDto> HandleAsync(UpdateCampaignCommand command, CancellationToken cancellationToken)
+    {
+        var existing = await repository.GetCampaignSnapshotAsync(command.Id, cancellationToken) ?? throw new NotFoundException("Campaign", command.Id);
+        var account = await repository.GetAccountSnapshotAsync(command.AccountId, cancellationToken) ?? throw new ValidationException("accountId", "Account must exist.");
+        var country = await repository.GetCountrySnapshotAsync(command.CountryId, cancellationToken) ?? throw new ValidationException("countryId", "Country must exist.");
+        if (!account.IsActive) throw new ValidationException("accountId", "Campaign parent account must be active.");
+        if (!country.IsActive) throw new ValidationException("countryId", "Campaign country must be active.");
+        if (account.CountryId != command.CountryId) throw new ValidationException("countryId", "Campaign country must match the account country.");
+        var (code, name) = await OrganizationValidation.NormalizeCodeNameAsync(command.Code, command.Name, "campaign", command.Id, repository.CampaignCodeExistsAsync, cancellationToken);
+        var description = OrganizationValidation.NormalizeDescription(command.Description);
+        await repository.UpdateCampaignAsync(command.Id, command.AccountId, command.CountryId, code, name, description, cancellationToken);
+        await auditWriter.WriteAsync("CampaignUpdated", "Campaign", command.Id, OrganizationAuditJson.Serialize(existing), OrganizationAuditJson.Serialize(new { command.AccountId, command.CountryId, code, name, description, existing.IsActive }), cancellationToken);
+        await repository.SaveChangesAsync(cancellationToken);
+        return await repository.GetCampaignByIdAsync(command.Id, cancellationToken) ?? throw new NotFoundException("Campaign", command.Id);
+    }
+}
+
+public sealed class DeactivateCampaignCommandHandler(IOrganizationManagementRepository repository, IAuditWriter auditWriter)
+{
+    public async Task HandleAsync(DeactivateCampaignCommand command, CancellationToken cancellationToken)
+    {
+        var existing = await repository.GetCampaignSnapshotAsync(command.Id, cancellationToken) ?? throw new NotFoundException("Campaign", command.Id);
+        if (!existing.IsActive) return;
+        await repository.DeactivateCampaignAsync(command.Id, cancellationToken);
+        await auditWriter.WriteAsync("CampaignDeactivated", "Campaign", command.Id, OrganizationAuditJson.Serialize(new { existing.IsActive }), OrganizationAuditJson.Serialize(new { IsActive = false }), cancellationToken);
+        await repository.SaveChangesAsync(cancellationToken);
+    }
+}
+
+public sealed class GetUserScopesQueryHandler(IOrganizationManagementRepository repository)
+{
+    public async Task<UserScopeAssignmentDto> HandleAsync(GetUserScopesQuery query, CancellationToken cancellationToken) =>
+        await repository.GetUserScopesAsync(query.UserId, cancellationToken) ?? throw new NotFoundException("User", query.UserId);
+}
+
+public sealed class UpdateUserScopesCommandHandler(IOrganizationManagementRepository repository, IAuditWriter auditWriter, ICurrentUserContext currentUserContext)
+{
+    public async Task<UserScopeAssignmentDto> HandleAsync(UpdateUserScopesCommand command, CancellationToken cancellationToken)
+    {
+        if (command.Scopes is null) throw new ValidationException("scopes", "Scopes are required.");
+        var scopes = NormalizeScopes(command.Scopes);
+        var user = await repository.GetScopeAssignmentUserAsync(command.UserId, cancellationToken) ?? throw new NotFoundException("User", command.UserId);
+        if (!user.IsActive) throw new ValidationException("userId", "Scopes can only be assigned to an active user.");
+        ValidateRoleEligibility(user.Roles, scopes);
+        var missing = await repository.GetMissingOrInactiveScopeTargetsAsync(scopes, cancellationToken);
+        if (missing.Count > 0) throw new ValidationException("scopes", "All scope targets must exist and be active.");
+
+        var changes = await repository.ReplaceUserScopesAsync(command.UserId, scopes, currentUserContext.UserId, cancellationToken);
+        foreach (var change in changes)
+        {
+            await auditWriter.WriteAsync(
+                change.Action,
+                "User",
+                command.UserId,
+                change.Action == "UserScopeDeactivated" ? OrganizationAuditJson.Serialize(change.Scope) : null,
+                change.Action == "UserScopeDeactivated" ? null : OrganizationAuditJson.Serialize(change.Scope),
+                cancellationToken);
+        }
+
+        await repository.SaveChangesAsync(cancellationToken);
+        return await repository.GetUserScopesAsync(command.UserId, cancellationToken) ?? throw new NotFoundException("User", command.UserId);
+    }
+
+    private static IReadOnlyList<UserScopeUpsertDto> NormalizeScopes(IReadOnlyCollection<UserScopeUpsertDto> requested)
+    {
+        var normalized = new List<UserScopeUpsertDto>();
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var scope in requested)
+        {
+            var scopeType = scope.ScopeType?.Trim();
+            var entityId = scopeType switch
+            {
+                ScopeTypes.Region => scope.RegionId,
+                ScopeTypes.Country => scope.CountryId,
+                ScopeTypes.Account => scope.AccountId,
+                ScopeTypes.Campaign => scope.CampaignId,
+                _ => null
+            };
+
+            if (!ScopeTypes.All.Contains(scopeType, StringComparer.Ordinal) || !entityId.HasValue)
+            {
+                throw new ValidationException("scopes", "Each scope must include a valid scope type and matching entity ID.");
+            }
+
+            var key = $"{scopeType}:{entityId.Value}";
+            if (keys.Add(key))
+            {
+                normalized.Add(scopeType switch
+                {
+                    ScopeTypes.Region => new UserScopeUpsertDto(scopeType, entityId, null, null, null),
+                    ScopeTypes.Country => new UserScopeUpsertDto(scopeType, null, entityId, null, null),
+                    ScopeTypes.Account => new UserScopeUpsertDto(scopeType, null, null, entityId, null),
+                    _ => new UserScopeUpsertDto(scopeType, null, null, null, entityId)
+                });
+            }
+        }
+
+        return normalized;
+    }
+
+    private static void ValidateRoleEligibility(IReadOnlyList<string> roles, IReadOnlyList<UserScopeUpsertDto> scopes)
+    {
+        if (roles.Contains(Roles.Admin, StringComparer.Ordinal) && scopes.Count > 0)
+        {
+            throw new ValidationException("scopes", "Admin users do not require operational scopes.");
+        }
+
+        if (scopes.Count == 0) return;
+        if (roles.Count == 0) throw new ValidationException("scopes", "Target user must have an eligible role for scopes.");
+
+        foreach (var scope in scopes)
+        {
+            var eligible = scope.ScopeType switch
+            {
+                ScopeTypes.Region => roles.Contains(Roles.OperationsManager, StringComparer.Ordinal) || roles.Contains(Roles.Viewer, StringComparer.Ordinal),
+                ScopeTypes.Country => roles.Contains(Roles.Viewer, StringComparer.Ordinal),
+                ScopeTypes.Account or ScopeTypes.Campaign => roles.Contains(Roles.Supervisor, StringComparer.Ordinal) || roles.Contains(Roles.Agent, StringComparer.Ordinal) || roles.Contains(Roles.Viewer, StringComparer.Ordinal),
+                _ => false
+            };
+
+            if (!eligible)
+            {
+                throw new ValidationException("scopes", "One or more scopes are not eligible for the target user's role.");
+            }
+        }
+    }
+}
+
+internal static class OrganizationValidation
+{
+    public static async Task<(string Code, string Name)> NormalizeCodeNameAsync(
+        string? code,
+        string? name,
+        string entityName,
+        Guid? excludingId,
+        Func<string, Guid?, CancellationToken, Task<bool>> codeExistsAsync,
+        CancellationToken cancellationToken)
+    {
+        var failures = new List<ValidationFailure>();
+        if (string.IsNullOrWhiteSpace(code)) failures.Add(new ValidationFailure("code", "Code is required."));
+        else if (code.Trim().Length > 50) failures.Add(new ValidationFailure("code", "Code must be 50 characters or fewer."));
+        if (string.IsNullOrWhiteSpace(name)) failures.Add(new ValidationFailure("name", "Name is required."));
+        else if (name.Trim().Length > 200) failures.Add(new ValidationFailure("name", "Name must be 200 characters or fewer."));
+        if (failures.Count > 0) throw new ValidationException(failures);
+
+        var normalizedCode = code!.Trim().ToUpperInvariant();
+        if (await codeExistsAsync(normalizedCode, excludingId, cancellationToken))
+        {
+            throw new ConflictException($"A {entityName} with this code already exists.");
+        }
+
+        return (normalizedCode, name!.Trim());
+    }
+
+    public static string? NormalizeDescription(string? description) =>
+        string.IsNullOrWhiteSpace(description) ? null : description.Trim();
+}
+
+internal static class OrganizationAuditJson
+{
+    public static string Serialize(object value) => JsonSerializer.Serialize(value, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+}

--- a/src/OpsSphere.Infrastructure/Authorization/ScopedQueryExtensions.cs
+++ b/src/OpsSphere.Infrastructure/Authorization/ScopedQueryExtensions.cs
@@ -22,9 +22,42 @@ public static class ScopedQueryExtensions
         if (profile.HasRole(Roles.Admin)) return query;
 
         var regionIds = GetAuthorizedRegionIds(profile.Scopes);
-        if (regionIds.Count == 0) return query.Where(_ => false);
+        var countryIds = GetDirectCountryIds(profile.Scopes);
+        var accountIds = GetDirectAccountIds(profile.Scopes);
+        var campaignIds = GetDirectCampaignIds(profile.Scopes);
+        if (regionIds.Count == 0 && countryIds.Count == 0 && accountIds.Count == 0 && campaignIds.Count == 0)
+            return query.Where(_ => false);
 
-        return query.Where(r => regionIds.Contains(r.Id));
+        return query.Where(r =>
+            (regionIds.Count > 0 && regionIds.Contains(r.Id)) ||
+            (countryIds.Count > 0 && r.Countries.Any(c => countryIds.Contains(c.Id))) ||
+            (accountIds.Count > 0 && r.Countries.Any(c => c.Accounts.Any(a => accountIds.Contains(a.Id)))) ||
+            (campaignIds.Count > 0 && r.Countries.Any(c => c.Campaigns.Any(campaign => campaignIds.Contains(campaign.Id)))));
+    }
+
+    /// <summary>
+    /// Filters countries to only those accessible by the given profile.
+    /// Hierarchy: Region -> Country.
+    /// </summary>
+    public static IQueryable<Country> ApplyScopeFilter(
+        this IQueryable<Country> query,
+        CurrentUserAuthorizationProfile profile)
+    {
+        if (profile.HasRole(Roles.Admin)) return query;
+
+        var countryIds = GetDirectCountryIds(profile.Scopes);
+        var accountIds = GetDirectAccountIds(profile.Scopes);
+        var campaignIds = GetDirectCampaignIds(profile.Scopes);
+        var regionIds = GetAuthorizedRegionIds(profile.Scopes);
+
+        if (countryIds.Count == 0 && accountIds.Count == 0 && campaignIds.Count == 0 && regionIds.Count == 0)
+            return query.Where(_ => false);
+
+        return query.Where(c =>
+            (countryIds.Count > 0 && countryIds.Contains(c.Id)) ||
+            (accountIds.Count > 0 && c.Accounts.Any(a => accountIds.Contains(a.Id))) ||
+            (campaignIds.Count > 0 && c.Campaigns.Any(campaign => campaignIds.Contains(campaign.Id))) ||
+            (regionIds.Count > 0 && regionIds.Contains(c.RegionId)));
     }
 
     /// <summary>
@@ -38,14 +71,16 @@ public static class ScopedQueryExtensions
         if (profile.HasRole(Roles.Admin)) return query;
 
         var accountIds = GetDirectAccountIds(profile.Scopes);
+        var campaignIds = GetDirectCampaignIds(profile.Scopes);
         var countryIds = GetDirectCountryIds(profile.Scopes);
         var regionIds = GetAuthorizedRegionIds(profile.Scopes);
 
-        if (accountIds.Count == 0 && countryIds.Count == 0 && regionIds.Count == 0)
+        if (accountIds.Count == 0 && campaignIds.Count == 0 && countryIds.Count == 0 && regionIds.Count == 0)
             return query.Where(_ => false);
 
         return query.Where(a =>
             (accountIds.Count > 0 && accountIds.Contains(a.Id)) ||
+            (campaignIds.Count > 0 && a.Campaigns.Any(c => campaignIds.Contains(c.Id))) ||
             (countryIds.Count > 0 && countryIds.Contains(a.CountryId)) ||
             (regionIds.Count > 0 && regionIds.Contains(a.Country.RegionId)));
     }

--- a/src/OpsSphere.Infrastructure/DependencyInjection.cs
+++ b/src/OpsSphere.Infrastructure/DependencyInjection.cs
@@ -8,6 +8,7 @@ using OpsSphere.Domain.Entities;
 using OpsSphere.Infrastructure.Authentication;
 using OpsSphere.Infrastructure.Authorization;
 using OpsSphere.Infrastructure.Identity;
+using OpsSphere.Infrastructure.OrganizationManagement;
 using OpsSphere.Infrastructure.Persistence;
 using OpsSphere.Infrastructure.Persistence.SeedData;
 using OpsSphere.Infrastructure.UserManagement;
@@ -43,6 +44,7 @@ public static class DependencyInjection
         services.AddScoped<IAuthUserReader, AuthUserReader>();
         services.AddScoped<IAuthUnitOfWork, AuthUnitOfWork>();
         services.AddScoped<IUserManagementRepository, UserManagementRepository>();
+        services.AddScoped<IOrganizationManagementRepository, OrganizationManagementRepository>();
         services.AddScoped<IAuditWriter, AuditWriter>();
         services.AddScoped<OpsSphereDataSeeder>();
 

--- a/src/OpsSphere.Infrastructure/OrganizationManagement/OrganizationManagementRepository.cs
+++ b/src/OpsSphere.Infrastructure/OrganizationManagement/OrganizationManagementRepository.cs
@@ -1,0 +1,316 @@
+using Microsoft.EntityFrameworkCore;
+using OpsSphere.Application.Common.Authorization;
+using OpsSphere.Application.Common.Interfaces;
+using OpsSphere.Application.Features.OrganizationManagement;
+using OpsSphere.Domain.Authorization;
+using OpsSphere.Domain.Entities;
+using OpsSphere.Infrastructure.Authorization;
+using OpsSphere.Infrastructure.Persistence;
+
+namespace OpsSphere.Infrastructure.OrganizationManagement;
+
+internal sealed class OrganizationManagementRepository : IOrganizationManagementRepository
+{
+    private readonly OpsSphereDbContext dbContext;
+    private readonly ICurrentUserAuthorizationService authorizationService;
+
+    public OrganizationManagementRepository(OpsSphereDbContext dbContext, ICurrentUserAuthorizationService authorizationService)
+    {
+        this.dbContext = dbContext;
+        this.authorizationService = authorizationService;
+    }
+
+    public async Task<IReadOnlyList<RegionDto>> GetRegionsAsync(CancellationToken cancellationToken) =>
+        await ApplyScope(await GetProfileAsync(cancellationToken), dbContext.Regions.AsNoTracking())
+            .OrderBy(r => r.Code)
+            .Select(r => new RegionDto(r.Id, r.Code, r.Name, r.IsActive, r.CreatedAt, r.UpdatedAt))
+            .ToArrayAsync(cancellationToken);
+
+    public async Task<RegionDto?> GetRegionByIdAsync(Guid id, CancellationToken cancellationToken) =>
+        await ApplyScope(await GetProfileAsync(cancellationToken), dbContext.Regions.AsNoTracking())
+            .Where(r => r.Id == id)
+            .Select(r => new RegionDto(r.Id, r.Code, r.Name, r.IsActive, r.CreatedAt, r.UpdatedAt))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public async Task<RegionSnapshot?> GetRegionSnapshotAsync(Guid id, CancellationToken cancellationToken) =>
+        await dbContext.Regions.AsNoTracking().Where(r => r.Id == id)
+            .Select(r => new RegionSnapshot(r.Id, r.Code, r.Name, r.IsActive))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public Task<bool> RegionCodeExistsAsync(string code, Guid? excludingId, CancellationToken cancellationToken) =>
+        dbContext.Regions.AnyAsync(r => r.Code == code && (!excludingId.HasValue || r.Id != excludingId.Value), cancellationToken);
+
+    public Task AddRegionAsync(OrganizationEntityCreateModel model, CancellationToken cancellationToken)
+    {
+        dbContext.Regions.Add(new Region { Id = model.Id, Code = model.Code, Name = model.Name, IsActive = true });
+        return Task.CompletedTask;
+    }
+
+    public async Task UpdateRegionAsync(Guid id, string code, string name, CancellationToken cancellationToken)
+    {
+        var region = await dbContext.Regions.FirstAsync(r => r.Id == id, cancellationToken);
+        region.Code = code;
+        region.Name = name;
+    }
+
+    public Task<bool> HasActiveCountriesAsync(Guid regionId, CancellationToken cancellationToken) =>
+        dbContext.Countries.AnyAsync(c => c.RegionId == regionId && c.IsActive, cancellationToken);
+
+    public async Task DeactivateRegionAsync(Guid id, CancellationToken cancellationToken) =>
+        (await dbContext.Regions.FirstAsync(r => r.Id == id, cancellationToken)).IsActive = false;
+
+    public async Task<IReadOnlyList<CountryDto>> GetCountriesAsync(CancellationToken cancellationToken) =>
+        await ApplyScope(await GetProfileAsync(cancellationToken), dbContext.Countries.AsNoTracking())
+            .OrderBy(c => c.Code)
+            .Select(c => new CountryDto(c.Id, c.RegionId, c.Region.Code, c.Region.Name, c.Code, c.Name, c.IsActive, c.CreatedAt, c.UpdatedAt))
+            .ToArrayAsync(cancellationToken);
+
+    public async Task<CountryDto?> GetCountryByIdAsync(Guid id, CancellationToken cancellationToken) =>
+        await ApplyScope(await GetProfileAsync(cancellationToken), dbContext.Countries.AsNoTracking())
+            .Where(c => c.Id == id)
+            .Select(c => new CountryDto(c.Id, c.RegionId, c.Region.Code, c.Region.Name, c.Code, c.Name, c.IsActive, c.CreatedAt, c.UpdatedAt))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public async Task<CountrySnapshot?> GetCountrySnapshotAsync(Guid id, CancellationToken cancellationToken) =>
+        await dbContext.Countries.AsNoTracking().Where(c => c.Id == id)
+            .Select(c => new CountrySnapshot(c.Id, c.RegionId, c.Code, c.Name, c.IsActive))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public Task<bool> CountryCodeExistsAsync(string code, Guid? excludingId, CancellationToken cancellationToken) =>
+        dbContext.Countries.AnyAsync(c => c.Code == code && (!excludingId.HasValue || c.Id != excludingId.Value), cancellationToken);
+
+    public Task AddCountryAsync(CountryCreateModel model, CancellationToken cancellationToken)
+    {
+        dbContext.Countries.Add(new Country { Id = model.Id, RegionId = model.RegionId, Code = model.Code, Name = model.Name, IsActive = true });
+        return Task.CompletedTask;
+    }
+
+    public async Task UpdateCountryAsync(Guid id, Guid regionId, string code, string name, CancellationToken cancellationToken)
+    {
+        var country = await dbContext.Countries.FirstAsync(c => c.Id == id, cancellationToken);
+        country.RegionId = regionId;
+        country.Code = code;
+        country.Name = name;
+    }
+
+    public async Task<bool> HasActiveAccountsOrCampaignsAsync(Guid countryId, CancellationToken cancellationToken) =>
+        await dbContext.Accounts.AnyAsync(a => a.CountryId == countryId && a.IsActive, cancellationToken) ||
+        await dbContext.Campaigns.AnyAsync(c => c.CountryId == countryId && c.IsActive, cancellationToken);
+
+    public async Task DeactivateCountryAsync(Guid id, CancellationToken cancellationToken) =>
+        (await dbContext.Countries.FirstAsync(c => c.Id == id, cancellationToken)).IsActive = false;
+
+    public async Task<IReadOnlyList<AccountDto>> GetAccountsAsync(CancellationToken cancellationToken) =>
+        await ApplyScope(await GetProfileAsync(cancellationToken), dbContext.Accounts.AsNoTracking())
+            .OrderBy(a => a.Code)
+            .Select(a => new AccountDto(a.Id, a.CountryId, a.Country.Code, a.Country.Name, a.Country.RegionId, a.Country.Region.Code, a.Code, a.Name, a.Description, a.IsActive, a.CreatedAt, a.UpdatedAt))
+            .ToArrayAsync(cancellationToken);
+
+    public async Task<AccountDto?> GetAccountByIdAsync(Guid id, CancellationToken cancellationToken) =>
+        await ApplyScope(await GetProfileAsync(cancellationToken), dbContext.Accounts.AsNoTracking())
+            .Where(a => a.Id == id)
+            .Select(a => new AccountDto(a.Id, a.CountryId, a.Country.Code, a.Country.Name, a.Country.RegionId, a.Country.Region.Code, a.Code, a.Name, a.Description, a.IsActive, a.CreatedAt, a.UpdatedAt))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public async Task<AccountSnapshot?> GetAccountSnapshotAsync(Guid id, CancellationToken cancellationToken) =>
+        await dbContext.Accounts.AsNoTracking().Where(a => a.Id == id)
+            .Select(a => new AccountSnapshot(a.Id, a.CountryId, a.Code, a.Name, a.Description, a.IsActive))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public Task<bool> AccountCodeExistsAsync(string code, Guid? excludingId, CancellationToken cancellationToken) =>
+        dbContext.Accounts.AnyAsync(a => a.Code == code && (!excludingId.HasValue || a.Id != excludingId.Value), cancellationToken);
+
+    public Task AddAccountAsync(AccountCreateModel model, CancellationToken cancellationToken)
+    {
+        dbContext.Accounts.Add(new Account { Id = model.Id, CountryId = model.CountryId, Code = model.Code, Name = model.Name, Description = model.Description, IsActive = true });
+        return Task.CompletedTask;
+    }
+
+    public async Task UpdateAccountAsync(Guid id, Guid countryId, string code, string name, string? description, CancellationToken cancellationToken)
+    {
+        var account = await dbContext.Accounts.FirstAsync(a => a.Id == id, cancellationToken);
+        account.CountryId = countryId;
+        account.Code = code;
+        account.Name = name;
+        account.Description = description;
+    }
+
+    public Task<bool> HasActiveCampaignsAsync(Guid accountId, CancellationToken cancellationToken) =>
+        dbContext.Campaigns.AnyAsync(c => c.AccountId == accountId && c.IsActive, cancellationToken);
+
+    public async Task DeactivateAccountAsync(Guid id, CancellationToken cancellationToken) =>
+        (await dbContext.Accounts.FirstAsync(a => a.Id == id, cancellationToken)).IsActive = false;
+
+    public async Task<IReadOnlyList<CampaignDto>> GetCampaignsAsync(CancellationToken cancellationToken) =>
+        await ApplyScope(await GetProfileAsync(cancellationToken), dbContext.Campaigns.AsNoTracking())
+            .OrderBy(c => c.Code)
+            .Select(c => new CampaignDto(c.Id, c.AccountId, c.Account.Code, c.Account.Name, c.CountryId, c.Country.Code, c.Country.Name, c.Country.RegionId, c.Country.Region.Code, c.Code, c.Name, c.Description, c.IsActive, c.CreatedAt, c.UpdatedAt))
+            .ToArrayAsync(cancellationToken);
+
+    public async Task<CampaignDto?> GetCampaignByIdAsync(Guid id, CancellationToken cancellationToken) =>
+        await ApplyScope(await GetProfileAsync(cancellationToken), dbContext.Campaigns.AsNoTracking())
+            .Where(c => c.Id == id)
+            .Select(c => new CampaignDto(c.Id, c.AccountId, c.Account.Code, c.Account.Name, c.CountryId, c.Country.Code, c.Country.Name, c.Country.RegionId, c.Country.Region.Code, c.Code, c.Name, c.Description, c.IsActive, c.CreatedAt, c.UpdatedAt))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public async Task<CampaignSnapshot?> GetCampaignSnapshotAsync(Guid id, CancellationToken cancellationToken) =>
+        await dbContext.Campaigns.AsNoTracking().Where(c => c.Id == id)
+            .Select(c => new CampaignSnapshot(c.Id, c.AccountId, c.CountryId, c.Code, c.Name, c.Description, c.IsActive))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public Task<bool> CampaignCodeExistsAsync(string code, Guid? excludingId, CancellationToken cancellationToken) =>
+        dbContext.Campaigns.AnyAsync(c => c.Code == code && (!excludingId.HasValue || c.Id != excludingId.Value), cancellationToken);
+
+    public Task AddCampaignAsync(CampaignCreateModel model, CancellationToken cancellationToken)
+    {
+        dbContext.Campaigns.Add(new Campaign { Id = model.Id, AccountId = model.AccountId, CountryId = model.CountryId, Code = model.Code, Name = model.Name, Description = model.Description, IsActive = true });
+        return Task.CompletedTask;
+    }
+
+    public async Task UpdateCampaignAsync(Guid id, Guid accountId, Guid countryId, string code, string name, string? description, CancellationToken cancellationToken)
+    {
+        var campaign = await dbContext.Campaigns.FirstAsync(c => c.Id == id, cancellationToken);
+        campaign.AccountId = accountId;
+        campaign.CountryId = countryId;
+        campaign.Code = code;
+        campaign.Name = name;
+        campaign.Description = description;
+    }
+
+    public async Task DeactivateCampaignAsync(Guid id, CancellationToken cancellationToken) =>
+        (await dbContext.Campaigns.FirstAsync(c => c.Id == id, cancellationToken)).IsActive = false;
+
+    public async Task<UserScopeAssignmentDto?> GetUserScopesAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        var user = await dbContext.Users.AsNoTracking()
+            .Include(u => u.UserRoles).ThenInclude(ur => ur.Role)
+            .Include(u => u.UserScopes).ThenInclude(us => us.Region)
+            .Include(u => u.UserScopes).ThenInclude(us => us.Country)
+            .Include(u => u.UserScopes).ThenInclude(us => us.Account)
+            .Include(u => u.UserScopes).ThenInclude(us => us.Campaign)
+            .FirstOrDefaultAsync(u => u.Id == userId, cancellationToken);
+
+        return user is null
+            ? null
+            : new UserScopeAssignmentDto(
+                user.Id,
+                user.Email,
+                user.DisplayName,
+                user.IsActive,
+                user.UserRoles.Select(ur => ur.Role.Name).OrderBy(n => n).ToArray(),
+                user.UserScopes.OrderBy(us => us.ScopeType).ThenBy(us => us.CreatedAt).Select(MapScope).ToArray());
+    }
+
+    public async Task<UserScopeValidationUser?> GetScopeAssignmentUserAsync(Guid userId, CancellationToken cancellationToken) =>
+        await dbContext.Users.AsNoTracking()
+            .Where(u => u.Id == userId)
+            .Select(u => new UserScopeValidationUser(u.Id, u.IsActive, u.UserRoles.Select(ur => ur.Role.Name).ToArray()))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public async Task<IReadOnlyList<string>> GetMissingOrInactiveScopeTargetsAsync(IReadOnlyCollection<UserScopeUpsertDto> scopes, CancellationToken cancellationToken)
+    {
+        var missing = new List<string>();
+        foreach (var scope in scopes)
+        {
+            var exists = scope.ScopeType switch
+            {
+                ScopeTypes.Region => await dbContext.Regions.AnyAsync(r => r.Id == scope.RegionId && r.IsActive, cancellationToken),
+                ScopeTypes.Country => await dbContext.Countries.AnyAsync(c => c.Id == scope.CountryId && c.IsActive, cancellationToken),
+                ScopeTypes.Account => await dbContext.Accounts.AnyAsync(a => a.Id == scope.AccountId && a.IsActive, cancellationToken),
+                ScopeTypes.Campaign => await dbContext.Campaigns.AnyAsync(c => c.Id == scope.CampaignId && c.IsActive, cancellationToken),
+                _ => false
+            };
+
+            if (!exists) missing.Add(scope.ScopeType ?? string.Empty);
+        }
+
+        return missing;
+    }
+
+    public async Task<IReadOnlyList<UserScopeChange>> ReplaceUserScopesAsync(Guid userId, IReadOnlyCollection<UserScopeUpsertDto> scopes, Guid? actorUserId, CancellationToken cancellationToken)
+    {
+        var existing = await dbContext.UserScopes
+            .Include(us => us.Region)
+            .Include(us => us.Country)
+            .Include(us => us.Account)
+            .Include(us => us.Campaign)
+            .Where(us => us.UserId == userId)
+            .ToListAsync(cancellationToken);
+
+        var now = DateTime.UtcNow;
+        var desiredKeys = scopes.Select(ScopeKey).ToHashSet(StringComparer.Ordinal);
+        var changes = new List<UserScopeChange>();
+
+        foreach (var scope in existing.Where(us => us.IsActive && !desiredKeys.Contains(ScopeKey(us))).ToArray())
+        {
+            scope.IsActive = false;
+            changes.Add(new UserScopeChange("UserScopeDeactivated", MapScope(scope)));
+        }
+
+        foreach (var desired in scopes)
+        {
+            var key = ScopeKey(desired);
+            var current = existing.FirstOrDefault(us => ScopeKey(us) == key);
+            if (current is null)
+            {
+                current = new UserScope
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = userId,
+                    ScopeType = desired.ScopeType!,
+                    RegionId = desired.RegionId,
+                    CountryId = desired.CountryId,
+                    AccountId = desired.AccountId,
+                    CampaignId = desired.CampaignId,
+                    IsActive = true,
+                    CreatedAt = now,
+                    CreatedByUserId = actorUserId
+                };
+                dbContext.UserScopes.Add(current);
+                changes.Add(new UserScopeChange("UserScopeAssigned", MapScope(current)));
+            }
+            else if (!current.IsActive)
+            {
+                current.IsActive = true;
+                changes.Add(new UserScopeChange("UserScopeUpdated", MapScope(current)));
+            }
+        }
+
+        return changes;
+    }
+
+    public Task SaveChangesAsync(CancellationToken cancellationToken) => dbContext.SaveChangesAsync(cancellationToken);
+
+    private async Task<CurrentUserAuthorizationProfile> GetProfileAsync(CancellationToken cancellationToken) =>
+        await authorizationService.GetCurrentUserAuthorizationAsync(cancellationToken)
+        ?? new CurrentUserAuthorizationProfile(Guid.Empty, string.Empty, false, [], [], []);
+
+    private static IQueryable<Region> ApplyScope(CurrentUserAuthorizationProfile profile, IQueryable<Region> query) => query.ApplyScopeFilter(profile);
+    private static IQueryable<Country> ApplyScope(CurrentUserAuthorizationProfile profile, IQueryable<Country> query) => query.ApplyScopeFilter(profile);
+    private static IQueryable<Account> ApplyScope(CurrentUserAuthorizationProfile profile, IQueryable<Account> query) => query.ApplyScopeFilter(profile);
+    private static IQueryable<Campaign> ApplyScope(CurrentUserAuthorizationProfile profile, IQueryable<Campaign> query) => query.ApplyScopeFilter(profile);
+
+    private static UserScopeDto MapScope(UserScope us) => new(
+        us.Id,
+        us.ScopeType,
+        us.RegionId,
+        us.Region == null ? null : us.Region.Code,
+        us.Region == null ? null : us.Region.Name,
+        us.CountryId,
+        us.Country == null ? null : us.Country.Code,
+        us.Country == null ? null : us.Country.Name,
+        us.AccountId,
+        us.Account == null ? null : us.Account.Code,
+        us.Account == null ? null : us.Account.Name,
+        us.CampaignId,
+        us.Campaign == null ? null : us.Campaign.Code,
+        us.Campaign == null ? null : us.Campaign.Name,
+        us.IsActive,
+        us.CreatedAt);
+
+    private static string ScopeKey(UserScopeUpsertDto scope) =>
+        $"{scope.ScopeType}:{scope.RegionId ?? scope.CountryId ?? scope.AccountId ?? scope.CampaignId}";
+
+    private static string ScopeKey(UserScope scope) =>
+        $"{scope.ScopeType}:{scope.RegionId ?? scope.CountryId ?? scope.AccountId ?? scope.CampaignId}";
+}

--- a/tests/OpsSphere.IntegrationTests/OrganizationManagement/OrganizationApiTests.cs
+++ b/tests/OpsSphere.IntegrationTests/OrganizationManagement/OrganizationApiTests.cs
@@ -1,0 +1,516 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using OpsSphere.Domain.Entities;
+using OpsSphere.Infrastructure.Persistence;
+using OpsSphere.Infrastructure.Persistence.SeedData;
+
+namespace OpsSphere.IntegrationTests.OrganizationManagement;
+
+public sealed class OrganizationApiTests
+{
+    private const string AdminEmail = "admin@opssphere.local";
+    private const string AgentEmail = "agent.novabank@opssphere.local";
+    private const string ManagerEmail = "manager.latam@opssphere.local";
+    private const string SupervisorEmail = "supervisor.novabank@opssphere.local";
+    private const string ViewerEmail = "viewer.latam@opssphere.local";
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public async Task Admin_CanCreateUpdateAndDeactivateOrganizationHierarchy()
+    {
+        await using var factory = await OrganizationApiFactory.CreateAsync();
+        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+
+        var region = await CreateRegionAsync(client, "andr", "Andromeda Region");
+        Assert.Equal("ANDR", region.Code);
+        await factory.AssertAuditAsync("RegionCreated", "Region", region.Id);
+
+        var updatedRegionResponse = await client.PutAsJsonAsync($"/api/regions/{region.Id}", new { code = "ANDR-OPS", name = "Andromeda Operations" });
+        var updatedRegion = await ReadDataAsync<RegionResponse>(updatedRegionResponse);
+        Assert.Equal(HttpStatusCode.OK, updatedRegionResponse.StatusCode);
+        Assert.Equal("ANDR-OPS", updatedRegion.Code);
+        await factory.AssertAuditAsync("RegionUpdated", "Region", region.Id);
+
+        var country = await CreateCountryAsync(client, updatedRegion.Id, "luna", "Lunara");
+        await factory.AssertAuditAsync("CountryCreated", "Country", country.Id);
+
+        var updatedCountryResponse = await client.PutAsJsonAsync($"/api/countries/{country.Id}", new { regionId = updatedRegion.Id, code = "LUN", name = "Lunara Prime" });
+        var updatedCountry = await ReadDataAsync<CountryResponse>(updatedCountryResponse);
+        Assert.Equal(HttpStatusCode.OK, updatedCountryResponse.StatusCode);
+        Assert.Equal("LUN", updatedCountry.Code);
+        await factory.AssertAuditAsync("CountryUpdated", "Country", country.Id);
+
+        var account = await CreateAccountAsync(client, updatedCountry.Id, "orion-care", "Orion Care", "Fictional operations account.");
+        await factory.AssertAuditAsync("AccountCreated", "Account", account.Id);
+
+        var updatedAccountResponse = await client.PutAsJsonAsync($"/api/accounts/{account.Id}", new { countryId = updatedCountry.Id, code = "ORION", name = "Orion Support", description = "Updated fictional account." });
+        var updatedAccount = await ReadDataAsync<AccountResponse>(updatedAccountResponse);
+        Assert.Equal(HttpStatusCode.OK, updatedAccountResponse.StatusCode);
+        Assert.Equal("ORION", updatedAccount.Code);
+        await factory.AssertAuditAsync("AccountUpdated", "Account", account.Id);
+
+        var campaign = await CreateCampaignAsync(client, updatedAccount.Id, updatedCountry.Id, "orion-chat", "Orion Chat", "Fictional campaign.");
+        await factory.AssertAuditAsync("CampaignCreated", "Campaign", campaign.Id);
+
+        var updatedCampaignResponse = await client.PutAsJsonAsync($"/api/campaigns/{campaign.Id}", new { accountId = updatedAccount.Id, countryId = updatedCountry.Id, code = "ORION-VOICE", name = "Orion Voice", description = "Updated fictional campaign." });
+        var updatedCampaign = await ReadDataAsync<CampaignResponse>(updatedCampaignResponse);
+        Assert.Equal(HttpStatusCode.OK, updatedCampaignResponse.StatusCode);
+        Assert.Equal("ORION-VOICE", updatedCampaign.Code);
+        await factory.AssertAuditAsync("CampaignUpdated", "Campaign", campaign.Id);
+
+        Assert.Equal(HttpStatusCode.NoContent, (await client.PostAsync($"/api/campaigns/{campaign.Id}/deactivate", null)).StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent, (await client.PostAsync($"/api/accounts/{updatedAccount.Id}/deactivate", null)).StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent, (await client.PostAsync($"/api/countries/{updatedCountry.Id}/deactivate", null)).StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent, (await client.PostAsync($"/api/regions/{updatedRegion.Id}/deactivate", null)).StatusCode);
+
+        await factory.AssertAuditAsync("CampaignDeactivated", "Campaign", campaign.Id);
+        await factory.AssertAuditAsync("AccountDeactivated", "Account", updatedAccount.Id);
+        await factory.AssertAuditAsync("CountryDeactivated", "Country", updatedCountry.Id);
+        await factory.AssertAuditAsync("RegionDeactivated", "Region", updatedRegion.Id);
+        await AssertResponseDoesNotExposeSensitiveDataAsync(updatedCampaignResponse);
+    }
+
+    [Fact]
+    public async Task NonAdmin_CannotCreateUpdateOrDeactivateOrganizationRecords()
+    {
+        await using var factory = await OrganizationApiFactory.CreateAsync();
+        var client = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+
+        var createRegion = await client.PostAsJsonAsync("/api/regions", new { code = "DENY-R", name = "Denied Region" });
+        var updateRegion = await client.PutAsJsonAsync($"/api/regions/{SeedIds.Regions.Latam}", new { code = "LATAM", name = "Denied Region Update" });
+        var deactivateRegion = await client.PostAsync($"/api/regions/{SeedIds.Regions.Latam}/deactivate", null);
+        var createCountry = await client.PostAsJsonAsync("/api/countries", new { regionId = SeedIds.Regions.Latam, code = "DN", name = "Denied Country" });
+        var updateCountry = await client.PutAsJsonAsync($"/api/countries/{SeedIds.Countries.Mexico}", new { regionId = SeedIds.Regions.Latam, code = "MX", name = "Denied Country Update" });
+        var deactivateCountry = await client.PostAsync($"/api/countries/{SeedIds.Countries.Mexico}/deactivate", null);
+        var createAccount = await client.PostAsJsonAsync("/api/accounts", new { countryId = SeedIds.Countries.Mexico, code = "DENY-A", name = "Denied Account" });
+        var updateAccount = await client.PutAsJsonAsync($"/api/accounts/{SeedIds.Accounts.NovaBank}", new { countryId = SeedIds.Countries.Mexico, code = "NOVABANK", name = "Denied Account Update" });
+        var deactivateAccount = await client.PostAsync($"/api/accounts/{SeedIds.Accounts.NovaBank}/deactivate", null);
+        var createCampaign = await client.PostAsJsonAsync("/api/campaigns", new { accountId = SeedIds.Accounts.NovaBank, countryId = SeedIds.Countries.Mexico, code = "DENY-C", name = "Denied Campaign" });
+        var updateCampaign = await client.PutAsJsonAsync($"/api/campaigns/{SeedIds.Campaigns.NovaBankCreditCard}", new { accountId = SeedIds.Accounts.NovaBank, countryId = SeedIds.Countries.Mexico, code = "NOVABANK-CC", name = "Denied Campaign Update" });
+        var deactivateCampaign = await client.PostAsync($"/api/campaigns/{SeedIds.Campaigns.NovaBankCreditCard}/deactivate", null);
+
+        foreach (var response in new[] { createRegion, updateRegion, deactivateRegion, createCountry, updateCountry, deactivateCountry, createAccount, updateAccount, deactivateAccount, createCampaign, updateCampaign, deactivateCampaign })
+        {
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        }
+    }
+
+    [Fact]
+    public async Task OrganizationValidation_RejectsRequiredFieldAndDuplicateCodeFailures()
+    {
+        await using var factory = await OrganizationApiFactory.CreateAsync();
+        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+
+        var missing = await client.PostAsJsonAsync("/api/regions", new { code = "", name = "" });
+        var missingError = await ReadErrorAsync(missing);
+        Assert.Equal(HttpStatusCode.BadRequest, missing.StatusCode);
+        Assert.Equal("validation_error", missingError.Error.Code);
+        Assert.Contains(missingError.Error.Details, detail => detail.Field == "code");
+        Assert.Contains(missingError.Error.Details, detail => detail.Field == "name");
+
+        await AssertConflictAsync(await client.PostAsJsonAsync("/api/regions", new { code = "LATAM", name = "Duplicate Latam" }));
+        await AssertConflictAsync(await client.PostAsJsonAsync("/api/countries", new { regionId = SeedIds.Regions.Latam, code = "MX", name = "Duplicate Mexico" }));
+        await AssertConflictAsync(await client.PostAsJsonAsync("/api/accounts", new { countryId = SeedIds.Countries.Mexico, code = "NOVABANK", name = "Duplicate NovaBank" }));
+        await AssertConflictAsync(await client.PostAsJsonAsync("/api/campaigns", new { accountId = SeedIds.Accounts.NovaBank, countryId = SeedIds.Countries.Mexico, code = "NOVABANK-CC", name = "Duplicate Campaign" }));
+    }
+
+    [Fact]
+    public async Task OrganizationParentsAndDeactivationRules_AreEnforced()
+    {
+        await using var factory = await OrganizationApiFactory.CreateAsync();
+        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        var inactiveRegionId = await factory.AddInactiveRegionAsync("VOID-R", "Void Region");
+        var inactiveCountryId = await factory.AddInactiveCountryAsync(inactiveRegionId, "VOID-C", "Void Country");
+        var inactiveAccountId = await factory.AddInactiveAccountAsync(inactiveCountryId, "VOID-A", "Void Account");
+
+        await AssertValidationAsync(await client.PostAsJsonAsync("/api/countries", new { regionId = Guid.NewGuid(), code = "MISSING-R", name = "Missing Region Country" }), "regionId");
+        await AssertValidationAsync(await client.PostAsJsonAsync("/api/countries", new { regionId = inactiveRegionId, code = "INACTIVE-R", name = "Inactive Region Country" }), "regionId");
+        await AssertValidationAsync(await client.PostAsJsonAsync("/api/accounts", new { countryId = Guid.NewGuid(), code = "MISSING-C", name = "Missing Country Account" }), "countryId");
+        await AssertValidationAsync(await client.PostAsJsonAsync("/api/accounts", new { countryId = inactiveCountryId, code = "INACTIVE-C", name = "Inactive Country Account" }), "countryId");
+        await AssertValidationAsync(await client.PostAsJsonAsync("/api/campaigns", new { accountId = Guid.NewGuid(), countryId = SeedIds.Countries.Mexico, code = "MISSING-A", name = "Missing Account Campaign" }), "accountId");
+        await AssertValidationAsync(await client.PostAsJsonAsync("/api/campaigns", new { accountId = inactiveAccountId, countryId = inactiveCountryId, code = "INACTIVE-A", name = "Inactive Account Campaign" }), "accountId");
+        await AssertValidationAsync(await client.PostAsJsonAsync("/api/campaigns", new { accountId = SeedIds.Accounts.NovaBank, countryId = SeedIds.Countries.UnitedStates, code = "MISMATCH-COUNTRY", name = "Mismatched Country Campaign" }), "countryId");
+
+        await AssertBusinessRuleAsync(await client.PostAsync($"/api/regions/{SeedIds.Regions.Latam}/deactivate", null));
+        await AssertBusinessRuleAsync(await client.PostAsync($"/api/countries/{SeedIds.Countries.Mexico}/deactivate", null));
+        await AssertBusinessRuleAsync(await client.PostAsync($"/api/accounts/{SeedIds.Accounts.NovaBank}/deactivate", null));
+    }
+
+    [Theory]
+    [InlineData("manager.latam@opssphere.local", "Region")]
+    [InlineData("supervisor.novabank@opssphere.local", "Account")]
+    [InlineData("supervisor.novabank@opssphere.local", "Campaign")]
+    [InlineData("agent.novabank@opssphere.local", "Account")]
+    [InlineData("agent.novabank@opssphere.local", "Campaign")]
+    [InlineData("viewer.latam@opssphere.local", "Region")]
+    [InlineData("viewer.latam@opssphere.local", "Country")]
+    [InlineData("viewer.latam@opssphere.local", "Account")]
+    [InlineData("viewer.latam@opssphere.local", "Campaign")]
+    public async Task UserScopes_CanBeAssignedAccordingToRole(string email, string scopeType)
+    {
+        await using var factory = await OrganizationApiFactory.CreateAsync();
+        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        var userId = await factory.GetUserIdAsync(email);
+
+        var response = await client.PutAsJsonAsync($"/api/users/{userId}/scopes", new
+        {
+            scopes = new[] { CreateScopeRequest(scopeType) }
+        });
+        var assignment = await ReadDataAsync<UserScopeAssignmentResponse>(response);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains(assignment.Scopes, scope => scope.ScopeType == scopeType && scope.IsActive);
+        await factory.AssertAuditAsync("UserScopeAssigned", "User", userId);
+    }
+
+    [Fact]
+    public async Task UserScopes_RejectInvalidRoleInvalidScopeInactiveUserAndInactiveTargets()
+    {
+        await using var factory = await OrganizationApiFactory.CreateAsync();
+        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        var inactiveRegionId = await factory.AddInactiveRegionAsync("SLEEP-R", "Sleeping Region");
+        await factory.DeactivateUserAsync(SeedIds.Users.ViewerLatam);
+
+        await AssertValidationAsync(await client.PutAsJsonAsync($"/api/users/{SeedIds.Users.ManagerLatam}/scopes", new { scopes = new[] { CreateScopeRequest("Account") } }), "scopes");
+        await AssertValidationAsync(await client.PutAsJsonAsync($"/api/users/{SeedIds.Users.SupervisorNovabank}/scopes", new { scopes = new[] { new { scopeType = "Planet", regionId = SeedIds.Regions.Latam, countryId = (Guid?)null, accountId = (Guid?)null, campaignId = (Guid?)null } } }), "scopes");
+        await AssertValidationAsync(await client.PutAsJsonAsync($"/api/users/{SeedIds.Users.ViewerLatam}/scopes", new { scopes = new[] { CreateScopeRequest("Region") } }), "userId");
+        await AssertValidationAsync(await client.PutAsJsonAsync($"/api/users/{SeedIds.Users.ManagerLatam}/scopes", new { scopes = new[] { new { scopeType = "Region", regionId = (Guid?)inactiveRegionId, countryId = (Guid?)null, accountId = (Guid?)null, campaignId = (Guid?)null } } }), "scopes");
+    }
+
+    [Fact]
+    public async Task UserScopes_WriteAuditForAssignDeactivateAndReactivate()
+    {
+        await using var factory = await OrganizationApiFactory.CreateAsync();
+        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+
+        var assignAccount = await client.PutAsJsonAsync($"/api/users/{SeedIds.Users.AgentNovabank}/scopes", new { scopes = new[] { CreateScopeRequest("Account") } });
+        Assert.Equal(HttpStatusCode.OK, assignAccount.StatusCode);
+        await factory.AssertAuditAsync("UserScopeAssigned", "User", SeedIds.Users.AgentNovabank);
+        await factory.AssertAuditAsync("UserScopeDeactivated", "User", SeedIds.Users.AgentNovabank);
+
+        var reactivateCampaign = await client.PutAsJsonAsync($"/api/users/{SeedIds.Users.AgentNovabank}/scopes", new
+        {
+            scopes = new[]
+            {
+                new { scopeType = "Campaign", regionId = (Guid?)null, countryId = (Guid?)null, accountId = (Guid?)null, campaignId = (Guid?)SeedIds.Campaigns.NovaBankCreditCard }
+            }
+        });
+        Assert.Equal(HttpStatusCode.OK, reactivateCampaign.StatusCode);
+        await factory.AssertAuditAsync("UserScopeUpdated", "User", SeedIds.Users.AgentNovabank);
+    }
+
+    [Fact]
+    public async Task ScopedReads_FilterOrganizationRecordsServerSide()
+    {
+        await using var factory = await OrganizationApiFactory.CreateAsync();
+        var manager = await CreateAuthenticatedClientAsync(factory, ManagerEmail);
+        var viewer = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
+        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+
+        var managerRegions = await ReadDataAsync<IReadOnlyList<RegionResponse>>(await manager.GetAsync("/api/regions"));
+        var viewerCountries = await ReadDataAsync<IReadOnlyList<CountryResponse>>(await viewer.GetAsync("/api/countries"));
+        var supervisorAccounts = await ReadDataAsync<IReadOnlyList<AccountResponse>>(await supervisor.GetAsync("/api/accounts"));
+        var supervisorCampaigns = await ReadDataAsync<IReadOnlyList<CampaignResponse>>(await supervisor.GetAsync("/api/campaigns"));
+        var agentRegions = await ReadDataAsync<IReadOnlyList<RegionResponse>>(await agent.GetAsync("/api/regions"));
+        var agentCountries = await ReadDataAsync<IReadOnlyList<CountryResponse>>(await agent.GetAsync("/api/countries"));
+        var agentAccounts = await ReadDataAsync<IReadOnlyList<AccountResponse>>(await agent.GetAsync("/api/accounts"));
+        var agentCampaigns = await ReadDataAsync<IReadOnlyList<CampaignResponse>>(await agent.GetAsync("/api/campaigns"));
+
+        Assert.Single(managerRegions);
+        Assert.Contains(managerRegions, region => region.Code == "LATAM");
+        Assert.DoesNotContain(viewerCountries, country => country.Code == "US");
+        Assert.Single(supervisorAccounts);
+        Assert.Contains(supervisorAccounts, account => account.Code == "NOVABANK");
+        Assert.Equal(2, supervisorCampaigns.Count(campaign => campaign.AccountCode == "NOVABANK"));
+        Assert.Single(agentRegions);
+        Assert.Contains(agentRegions, region => region.Code == "LATAM");
+        Assert.Single(agentCountries);
+        Assert.Contains(agentCountries, country => country.Code == "MX");
+        Assert.Single(agentAccounts);
+        Assert.Contains(agentAccounts, account => account.Code == "NOVABANK");
+        Assert.Single(agentCampaigns);
+        Assert.Contains(agentCampaigns, campaign => campaign.Code == "NOVABANK-CC");
+    }
+
+    [Fact]
+    public async Task OrganizationResponses_UseEnvelopeAndDoNotExposeSecrets()
+    {
+        await using var factory = await OrganizationApiFactory.CreateAsync();
+        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+
+        var regionResponse = await client.GetAsync("/api/regions");
+        var json = await regionResponse.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, regionResponse.StatusCode);
+        Assert.Contains("\"data\"", json, StringComparison.OrdinalIgnoreCase);
+        await AssertResponseDoesNotExposeSensitiveDataAsync(regionResponse);
+    }
+
+    private static object CreateScopeRequest(string scopeType) => scopeType switch
+    {
+        "Region" => new { scopeType, regionId = (Guid?)SeedIds.Regions.NorthAmerica, countryId = (Guid?)null, accountId = (Guid?)null, campaignId = (Guid?)null },
+        "Country" => new { scopeType, regionId = (Guid?)null, countryId = (Guid?)SeedIds.Countries.UnitedStates, accountId = (Guid?)null, campaignId = (Guid?)null },
+        "Account" => new { scopeType, regionId = (Guid?)null, countryId = (Guid?)null, accountId = (Guid?)SeedIds.Accounts.Streamly, campaignId = (Guid?)null },
+        "Campaign" => new { scopeType, regionId = (Guid?)null, countryId = (Guid?)null, accountId = (Guid?)null, campaignId = (Guid?)SeedIds.Campaigns.StreamlyCreator },
+        _ => throw new ArgumentOutOfRangeException(nameof(scopeType), scopeType, null)
+    };
+
+    private static async Task<RegionResponse> CreateRegionAsync(HttpClient client, string code, string name)
+    {
+        var response = await client.PostAsJsonAsync("/api/regions", new { code, name });
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        return await ReadDataAsync<RegionResponse>(response);
+    }
+
+    private static async Task<CountryResponse> CreateCountryAsync(HttpClient client, Guid regionId, string code, string name)
+    {
+        var response = await client.PostAsJsonAsync("/api/countries", new { regionId, code, name });
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        return await ReadDataAsync<CountryResponse>(response);
+    }
+
+    private static async Task<AccountResponse> CreateAccountAsync(HttpClient client, Guid countryId, string code, string name, string description)
+    {
+        var response = await client.PostAsJsonAsync("/api/accounts", new { countryId, code, name, description });
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        return await ReadDataAsync<AccountResponse>(response);
+    }
+
+    private static async Task<CampaignResponse> CreateCampaignAsync(HttpClient client, Guid accountId, Guid countryId, string code, string name, string description)
+    {
+        var response = await client.PostAsJsonAsync("/api/campaigns", new { accountId, countryId, code, name, description });
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        return await ReadDataAsync<CampaignResponse>(response);
+    }
+
+    private static async Task AssertConflictAsync(HttpResponseMessage response)
+    {
+        var error = await ReadErrorAsync(response);
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+        Assert.Equal("conflict", error.Error.Code);
+    }
+
+    private static async Task AssertValidationAsync(HttpResponseMessage response, string field)
+    {
+        var error = await ReadErrorAsync(response);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("validation_error", error.Error.Code);
+        Assert.Contains(error.Error.Details, detail => detail.Field == field);
+    }
+
+    private static async Task AssertBusinessRuleAsync(HttpResponseMessage response)
+    {
+        var error = await ReadErrorAsync(response);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("business_rule_violation", error.Error.Code);
+    }
+
+    private static async Task<HttpClient> CreateAuthenticatedClientAsync(OrganizationApiFactory factory, string email)
+    {
+        var client = factory.CreateClient();
+        var loginResponse = await client.PostAsJsonAsync("/api/auth/login", new
+        {
+            email,
+            password = OpsSphereSeedData.LocalDemoPassword
+        });
+        loginResponse.EnsureSuccessStatusCode();
+        var loginBody = await ReadResponseAsync<ApiResponse<LoginData>>(loginResponse);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", loginBody.Data.AccessToken);
+
+        return client;
+    }
+
+    private static async Task<T> ReadDataAsync<T>(HttpResponseMessage response)
+    {
+        var envelope = await ReadResponseAsync<ApiResponse<T>>(response);
+        return envelope.Data;
+    }
+
+    private static async Task<ApiErrorResponse> ReadErrorAsync(HttpResponseMessage response) =>
+        await ReadResponseAsync<ApiErrorResponse>(response);
+
+    private static async Task<T> ReadResponseAsync<T>(HttpResponseMessage response)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
+
+        return value ?? throw new InvalidOperationException($"Could not deserialize {typeof(T).Name} from {(int)response.StatusCode}: {json}");
+    }
+
+    private static async Task AssertResponseDoesNotExposeSensitiveDataAsync(HttpResponseMessage response)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        foreach (var term in new[] { "passwordHash", "temporaryPassword", "accessToken", "refreshToken", "jwt", "secret", OrganizationApiFactory.JwtSigningKey })
+        {
+            Assert.DoesNotContain(term, json, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private sealed record ApiResponse<T>(T Data);
+    private sealed record ApiErrorResponse(ApiError Error);
+    private sealed record ApiError(string Code, string Message, IReadOnlyList<ApiErrorDetail> Details);
+    private sealed record ApiErrorDetail(string? Field, string Message);
+    private sealed record LoginData(string AccessToken);
+    private sealed record RegionResponse(Guid Id, string Code, string Name, bool IsActive);
+    private sealed record CountryResponse(Guid Id, Guid RegionId, string RegionCode, string Code, string Name, bool IsActive);
+    private sealed record AccountResponse(Guid Id, Guid CountryId, string CountryCode, Guid RegionId, string RegionCode, string Code, string Name, string? Description, bool IsActive);
+    private sealed record CampaignResponse(Guid Id, Guid AccountId, string AccountCode, Guid CountryId, string CountryCode, Guid RegionId, string RegionCode, string Code, string Name, string? Description, bool IsActive);
+    private sealed record UserScopeAssignmentResponse(Guid UserId, string Email, bool IsActive, IReadOnlyList<string> Roles, IReadOnlyList<UserScopeResponse> Scopes);
+    private sealed record UserScopeResponse(Guid Id, string ScopeType, Guid? RegionId, Guid? CountryId, Guid? AccountId, Guid? CampaignId, bool IsActive);
+
+    internal sealed class OrganizationApiFactory : WebApplicationFactory<Program>
+    {
+        public const string JwtSigningKey = "integration-testing-only-fictional-jwt-signing-key";
+
+        private readonly SqliteConnection connection = new("Data Source=:memory:");
+
+        public static async Task<OrganizationApiFactory> CreateAsync()
+        {
+            ConfigureEnvironment();
+            var factory = new OrganizationApiFactory();
+            await factory.connection.OpenAsync();
+            await factory.InitializeDatabaseAsync();
+
+            return factory;
+        }
+
+        public async Task<Guid> GetUserIdAsync(string email)
+        {
+            using var scope = Services.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+
+            return await dbContext.Users
+                .Where(user => user.Email == email)
+                .Select(user => user.Id)
+                .SingleAsync();
+        }
+
+        public async Task DeactivateUserAsync(Guid userId)
+        {
+            using var scope = Services.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+            var user = await dbContext.Users.SingleAsync(u => u.Id == userId);
+            user.IsActive = false;
+            user.DeactivatedAt = DateTime.UtcNow;
+            await dbContext.SaveChangesAsync();
+        }
+
+        public async Task<Guid> AddInactiveRegionAsync(string code, string name)
+        {
+            using var scope = Services.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+            var region = new Region { Id = Guid.NewGuid(), Code = code, Name = name, IsActive = false, CreatedAt = DateTime.UtcNow };
+            dbContext.Regions.Add(region);
+            await dbContext.SaveChangesAsync();
+
+            return region.Id;
+        }
+
+        public async Task<Guid> AddInactiveCountryAsync(Guid regionId, string code, string name)
+        {
+            using var scope = Services.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+            var country = new Country { Id = Guid.NewGuid(), RegionId = regionId, Code = code, Name = name, IsActive = false, CreatedAt = DateTime.UtcNow };
+            dbContext.Countries.Add(country);
+            await dbContext.SaveChangesAsync();
+
+            return country.Id;
+        }
+
+        public async Task<Guid> AddInactiveAccountAsync(Guid countryId, string code, string name)
+        {
+            using var scope = Services.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+            var account = new Account { Id = Guid.NewGuid(), CountryId = countryId, Code = code, Name = name, IsActive = false, CreatedAt = DateTime.UtcNow };
+            dbContext.Accounts.Add(account);
+            await dbContext.SaveChangesAsync();
+
+            return account.Id;
+        }
+
+        public async Task AssertAuditAsync(string action, string entityType, Guid entityId)
+        {
+            using var scope = Services.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+
+            var audit = await dbContext.AuditLogs
+                .AsNoTracking()
+                .Where(log => log.Action == action && log.EntityType == entityType && log.EntityId == entityId)
+                .OrderByDescending(log => log.CreatedAt)
+                .FirstOrDefaultAsync();
+
+            Assert.NotNull(audit);
+            Assert.Equal(SeedIds.Users.Admin, audit.ActorUserId);
+            Assert.False(string.IsNullOrWhiteSpace(audit.CorrelationId));
+            Assert.DoesNotContain("password", audit.PreviousValue ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("password", audit.NewValue ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(JwtSigningKey, audit.PreviousValue ?? string.Empty, StringComparison.Ordinal);
+            Assert.DoesNotContain(JwtSigningKey, audit.NewValue ?? string.Empty, StringComparison.Ordinal);
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Testing");
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["ConnectionStrings:DefaultConnection"] = "Server=(local);Database=OpsSphereOrganizationTests;Trusted_Connection=True;TrustServerCertificate=True;",
+                    ["SeedData:Enabled"] = "false",
+                    ["Jwt:Issuer"] = "OpsSphere.Tests",
+                    ["Jwt:Audience"] = "OpsSphere.Tests.Angular",
+                    ["Jwt:ExpirationMinutes"] = "60",
+                    ["Jwt:SigningKey"] = JwtSigningKey
+                });
+            });
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<IDbContextOptionsConfiguration<OpsSphereDbContext>>();
+                services.RemoveAll<DbContextOptions<OpsSphereDbContext>>();
+                services.AddDbContext<OpsSphereDbContext>(options => options.UseSqlite(connection));
+            });
+        }
+
+        private static void ConfigureEnvironment()
+        {
+            Environment.SetEnvironmentVariable(
+                "ConnectionStrings__DefaultConnection",
+                "Server=(local);Database=OpsSphereOrganizationTests;Trusted_Connection=True;TrustServerCertificate=True;");
+            Environment.SetEnvironmentVariable("SeedData__Enabled", "false");
+            Environment.SetEnvironmentVariable("Jwt__Issuer", "OpsSphere.Tests");
+            Environment.SetEnvironmentVariable("Jwt__Audience", "OpsSphere.Tests.Angular");
+            Environment.SetEnvironmentVariable("Jwt__ExpirationMinutes", "60");
+            Environment.SetEnvironmentVariable("Jwt__SigningKey", JwtSigningKey);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await connection.DisposeAsync();
+            await base.DisposeAsync();
+        }
+
+        private async Task InitializeDatabaseAsync()
+        {
+            using var scope = Services.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+            await dbContext.Database.EnsureDeletedAsync();
+            await dbContext.Database.EnsureCreatedAsync();
+
+            var seeder = scope.ServiceProvider.GetRequiredService<OpsSphereDataSeeder>();
+            await seeder.SeedAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the organization structure management foundation for OpsSphere.

This PR adds Admin-only operational hierarchy management for regions, countries, accounts, campaigns, and UserScope-based assignments. It also adds scoped organization reads for operational users, organization management frontend screens, audit events, safe structured logs, and test coverage across backend and frontend.

## Added / Changed

- Added organization management backend APIs for regions, countries, accounts, and campaigns.
- Added create, update, deactivate, list, and detail operations for organization records.
- Added UserScope-based assignment management for managers, supervisors, agents, and viewers.
- Added server-side scoped read filtering for organization data.
- Added Country scope filtering support.
- Added parent context reads for account/campaign-scoped users.
- Added hierarchy validation for region, country, account, and campaign relationships.
- Added deactivation rules that preserve records and block parent deactivation while active children exist.
- Added audit events for organization and UserScope assignment changes.
- Added safe structured logs for organization and assignment governance changes.
- Added Angular organization management routes and screens.
- Added organization management navigation and permission-aware route UX.
- Added backend integration tests for Admin writes, non-admin denial, scoped reads, hierarchy validation, deactivation behavior, assignments, and audit records.
- Added frontend tests for organization routes and organization service behavior.
- Kept UserScopes as the MVP assignment model.
- No schema changes, migrations, or dedicated assignment tables were introduced.

## Validation

- [x] Reviewed changed files.
- [x] Confirmed scope matches the related issue.
- [x] Confirmed validation expectations from `docs/implementation-guardrails.md` were met or documented.
- [x] `dotnet restore`
- [x] `dotnet build`
- [x] `dotnet test` — 113 total tests passed
- [x] `npm ci` — 0 vulnerabilities
- [x] `npm run build`
- [x] `npm run test` — 54 successful

## Scope Confirmation

- [x] This PR contains no out-of-scope work.
- [x] This PR does not introduce unrelated source, package, migration, Docker, or GitHub Actions changes.
- [x] Workforce scheduling, HR management, payroll, capacity planning, advanced org charts, customer management, ticket workflows, dashboard analytics, and external integrations remain out of scope.
- [x] Dedicated assignment tables were not introduced; UserScopes remain the MVP assignment model.

## Related Issue

Closes #44

## Checklist

- [x] Branch name includes the issue number.
- [x] Related issue defines scope, out of scope, acceptance criteria, and validation.
- [x] Architecture boundaries and MVP limits from `docs/implementation-guardrails.md` are respected.
- [x] Documentation is updated when behavior, architecture, setup, or validation expectations change.