### PR TITLE
Add migration for AuditLogs index and implement integration tests for…

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -198,6 +198,14 @@ export const routes: Routes = [
     loadComponent: () => import('./features/tickets/ticket-detail.component').then((m) => m.TicketDetailComponent)
   },
   {
+    path: 'audit',
+    canActivate: [permissionGuard],
+    data: {
+      permissions: [AppPermissions.AuditView]
+    },
+    loadComponent: () => import('./features/audit/audit-list.component').then((m) => m.AuditListComponent)
+  },
+  {
     path: 'users',
     redirectTo: 'admin/users'
   },

--- a/frontend/src/app/features/audit/audit-list.component.spec.ts
+++ b/frontend/src/app/features/audit/audit-list.component.spec.ts
@@ -1,0 +1,109 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { defer, of } from 'rxjs';
+
+import { ApiErrorParserService } from '../../core/services/api-error-parser.service';
+import { AuditListComponent } from './audit-list.component';
+import { AuditService } from './audit.service';
+
+describe('AuditListComponent', () => {
+  let auditService: jasmine.SpyObj<Pick<AuditService, 'getAuditLogs' | 'getAuditLogById'>>;
+  let errorParser: jasmine.SpyObj<Pick<ApiErrorParserService, 'parse'>>;
+  let fixture: ComponentFixture<AuditListComponent>;
+
+  beforeEach(() => {
+    auditService = jasmine.createSpyObj<Pick<AuditService, 'getAuditLogs' | 'getAuditLogById'>>(
+      'AuditService',
+      ['getAuditLogs', 'getAuditLogById']
+    );
+    errorParser = jasmine.createSpyObj<Pick<ApiErrorParserService, 'parse'>>('ApiErrorParserService', ['parse']);
+    errorParser.parse.and.returnValue({ code: 'bad_request', message: 'Request failed.', details: [] });
+    auditService.getAuditLogs.and.returnValue(of({
+      items: [
+        {
+          id: 'audit-1',
+          actorUserId: 'user-1',
+          actorDisplayName: 'Nova Supervisor',
+          action: 'TicketCreated',
+          entityType: 'Ticket',
+          entityId: 'ticket-1',
+          createdAt: '2026-05-18T00:00:00Z',
+          correlationId: 'corr-1'
+        }
+      ],
+      page: 1,
+      pageSize: 25,
+      totalCount: 1,
+      totalPages: 1
+    }));
+    auditService.getAuditLogById.and.returnValue(of({
+      id: 'audit-1',
+      actorUserId: 'user-1',
+      actorDisplayName: 'Nova Supervisor',
+      action: 'TicketCreated',
+      entityType: 'Ticket',
+      entityId: 'ticket-1',
+      createdAt: '2026-05-18T00:00:00Z',
+      correlationId: 'corr-1',
+      previousValue: null,
+      newValue: '{"status":"Open"}'
+    }));
+
+    TestBed.configureTestingModule({
+      imports: [AuditListComponent],
+      providers: [
+        { provide: AuditService, useValue: auditService },
+        { provide: ApiErrorParserService, useValue: errorParser }
+      ]
+    });
+  });
+
+  it('renders audit entries', () => {
+    fixture = TestBed.createComponent(AuditListComponent);
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('TicketCreated');
+    expect(text).toContain('Nova Supervisor');
+    expect(text).toContain('Ticket');
+  });
+
+  it('filter by actor calls service with actor filter', () => {
+    fixture = TestBed.createComponent(AuditListComponent);
+    fixture.detectChanges();
+
+    const component = fixture.componentInstance;
+    component.filterForm.patchValue({ actorUserId: 'user-1' });
+    component.applyFilters();
+
+    expect(auditService.getAuditLogs).toHaveBeenCalledWith(jasmine.objectContaining({
+      actorUserId: 'user-1',
+      page: 1,
+      pageSize: 25
+    }));
+  });
+
+  it('loads detail for expanded row', async () => {
+    fixture = TestBed.createComponent(AuditListComponent);
+    fixture.detectChanges();
+    auditService.getAuditLogById.and.returnValue(defer(() => Promise.resolve({
+      id: 'audit-1',
+      actorUserId: 'user-1',
+      actorDisplayName: 'Nova Supervisor',
+      action: 'TicketCreated',
+      entityType: 'Ticket',
+      entityId: 'ticket-1',
+      createdAt: '2026-05-18T00:00:00Z',
+      correlationId: 'corr-1',
+      previousValue: null,
+      newValue: '{"status":"Open"}'
+    })));
+
+    fixture.componentInstance.toggleDetail(fixture.componentInstance.auditLogs[0]);
+    await fixture.whenStable();
+
+    expect(auditService.getAuditLogById).toHaveBeenCalledOnceWith('audit-1');
+    expect(fixture.componentInstance.expandedId).toBe('audit-1');
+    expect(fixture.componentInstance.selectedDetail?.correlationId).toBe('corr-1');
+    expect(fixture.componentInstance.formatAuditValue(fixture.componentInstance.selectedDetail?.newValue)).toContain('"status": "Open"');
+  });
+});

--- a/frontend/src/app/features/audit/audit-list.component.ts
+++ b/frontend/src/app/features/audit/audit-list.component.ts
@@ -1,0 +1,271 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+
+import { SafeApiError } from '../../core/models/api-error.models';
+import { ApiErrorParserService } from '../../core/services/api-error-parser.service';
+import { AuditLogDetail, AuditLogFilters, AuditLogListItem } from './audit.models';
+import { AuditService } from './audit.service';
+
+@Component({
+  selector: 'app-audit-list',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  template: `
+    <div class="page-container">
+      <div class="page-header">
+        <h1>Audit Logs</h1>
+      </div>
+
+      <form class="filter-panel" [formGroup]="filterForm" (ngSubmit)="applyFilters()">
+        <div class="form-grid">
+          <div class="form-group">
+            <label for="actorUserId">Actor User ID</label>
+            <input id="actorUserId" type="text" formControlName="actorUserId" />
+          </div>
+          <div class="form-group">
+            <label for="action">Action</label>
+            <input id="action" type="text" formControlName="action" />
+          </div>
+          <div class="form-group">
+            <label for="entityType">Entity Type</label>
+            <input id="entityType" type="text" formControlName="entityType" />
+          </div>
+          <div class="form-group">
+            <label for="entityId">Entity ID</label>
+            <input id="entityId" type="text" formControlName="entityId" />
+          </div>
+          <div class="form-group">
+            <label for="fromUtc">From</label>
+            <input id="fromUtc" type="datetime-local" formControlName="fromUtc" />
+          </div>
+          <div class="form-group">
+            <label for="toUtc">To</label>
+            <input id="toUtc" type="datetime-local" formControlName="toUtc" />
+          </div>
+        </div>
+
+        <div class="actions">
+          <button type="submit" class="btn btn-primary" [disabled]="loading">Apply Filters</button>
+          <button type="button" class="btn btn-secondary" (click)="resetFilters()" [disabled]="loading">Reset</button>
+        </div>
+      </form>
+
+      <div *ngIf="loading" class="loading">Loading audit logs...</div>
+      <div *ngIf="error" class="error">{{ error }}</div>
+
+      <table *ngIf="!loading && auditLogs.length > 0" class="data-table">
+        <thead>
+          <tr>
+            <th>Created</th>
+            <th>Actor</th>
+            <th>Action</th>
+            <th>Entity Type</th>
+            <th>Entity ID</th>
+            <th>Details</th>
+          </tr>
+        </thead>
+        <tbody>
+          <ng-container *ngFor="let item of auditLogs">
+            <tr>
+              <td>{{ item.createdAt | date:'medium' }}</td>
+              <td>{{ item.actorDisplayName || item.actorUserId || 'System' }}</td>
+              <td>{{ item.action }}</td>
+              <td>{{ item.entityType }}</td>
+              <td>{{ item.entityId }}</td>
+              <td>
+                <button type="button" class="btn btn-secondary" (click)="toggleDetail(item)" [disabled]="detailLoadingId === item.id">
+                  {{ expandedId === item.id ? 'Hide' : 'View' }}
+                </button>
+              </td>
+            </tr>
+            <tr *ngIf="expandedId === item.id">
+              <td colspan="6">
+                <div *ngIf="detailLoadingId === item.id" class="loading">Loading details...</div>
+                <div *ngIf="detailError" class="error">{{ detailError }}</div>
+                <div *ngIf="selectedDetail" class="audit-detail">
+                  <p><strong>Correlation ID:</strong> {{ selectedDetail.correlationId || 'Not set' }}</p>
+                  <div class="detail-grid">
+                    <div>
+                      <h2>Previous Value</h2>
+                      <pre>{{ formatAuditValue(selectedDetail.previousValue) }}</pre>
+                    </div>
+                    <div>
+                      <h2>New Value</h2>
+                      <pre>{{ formatAuditValue(selectedDetail.newValue) }}</pre>
+                    </div>
+                  </div>
+                </div>
+              </td>
+            </tr>
+          </ng-container>
+        </tbody>
+      </table>
+
+      <p *ngIf="!loading && auditLogs.length === 0">No audit logs found.</p>
+
+      <div class="pagination">
+        <button type="button" class="btn btn-secondary" (click)="goToPage(page - 1)" [disabled]="loading || page <= 1">Previous</button>
+        <span>Page {{ page }} of {{ totalPages || 1 }}</span>
+        <button type="button" class="btn btn-secondary" (click)="goToPage(page + 1)" [disabled]="loading || page >= totalPages">Next</button>
+        <label for="pageSize">Rows</label>
+        <select id="pageSize" [value]="pageSize" (change)="changePageSize($event)">
+          <option value="10">10</option>
+          <option value="25">25</option>
+          <option value="50">50</option>
+          <option value="100">100</option>
+        </select>
+      </div>
+    </div>
+  `,
+  styles: [`
+    .filter-panel { margin-bottom: 1rem; }
+    .form-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; }
+    .actions, .pagination { display: flex; align-items: center; gap: .75rem; flex-wrap: wrap; margin: 1rem 0; }
+    .audit-detail { padding: .75rem 0; }
+    .detail-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; }
+    .detail-grid h2 { font-size: 1rem; margin: 0 0 .5rem; }
+    pre { white-space: pre-wrap; word-break: break-word; margin: 0; }
+  `]
+})
+export class AuditListComponent implements OnInit {
+  private readonly auditService = inject(AuditService);
+  private readonly errorParser = inject(ApiErrorParserService);
+  private readonly fb = inject(FormBuilder);
+
+  auditLogs: AuditLogListItem[] = [];
+  selectedDetail: AuditLogDetail | null = null;
+  expandedId: string | null = null;
+  detailLoadingId: string | null = null;
+  loading = true;
+  error: string | null = null;
+  detailError: string | null = null;
+  page = 1;
+  pageSize = 25;
+  totalPages = 0;
+  totalCount = 0;
+
+  filterForm = this.fb.group({
+    actorUserId: [''],
+    action: [''],
+    entityType: [''],
+    entityId: [''],
+    fromUtc: [''],
+    toUtc: ['']
+  });
+
+  ngOnInit() {
+    this.loadAuditLogs();
+  }
+
+  applyFilters() {
+    this.page = 1;
+    this.loadAuditLogs();
+  }
+
+  resetFilters() {
+    this.filterForm.reset({
+      actorUserId: '',
+      action: '',
+      entityType: '',
+      entityId: '',
+      fromUtc: '',
+      toUtc: ''
+    });
+    this.page = 1;
+    this.loadAuditLogs();
+  }
+
+  goToPage(page: number) {
+    if (page < 1 || (this.totalPages > 0 && page > this.totalPages)) return;
+    this.page = page;
+    this.loadAuditLogs();
+  }
+
+  changePageSize(event: Event) {
+    const value = Number((event.target as HTMLSelectElement).value);
+    this.pageSize = value;
+    this.page = 1;
+    this.loadAuditLogs();
+  }
+
+  toggleDetail(item: AuditLogListItem) {
+    if (this.expandedId === item.id) {
+      this.expandedId = null;
+      this.selectedDetail = null;
+      this.detailError = null;
+      return;
+    }
+
+    this.expandedId = item.id;
+    this.selectedDetail = null;
+    this.detailError = null;
+    this.detailLoadingId = item.id;
+
+    this.auditService.getAuditLogById(item.id).subscribe({
+      next: (detail) => {
+        this.selectedDetail = detail;
+        this.detailLoadingId = null;
+      },
+      error: (err) => {
+        const parsed: SafeApiError = this.errorParser.parse(err);
+        this.detailError = parsed.message;
+        this.detailLoadingId = null;
+      }
+    });
+  }
+
+  formatAuditValue(value?: string | null) {
+    if (!value) return 'Not set';
+
+    try {
+      return JSON.stringify(JSON.parse(value), null, 2);
+    } catch {
+      return value;
+    }
+  }
+
+  private loadAuditLogs() {
+    this.loading = true;
+    this.error = null;
+    this.expandedId = null;
+    this.selectedDetail = null;
+    this.detailError = null;
+
+    this.auditService.getAuditLogs(this.buildFilters()).subscribe({
+      next: (result) => {
+        this.auditLogs = result.items;
+        this.page = result.page;
+        this.pageSize = result.pageSize;
+        this.totalCount = result.totalCount;
+        this.totalPages = result.totalPages;
+        this.loading = false;
+      },
+      error: (err) => {
+        const parsed: SafeApiError = this.errorParser.parse(err);
+        this.error = parsed.message;
+        this.auditLogs = [];
+        this.loading = false;
+      }
+    });
+  }
+
+  private buildFilters(): AuditLogFilters {
+    const value = this.filterForm.getRawValue();
+    return {
+      actorUserId: this.clean(value.actorUserId),
+      action: this.clean(value.action),
+      entityType: this.clean(value.entityType),
+      entityId: this.clean(value.entityId),
+      fromUtc: this.clean(value.fromUtc),
+      toUtc: this.clean(value.toUtc),
+      page: this.page,
+      pageSize: this.pageSize
+    };
+  }
+
+  private clean(value?: string | null) {
+    const trimmed = value?.trim();
+    return trimmed ? trimmed : null;
+  }
+}

--- a/frontend/src/app/features/audit/audit.models.ts
+++ b/frontend/src/app/features/audit/audit.models.ts
@@ -1,0 +1,44 @@
+export interface AuditLogListItem {
+  id: string;
+  actorUserId?: string | null;
+  actorDisplayName?: string | null;
+  action: string;
+  entityType: string;
+  entityId: string;
+  createdAt: string;
+  correlationId?: string | null;
+}
+
+export interface AuditLogDetail extends AuditLogListItem {
+  previousValue?: string | null;
+  newValue?: string | null;
+}
+
+export interface AuditLogFilters {
+  actorUserId?: string | null;
+  action?: string | null;
+  entityType?: string | null;
+  entityId?: string | null;
+  fromUtc?: string | null;
+  toUtc?: string | null;
+  accountId?: string | null;
+  campaignId?: string | null;
+  page?: number | null;
+  pageSize?: number | null;
+}
+
+export interface PagedApiResponse<T> {
+  data: T[];
+  page: number;
+  pageSize: number;
+  totalCount: number;
+  totalPages: number;
+}
+
+export interface PagedResult<T> {
+  items: T[];
+  page: number;
+  pageSize: number;
+  totalCount: number;
+  totalPages: number;
+}

--- a/frontend/src/app/features/audit/audit.service.spec.ts
+++ b/frontend/src/app/features/audit/audit.service.spec.ts
@@ -1,0 +1,76 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { ApiClientService } from '../../core/services/api-client.service';
+import { AuditService } from './audit.service';
+
+describe('AuditService', () => {
+  let service: AuditService;
+  let apiClient: jasmine.SpyObj<Pick<ApiClientService, 'get'>>;
+
+  beforeEach(() => {
+    apiClient = jasmine.createSpyObj<Pick<ApiClientService, 'get'>>('ApiClientService', ['get']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        AuditService,
+        { provide: ApiClientService, useValue: apiClient }
+      ]
+    });
+
+    service = TestBed.inject(AuditService);
+  });
+
+  it('getAuditLogs calls correct endpoint and unwraps paged data', (done) => {
+    const item = {
+      id: 'audit-1',
+      actorUserId: 'user-1',
+      actorDisplayName: 'Nova Supervisor',
+      action: 'TicketCreated',
+      entityType: 'Ticket',
+      entityId: 'ticket-1',
+      createdAt: '2026-05-18T00:00:00Z',
+      correlationId: 'corr-1'
+    };
+    apiClient.get.and.returnValue(of({ data: [item], page: 1, pageSize: 25, totalCount: 1, totalPages: 1 }));
+
+    service.getAuditLogs({ actorUserId: 'user-1', action: 'TicketCreated', page: 1, pageSize: 25 }).subscribe((result) => {
+      expect(result.items).toEqual([item]);
+      expect(result.totalCount).toBe(1);
+      expect(apiClient.get).toHaveBeenCalledOnceWith('audit-logs?actorUserId=user-1&action=TicketCreated&page=1&pageSize=25');
+      done();
+    });
+  });
+
+  it('getAuditLogById calls correct endpoint and unwraps data', (done) => {
+    const detail = {
+      id: 'audit-1',
+      actorUserId: 'user-1',
+      actorDisplayName: 'Nova Supervisor',
+      action: 'TicketCreated',
+      entityType: 'Ticket',
+      entityId: 'ticket-1',
+      createdAt: '2026-05-18T00:00:00Z',
+      correlationId: 'corr-1',
+      previousValue: null,
+      newValue: '{}'
+    };
+    apiClient.get.and.returnValue(of({ data: detail }));
+
+    service.getAuditLogById('audit-1').subscribe((result) => {
+      expect(result).toEqual(detail);
+      expect(apiClient.get).toHaveBeenCalledOnceWith('audit-logs/audit-1');
+      done();
+    });
+  });
+
+  it('getEntityAuditHistory calls correct endpoint', (done) => {
+    apiClient.get.and.returnValue(of({ data: [], page: 1, pageSize: 25, totalCount: 0, totalPages: 0 }));
+
+    service.getEntityAuditHistory('Ticket', 'ticket-1').subscribe((result) => {
+      expect(result.items).toEqual([]);
+      expect(apiClient.get).toHaveBeenCalledOnceWith('audit-logs/entity/Ticket/ticket-1');
+      done();
+    });
+  });
+});

--- a/frontend/src/app/features/audit/audit.service.ts
+++ b/frontend/src/app/features/audit/audit.service.ts
@@ -1,0 +1,60 @@
+import { Injectable, inject } from '@angular/core';
+import { map } from 'rxjs';
+
+import { ApiResponse } from '../../core/auth/auth.models';
+import { ApiClientService } from '../../core/services/api-client.service';
+import { AuditLogDetail, AuditLogFilters, AuditLogListItem, PagedApiResponse, PagedResult } from './audit.models';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuditService {
+  private readonly apiClient = inject(ApiClientService);
+
+  getAuditLogs(filters: AuditLogFilters = {}) {
+    return this.apiClient
+      .get<PagedApiResponse<AuditLogListItem>>(`audit-logs${this.buildQuery(filters)}`)
+      .pipe(map((response) => this.unwrapPaged(response)));
+  }
+
+  getAuditLogById(id: string) {
+    return this.apiClient
+      .get<ApiResponse<AuditLogDetail>>(`audit-logs/${id}`)
+      .pipe(map((response) => response.data));
+  }
+
+  getEntityAuditHistory(entityType: string, entityId: string, filters: Pick<AuditLogFilters, 'fromUtc' | 'toUtc' | 'page' | 'pageSize'> = {}) {
+    return this.apiClient
+      .get<PagedApiResponse<AuditLogListItem>>(
+        `audit-logs/entity/${encodeURIComponent(entityType)}/${entityId}${this.buildQuery(filters)}`
+      )
+      .pipe(map((response) => this.unwrapPaged(response)));
+  }
+
+  private buildQuery(filters: AuditLogFilters) {
+    const params = new URLSearchParams();
+    if (filters.actorUserId) params.set('actorUserId', filters.actorUserId);
+    if (filters.action) params.set('action', filters.action);
+    if (filters.entityType) params.set('entityType', filters.entityType);
+    if (filters.entityId) params.set('entityId', filters.entityId);
+    if (filters.fromUtc) params.set('fromUtc', filters.fromUtc);
+    if (filters.toUtc) params.set('toUtc', filters.toUtc);
+    if (filters.accountId) params.set('accountId', filters.accountId);
+    if (filters.campaignId) params.set('campaignId', filters.campaignId);
+    if (filters.page) params.set('page', String(filters.page));
+    if (filters.pageSize) params.set('pageSize', String(filters.pageSize));
+
+    const query = params.toString();
+    return query ? `?${query}` : '';
+  }
+
+  private unwrapPaged<T>(response: PagedApiResponse<T>): PagedResult<T> {
+    return {
+      items: response.data,
+      page: response.page,
+      pageSize: response.pageSize,
+      totalCount: response.totalCount,
+      totalPages: response.totalPages
+    };
+  }
+}

--- a/frontend/src/app/features/tickets/ticket-detail.component.spec.ts
+++ b/frontend/src/app/features/tickets/ticket-detail.component.spec.ts
@@ -1,16 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
-import { of, throwError } from 'rxjs';
+import { defer, of, throwError } from 'rxjs';
 
 import { AuthService } from '../../core/auth/auth.service';
 import { AppPermissions } from '../../core/auth/auth-permissions';
 import { ApiErrorParserService } from '../../core/services/api-error-parser.service';
+import { AuditService } from '../audit/audit.service';
 import { TicketDetailComponent } from './ticket-detail.component';
 import { TicketCommentDto, TicketDetail } from './ticket.models';
 import { TicketService } from './ticket.service';
 
 describe('TicketDetailComponent', () => {
   let ticketService: jasmine.SpyObj<Pick<TicketService, 'getTicket' | 'getEligibleAgents' | 'assignTicket' | 'updateTicketStatus' | 'updateTicketPriority' | 'getComments' | 'addComment' | 'escalateTicket' | 'resolveTicket' | 'closeTicket' | 'getTicketHistory'>>;
+  let auditService: jasmine.SpyObj<Pick<AuditService, 'getEntityAuditHistory'>>;
   let authService: jasmine.SpyObj<Pick<AuthService, 'hasPermission'>>;
   let errorParser: jasmine.SpyObj<Pick<ApiErrorParserService, 'parse'>>;
   let fixture: ComponentFixture<TicketDetailComponent>;
@@ -20,6 +22,7 @@ describe('TicketDetailComponent', () => {
       'TicketService',
       ['getTicket', 'getEligibleAgents', 'assignTicket', 'updateTicketStatus', 'updateTicketPriority', 'getComments', 'addComment', 'escalateTicket', 'resolveTicket', 'closeTicket', 'getTicketHistory']
     );
+    auditService = jasmine.createSpyObj<Pick<AuditService, 'getEntityAuditHistory'>>('AuditService', ['getEntityAuditHistory']);
     authService = jasmine.createSpyObj<Pick<AuthService, 'hasPermission'>>('AuthService', ['hasPermission']);
     errorParser = jasmine.createSpyObj<Pick<ApiErrorParserService, 'parse'>>('ApiErrorParserService', ['parse']);
 
@@ -33,6 +36,13 @@ describe('TicketDetailComponent', () => {
     ]));
     ticketService.getComments.and.returnValue(of([]));
     ticketService.getTicketHistory.and.returnValue(of([]));
+    auditService.getEntityAuditHistory.and.returnValue(of({
+      items: [],
+      page: 1,
+      pageSize: 25,
+      totalCount: 0,
+      totalPages: 0
+    }));
     errorParser.parse.and.returnValue({ code: 'bad_request', message: 'Request failed.', details: [] });
 
     TestBed.configureTestingModule({
@@ -48,6 +58,7 @@ describe('TicketDetailComponent', () => {
           }
         },
         { provide: TicketService, useValue: ticketService },
+        { provide: AuditService, useValue: auditService },
         { provide: AuthService, useValue: authService },
         { provide: ApiErrorParserService, useValue: errorParser }
       ]
@@ -146,6 +157,46 @@ describe('TicketDetailComponent', () => {
     expect(text).toContain('Nova Agent');
     expect(text).toContain('Checked the billing timeline.');
     expect(ticketService.getComments).toHaveBeenCalledOnceWith('ticket-1');
+  });
+
+  it('lazy-loads audit history when AuditView permission is present', async () => {
+    authService.hasPermission.and.callFake((permission) => permission === AppPermissions.AuditView);
+    ticketService.getTicket.and.returnValue(of(buildTicket({ status: 'Open' })));
+    auditService.getEntityAuditHistory.and.returnValue(defer(() => Promise.resolve({
+      items: [
+        {
+          id: 'audit-1',
+          actorUserId: 'user-1',
+          actorDisplayName: 'Nova Supervisor',
+          action: 'TicketCreated',
+          entityType: 'Ticket',
+          entityId: 'ticket-1',
+          createdAt: '2026-05-18T00:00:00Z',
+          correlationId: 'corr-1'
+        }
+      ],
+      page: 1,
+      pageSize: 25,
+      totalCount: 1,
+      totalPages: 1
+    })));
+
+    fixture = TestBed.createComponent(TicketDetailComponent);
+    fixture.detectChanges();
+
+    expect(auditService.getEntityAuditHistory).not.toHaveBeenCalled();
+
+    fixture.componentInstance.toggleAuditHistory();
+    await fixture.whenStable();
+
+    expect(auditService.getEntityAuditHistory).toHaveBeenCalledOnceWith('Ticket', 'ticket-1');
+    expect(fixture.componentInstance.auditHistoryExpanded).toBeTrue();
+    expect(fixture.componentInstance.auditHistory).toEqual([
+      jasmine.objectContaining({
+        action: 'TicketCreated',
+        actorDisplayName: 'Nova Supervisor'
+      })
+    ]);
   });
 
   it('shows add-comment form for TicketsComment and non-Closed ticket', () => {

--- a/frontend/src/app/features/tickets/ticket-detail.component.ts
+++ b/frontend/src/app/features/tickets/ticket-detail.component.ts
@@ -7,6 +7,8 @@ import { AppPermissions } from '../../core/auth/auth-permissions';
 import { AuthService } from '../../core/auth/auth.service';
 import { SafeApiError } from '../../core/models/api-error.models';
 import { ApiErrorParserService } from '../../core/services/api-error-parser.service';
+import { AuditLogListItem } from '../audit/audit.models';
+import { AuditService } from '../audit/audit.service';
 import { SlaStateBadgeComponent } from '../../shared/components/sla-state-badge.component';
 import { TicketService } from './ticket.service';
 import { EligibleAgentDto, TicketCommentDto, TicketDetail, TicketStatusHistoryItemDto } from './ticket.models';
@@ -265,6 +267,32 @@ import { EligibleAgentDto, TicketCommentDto, TicketDetail, TicketStatusHistoryIt
           </ng-template>
         </section>
 
+        <section *ngIf="canShowAuditHistory" class="audit-section" aria-labelledby="audit-title">
+          <h2 id="audit-title">Audit History</h2>
+
+          <button type="button" class="btn btn-secondary" (click)="toggleAuditHistory()" [disabled]="auditHistoryLoading">
+            {{ auditHistoryExpanded ? 'Hide Audit History' : 'Show Audit History' }}
+          </button>
+
+          <div *ngIf="auditHistoryExpanded">
+            <div *ngIf="auditHistoryLoading" class="loading">Loading audit history...</div>
+            <div *ngIf="auditHistoryError" class="error">{{ auditHistoryError }}</div>
+
+            <div *ngIf="!auditHistoryLoading && auditHistory.length > 0; else noAuditHistory" class="history-list">
+              <article *ngFor="let item of auditHistory" class="history-item">
+                <div><strong>{{ item.action }}</strong></div>
+                <div>{{ item.actorDisplayName || item.actorUserId || 'System' }}</div>
+                <div>{{ item.createdAt | date:'medium' }}</div>
+                <div *ngIf="item.correlationId">Correlation: {{ item.correlationId }}</div>
+              </article>
+            </div>
+
+            <ng-template #noAuditHistory>
+              <p *ngIf="!auditHistoryLoading && !auditHistoryError">No audit history found.</p>
+            </ng-template>
+          </div>
+        </section>
+
         <section *ngIf="canShowComments" class="comments-section" aria-labelledby="comments-title">
           <h2 id="comments-title">Internal Comments</h2>
 
@@ -313,6 +341,7 @@ export class TicketDetailComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
   private readonly fb = inject(FormBuilder);
   private readonly ticketService = inject(TicketService);
+  private readonly auditService = inject(AuditService);
   private readonly authService = inject(AuthService);
   private readonly errorParser = inject(ApiErrorParserService);
 
@@ -323,6 +352,7 @@ export class TicketDetailComponent implements OnInit {
   eligibleAgents: EligibleAgentDto[] = [];
   comments: TicketCommentDto[] = [];
   statusHistory: TicketStatusHistoryItemDto[] = [];
+  auditHistory: AuditLogListItem[] = [];
   loading = true;
   assignmentLoading = false;
   assignmentSubmitting = false;
@@ -332,6 +362,9 @@ export class TicketDetailComponent implements OnInit {
   escalationSubmitting = false;
   resolveSubmitting = false;
   closeSubmitting = false;
+  auditHistoryExpanded = false;
+  auditHistoryLoaded = false;
+  auditHistoryLoading = false;
   error: string | null = null;
   assignmentError: string | null = null;
   assignmentLoadError: string | null = null;
@@ -342,6 +375,7 @@ export class TicketDetailComponent implements OnInit {
   resolveError: string | null = null;
   closeError: string | null = null;
   historyError: string | null = null;
+  auditHistoryError: string | null = null;
   assignmentFieldErrors: Record<string, string> = {};
   statusFieldErrors: Record<string, string> = {};
   priorityFieldErrors: Record<string, string> = {};
@@ -408,6 +442,10 @@ export class TicketDetailComponent implements OnInit {
 
   get canShowHistory() {
     return this.authService.hasPermission(AppPermissions.TicketsHistoryView);
+  }
+
+  get canShowAuditHistory() {
+    return this.authService.hasPermission(AppPermissions.AuditView);
   }
 
   get canShowComments() {
@@ -729,6 +767,28 @@ export class TicketDetailComponent implements OnInit {
         const parsed = this.errorParser.parse(err);
         this.closeError = parsed.message;
         this.closeSubmitting = false;
+      }
+    });
+  }
+
+  toggleAuditHistory() {
+    this.auditHistoryExpanded = !this.auditHistoryExpanded;
+    if (!this.auditHistoryExpanded || this.auditHistoryLoaded || this.auditHistoryLoading || !this.ticket) return;
+
+    this.auditHistoryLoading = true;
+    this.auditHistoryError = null;
+
+    this.auditService.getEntityAuditHistory('Ticket', this.ticket.id).subscribe({
+      next: (result) => {
+        this.auditHistory = result.items;
+        this.auditHistoryLoaded = true;
+        this.auditHistoryLoading = false;
+      },
+      error: (err) => {
+        const parsed: SafeApiError = this.errorParser.parse(err);
+        this.auditHistoryError = parsed.message;
+        this.auditHistory = [];
+        this.auditHistoryLoading = false;
       }
     });
   }

--- a/src/OpsSphere.Api/Common/ApiEnvelope.cs
+++ b/src/OpsSphere.Api/Common/ApiEnvelope.cs
@@ -4,6 +4,13 @@ namespace OpsSphere.Api.Common;
 
 public sealed record ApiResponse<T>(T Data);
 
+public sealed record PagedApiResponse<T>(
+    IReadOnlyList<T> Data,
+    int Page,
+    int PageSize,
+    int TotalCount,
+    int TotalPages);
+
 public sealed record ApiErrorEnvelope(ApiError Error);
 
 public sealed record ApiError(

--- a/src/OpsSphere.Api/Controllers/AuditController.cs
+++ b/src/OpsSphere.Api/Controllers/AuditController.cs
@@ -1,0 +1,76 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using OpsSphere.Api.Common;
+using OpsSphere.Application.Features.AuditManagement;
+using OpsSphere.Domain.Authorization;
+
+namespace OpsSphere.Api.Controllers;
+
+[ApiController]
+[Route("api/audit-logs")]
+[Authorize]
+public sealed class AuditController : ControllerBase
+{
+    private readonly GetAuditLogsQueryHandler getAuditLogs;
+    private readonly GetAuditLogByIdQueryHandler getAuditLogById;
+    private readonly GetEntityAuditHistoryQueryHandler getEntityAuditHistory;
+
+    public AuditController(
+        GetAuditLogsQueryHandler getAuditLogs,
+        GetAuditLogByIdQueryHandler getAuditLogById,
+        GetEntityAuditHistoryQueryHandler getEntityAuditHistory)
+    {
+        this.getAuditLogs = getAuditLogs;
+        this.getAuditLogById = getAuditLogById;
+        this.getEntityAuditHistory = getEntityAuditHistory;
+    }
+
+    [HttpGet]
+    [Authorize(Policy = Permissions.AuditView)]
+    public async Task<IActionResult> GetAuditLogs(
+        [FromQuery] Guid? actorUserId,
+        [FromQuery] string? action,
+        [FromQuery] string? entityType,
+        [FromQuery] Guid? entityId,
+        [FromQuery] DateTime? fromUtc,
+        [FromQuery] DateTime? toUtc,
+        [FromQuery] Guid? accountId,
+        [FromQuery] Guid? campaignId,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 25,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await getAuditLogs.HandleAsync(
+            new GetAuditLogsQuery(actorUserId, action, entityType, entityId, fromUtc, toUtc, accountId, campaignId, page, pageSize),
+            cancellationToken);
+
+        return Ok(ToResponse(result));
+    }
+
+    [HttpGet("{id:guid}")]
+    [Authorize(Policy = Permissions.AuditView)]
+    public async Task<IActionResult> GetAuditLogById(Guid id, CancellationToken cancellationToken) =>
+        Ok(new ApiResponse<AuditLogDetailDto>(
+            await getAuditLogById.HandleAsync(new GetAuditLogByIdQuery(id), cancellationToken)));
+
+    [HttpGet("entity/{entityType}/{entityId:guid}")]
+    [Authorize(Policy = Permissions.AuditView)]
+    public async Task<IActionResult> GetEntityAuditHistory(
+        string entityType,
+        Guid entityId,
+        [FromQuery] DateTime? fromUtc,
+        [FromQuery] DateTime? toUtc,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 25,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await getEntityAuditHistory.HandleAsync(
+            new GetEntityAuditHistoryQuery(entityType, entityId, fromUtc, toUtc, page, pageSize),
+            cancellationToken);
+
+        return Ok(ToResponse(result));
+    }
+
+    private static PagedApiResponse<T> ToResponse<T>(PagedResultDto<T> result) =>
+        new(result.Items, result.Page, result.PageSize, result.TotalCount, result.TotalPages);
+}

--- a/src/OpsSphere.Application/Common/Interfaces/IAuditRepository.cs
+++ b/src/OpsSphere.Application/Common/Interfaces/IAuditRepository.cs
@@ -1,0 +1,10 @@
+using OpsSphere.Application.Features.AuditManagement;
+
+namespace OpsSphere.Application.Common.Interfaces;
+
+public interface IAuditRepository
+{
+    Task<PagedResultDto<AuditLogListItemDto>> GetAuditLogsAsync(GetAuditLogsQuery query, CancellationToken cancellationToken);
+    Task<AuditLogDetailDto?> GetAuditLogByIdAsync(Guid id, CancellationToken cancellationToken);
+    Task<PagedResultDto<AuditLogListItemDto>> GetEntityAuditHistoryAsync(GetEntityAuditHistoryQuery query, CancellationToken cancellationToken);
+}

--- a/src/OpsSphere.Application/DependencyInjection.cs
+++ b/src/OpsSphere.Application/DependencyInjection.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using OpsSphere.Application.Features.AuditManagement;
 using OpsSphere.Application.Features.Auth.GetCurrentUser;
 using OpsSphere.Application.Features.Auth.Login;
 using OpsSphere.Application.Features.CustomerManagement;
@@ -67,6 +68,9 @@ public static class DependencyInjection
         services.AddScoped<CloseTicketCommandHandler>();
         services.AddScoped<GetTicketStatusHistoryQueryHandler>();
         services.AddScoped<GetSlaSummaryQueryHandler>();
+        services.AddScoped<GetAuditLogsQueryHandler>();
+        services.AddScoped<GetAuditLogByIdQueryHandler>();
+        services.AddScoped<GetEntityAuditHistoryQueryHandler>();
         services.AddSingleton<SlaEvaluator>();
 
         return services;

--- a/src/OpsSphere.Application/Features/AuditManagement/AuditManagementDtos.cs
+++ b/src/OpsSphere.Application/Features/AuditManagement/AuditManagementDtos.cs
@@ -1,0 +1,30 @@
+namespace OpsSphere.Application.Features.AuditManagement;
+
+public sealed record AuditLogListItemDto(
+    Guid Id,
+    Guid? ActorUserId,
+    string? ActorDisplayName,
+    string Action,
+    string EntityType,
+    Guid EntityId,
+    DateTime CreatedAt,
+    string? CorrelationId);
+
+public sealed record AuditLogDetailDto(
+    Guid Id,
+    Guid? ActorUserId,
+    string? ActorDisplayName,
+    string Action,
+    string EntityType,
+    Guid EntityId,
+    string? PreviousValue,
+    string? NewValue,
+    string? CorrelationId,
+    DateTime CreatedAt);
+
+public sealed record PagedResultDto<T>(
+    IReadOnlyList<T> Items,
+    int Page,
+    int PageSize,
+    int TotalCount,
+    int TotalPages);

--- a/src/OpsSphere.Application/Features/AuditManagement/AuditManagementHandlers.cs
+++ b/src/OpsSphere.Application/Features/AuditManagement/AuditManagementHandlers.cs
@@ -1,0 +1,67 @@
+using OpsSphere.Application.Common.Exceptions;
+using OpsSphere.Application.Common.Interfaces;
+
+namespace OpsSphere.Application.Features.AuditManagement;
+
+public sealed class GetAuditLogsQueryHandler(IAuditRepository repository)
+{
+    public Task<PagedResultDto<AuditLogListItemDto>> HandleAsync(GetAuditLogsQuery query, CancellationToken cancellationToken)
+    {
+        ValidatePage(query.Page, query.PageSize);
+        ValidateDateRange(query.FromUtc, query.ToUtc);
+
+        return repository.GetAuditLogsAsync(query, cancellationToken);
+    }
+
+    private static void ValidatePage(int page, int pageSize)
+    {
+        var failures = new List<ValidationFailure>();
+        if (page < 1) failures.Add(new ValidationFailure("page", "Page must be 1 or greater."));
+        if (pageSize is < 1 or > 100) failures.Add(new ValidationFailure("pageSize", "Page size must be between 1 and 100."));
+        if (failures.Count > 0) throw new ValidationException(failures);
+    }
+
+    private static void ValidateDateRange(DateTime? fromUtc, DateTime? toUtc)
+    {
+        if (fromUtc.HasValue && toUtc.HasValue && fromUtc.Value > toUtc.Value)
+            throw new ValidationException("fromUtc", "From date/time must be before or equal to to date/time.");
+    }
+}
+
+public sealed class GetAuditLogByIdQueryHandler(IAuditRepository repository)
+{
+    public async Task<AuditLogDetailDto> HandleAsync(GetAuditLogByIdQuery query, CancellationToken cancellationToken)
+    {
+        if (query.Id == Guid.Empty)
+            throw new ValidationException("id", "Audit log id is required.");
+
+        return await repository.GetAuditLogByIdAsync(query.Id, cancellationToken)
+            ?? throw new NotFoundException("Audit log", query.Id);
+    }
+}
+
+public sealed class GetEntityAuditHistoryQueryHandler(IAuditRepository repository)
+{
+    public async Task<PagedResultDto<AuditLogListItemDto>> HandleAsync(GetEntityAuditHistoryQuery query, CancellationToken cancellationToken)
+    {
+        var failures = new List<ValidationFailure>();
+        if (string.IsNullOrWhiteSpace(query.EntityType))
+            failures.Add(new ValidationFailure("entityType", "Entity type is required."));
+        if (query.EntityId == Guid.Empty)
+            failures.Add(new ValidationFailure("entityId", "Entity id is required."));
+        if (query.Page < 1)
+            failures.Add(new ValidationFailure("page", "Page must be 1 or greater."));
+        if (query.PageSize is < 1 or > 100)
+            failures.Add(new ValidationFailure("pageSize", "Page size must be between 1 and 100."));
+        if (query.FromUtc.HasValue && query.ToUtc.HasValue && query.FromUtc.Value > query.ToUtc.Value)
+            failures.Add(new ValidationFailure("fromUtc", "From date/time must be before or equal to to date/time."));
+
+        if (failures.Count > 0) throw new ValidationException(failures);
+
+        var result = await repository.GetEntityAuditHistoryAsync(query, cancellationToken);
+        if (result.TotalCount == 0)
+            throw new NotFoundException($"{query.EntityType} audit history", query.EntityId);
+
+        return result;
+    }
+}

--- a/src/OpsSphere.Application/Features/AuditManagement/AuditManagementQueries.cs
+++ b/src/OpsSphere.Application/Features/AuditManagement/AuditManagementQueries.cs
@@ -1,0 +1,23 @@
+namespace OpsSphere.Application.Features.AuditManagement;
+
+public sealed record GetAuditLogsQuery(
+    Guid? ActorUserId,
+    string? Action,
+    string? EntityType,
+    Guid? EntityId,
+    DateTime? FromUtc,
+    DateTime? ToUtc,
+    Guid? AccountId,
+    Guid? CampaignId,
+    int Page = 1,
+    int PageSize = 25);
+
+public sealed record GetAuditLogByIdQuery(Guid Id);
+
+public sealed record GetEntityAuditHistoryQuery(
+    string EntityType,
+    Guid EntityId,
+    DateTime? FromUtc,
+    DateTime? ToUtc,
+    int Page = 1,
+    int PageSize = 25);

--- a/src/OpsSphere.Infrastructure/AuditManagement/AuditRepository.cs
+++ b/src/OpsSphere.Infrastructure/AuditManagement/AuditRepository.cs
@@ -1,0 +1,163 @@
+using Microsoft.EntityFrameworkCore;
+using OpsSphere.Application.Common.Authorization;
+using OpsSphere.Application.Common.Interfaces;
+using OpsSphere.Application.Features.AuditManagement;
+using OpsSphere.Domain.Authorization;
+using OpsSphere.Domain.Entities;
+using OpsSphere.Infrastructure.Authorization;
+using OpsSphere.Infrastructure.Persistence;
+
+namespace OpsSphere.Infrastructure.AuditManagement;
+
+internal sealed class AuditRepository : IAuditRepository
+{
+    private const string TicketEntityType = "Ticket";
+    private const string CustomerEntityType = "Customer";
+    private const string AccountEntityType = "Account";
+    private const string CampaignEntityType = "Campaign";
+
+    private readonly OpsSphereDbContext dbContext;
+    private readonly ICurrentUserAuthorizationService authorizationService;
+
+    public AuditRepository(OpsSphereDbContext dbContext, ICurrentUserAuthorizationService authorizationService)
+    {
+        this.dbContext = dbContext;
+        this.authorizationService = authorizationService;
+    }
+
+    public async Task<PagedResultDto<AuditLogListItemDto>> GetAuditLogsAsync(GetAuditLogsQuery query, CancellationToken cancellationToken)
+    {
+        var profile = await GetProfileAsync(cancellationToken);
+        var auditLogs = ApplyFilters(ApplyScope(profile), query);
+
+        return await ToPagedListAsync(auditLogs, query.Page, query.PageSize, cancellationToken);
+    }
+
+    public async Task<AuditLogDetailDto?> GetAuditLogByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var profile = await GetProfileAsync(cancellationToken);
+
+        return await ApplyScope(profile)
+            .Where(a => a.Id == id)
+            .Select(a => new AuditLogDetailDto(
+                a.Id,
+                a.ActorUserId,
+                a.ActorUser == null ? null : a.ActorUser.DisplayName,
+                a.Action,
+                a.EntityType,
+                a.EntityId,
+                a.PreviousValue,
+                a.NewValue,
+                a.CorrelationId,
+                a.CreatedAt))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<PagedResultDto<AuditLogListItemDto>> GetEntityAuditHistoryAsync(GetEntityAuditHistoryQuery query, CancellationToken cancellationToken)
+    {
+        var profile = await GetProfileAsync(cancellationToken);
+        var auditLogs = ApplyScope(profile)
+            .Where(a => a.EntityType == query.EntityType.Trim() && a.EntityId == query.EntityId);
+
+        if (query.FromUtc.HasValue)
+            auditLogs = auditLogs.Where(a => a.CreatedAt >= query.FromUtc.Value);
+        if (query.ToUtc.HasValue)
+            auditLogs = auditLogs.Where(a => a.CreatedAt <= query.ToUtc.Value);
+
+        return await ToPagedListAsync(auditLogs, query.Page, query.PageSize, cancellationToken);
+    }
+
+    private IQueryable<AuditLog> ApplyScope(CurrentUserAuthorizationProfile profile)
+    {
+        var auditLogs = dbContext.AuditLogs.AsNoTracking();
+        if (profile.HasRole(Roles.Admin) && profile.HasPermission(Permissions.AuditAdminView))
+            return auditLogs;
+
+        var scopedTickets = dbContext.Tickets
+            .AsNoTracking()
+            .Where(t => !t.IsDeleted)
+            .ApplyScopeFilter(profile);
+        var scopedCustomers = dbContext.Customers
+            .AsNoTracking()
+            .Where(c => !c.IsDeleted)
+            .ApplyScopeFilter(profile);
+
+        return auditLogs.Where(a =>
+            (a.EntityType == TicketEntityType && scopedTickets.Any(t => t.Id == a.EntityId)) ||
+            (a.EntityType == CustomerEntityType && scopedCustomers.Any(c => c.Id == a.EntityId)));
+    }
+
+    private IQueryable<AuditLog> ApplyFilters(IQueryable<AuditLog> auditLogs, GetAuditLogsQuery query)
+    {
+        if (query.ActorUserId.HasValue)
+            auditLogs = auditLogs.Where(a => a.ActorUserId == query.ActorUserId.Value);
+
+        var action = query.Action?.Trim();
+        if (!string.IsNullOrWhiteSpace(action))
+            auditLogs = auditLogs.Where(a => a.Action == action);
+
+        var entityType = query.EntityType?.Trim();
+        if (!string.IsNullOrWhiteSpace(entityType))
+            auditLogs = auditLogs.Where(a => a.EntityType == entityType);
+
+        if (query.EntityId.HasValue)
+            auditLogs = auditLogs.Where(a => a.EntityId == query.EntityId.Value);
+
+        if (query.FromUtc.HasValue)
+            auditLogs = auditLogs.Where(a => a.CreatedAt >= query.FromUtc.Value);
+
+        if (query.ToUtc.HasValue)
+            auditLogs = auditLogs.Where(a => a.CreatedAt <= query.ToUtc.Value);
+
+        if (query.AccountId.HasValue)
+            auditLogs = ApplyAccountFilter(auditLogs, query.AccountId.Value);
+
+        if (query.CampaignId.HasValue)
+            auditLogs = ApplyCampaignFilter(auditLogs, query.CampaignId.Value);
+
+        return auditLogs;
+    }
+
+    private IQueryable<AuditLog> ApplyAccountFilter(IQueryable<AuditLog> auditLogs, Guid accountId) =>
+        auditLogs.Where(a =>
+            (a.EntityType == TicketEntityType && dbContext.Tickets.AsNoTracking().Any(t => !t.IsDeleted && t.Id == a.EntityId && t.AccountId == accountId)) ||
+            (a.EntityType == CustomerEntityType && dbContext.Customers.AsNoTracking().Any(c => !c.IsDeleted && c.Id == a.EntityId && c.AccountId == accountId)) ||
+            (a.EntityType == AccountEntityType && a.EntityId == accountId));
+
+    private IQueryable<AuditLog> ApplyCampaignFilter(IQueryable<AuditLog> auditLogs, Guid campaignId) =>
+        auditLogs.Where(a =>
+            (a.EntityType == TicketEntityType && dbContext.Tickets.AsNoTracking().Any(t => !t.IsDeleted && t.Id == a.EntityId && t.CampaignId == campaignId)) ||
+            (a.EntityType == CustomerEntityType && dbContext.Customers.AsNoTracking().Any(c => !c.IsDeleted && c.Id == a.EntityId && c.Account.Campaigns.Any(camp => camp.Id == campaignId))) ||
+            (a.EntityType == CampaignEntityType && a.EntityId == campaignId));
+
+    private static async Task<PagedResultDto<AuditLogListItemDto>> ToPagedListAsync(
+        IQueryable<AuditLog> auditLogs,
+        int page,
+        int pageSize,
+        CancellationToken cancellationToken)
+    {
+        var totalCount = await auditLogs.CountAsync(cancellationToken);
+        var items = await auditLogs
+            .OrderByDescending(a => a.CreatedAt)
+            .ThenByDescending(a => a.Id)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(a => new AuditLogListItemDto(
+                a.Id,
+                a.ActorUserId,
+                a.ActorUser == null ? null : a.ActorUser.DisplayName,
+                a.Action,
+                a.EntityType,
+                a.EntityId,
+                a.CreatedAt,
+                a.CorrelationId))
+            .ToArrayAsync(cancellationToken);
+
+        var totalPages = totalCount == 0 ? 0 : (int)Math.Ceiling(totalCount / (double)pageSize);
+        return new PagedResultDto<AuditLogListItemDto>(items, page, pageSize, totalCount, totalPages);
+    }
+
+    private async Task<CurrentUserAuthorizationProfile> GetProfileAsync(CancellationToken cancellationToken) =>
+        await authorizationService.GetCurrentUserAuthorizationAsync(cancellationToken)
+        ?? new CurrentUserAuthorizationProfile(Guid.Empty, string.Empty, false, [], [], []);
+}

--- a/src/OpsSphere.Infrastructure/DependencyInjection.cs
+++ b/src/OpsSphere.Infrastructure/DependencyInjection.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using OpsSphere.Application.Common.Interfaces;
+using OpsSphere.Infrastructure.AuditManagement;
 using OpsSphere.Infrastructure.Auditing;
 using OpsSphere.Domain.Entities;
 using OpsSphere.Infrastructure.Authentication;
@@ -53,6 +54,7 @@ public static class DependencyInjection
         services.AddScoped<ISlaRepository, SlaRepository>();
         services.AddScoped<ISlaSummaryRepository, SlaSummaryRepository>();
         services.AddScoped<ITicketNumberGenerator, SequentialTicketNumberGenerator>();
+        services.AddScoped<IAuditRepository, AuditRepository>();
         services.AddScoped<IAuditWriter, AuditWriter>();
         services.AddScoped<OpsSphereDataSeeder>();
 

--- a/src/OpsSphere.Infrastructure/Persistence/Configurations/AuditLogConfiguration.cs
+++ b/src/OpsSphere.Infrastructure/Persistence/Configurations/AuditLogConfiguration.cs
@@ -20,6 +20,7 @@ internal sealed class AuditLogConfiguration : IEntityTypeConfiguration<AuditLog>
         builder.HasIndex(a => a.ActorUserId).HasDatabaseName("IX_AuditLogs_ActorUserId");
         builder.HasIndex(a => a.Action).HasDatabaseName("IX_AuditLogs_Action");
         builder.HasIndex(a => new { a.EntityType, a.EntityId }).HasDatabaseName("IX_AuditLogs_EntityType_EntityId");
+        builder.HasIndex(a => new { a.EntityType, a.EntityId, a.CreatedAt }).HasDatabaseName("IX_AuditLogs_EntityType_EntityId_CreatedAt");
         builder.HasIndex(a => a.CreatedAt).HasDatabaseName("IX_AuditLogs_CreatedAt");
         builder.HasIndex(a => a.CorrelationId).HasDatabaseName("IX_AuditLogs_CorrelationId");
 

--- a/src/OpsSphere.Infrastructure/Persistence/Migrations/20260518185236_AddAuditLogEntityHistoryIndex.Designer.cs
+++ b/src/OpsSphere.Infrastructure/Persistence/Migrations/20260518185236_AddAuditLogEntityHistoryIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OpsSphere.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using OpsSphere.Infrastructure.Persistence;
 namespace OpsSphere.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(OpsSphereDbContext))]
-    partial class OpsSphereDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260518185236_AddAuditLogEntityHistoryIndex")]
+    partial class AddAuditLogEntityHistoryIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OpsSphere.Infrastructure/Persistence/Migrations/20260518185236_AddAuditLogEntityHistoryIndex.cs
+++ b/src/OpsSphere.Infrastructure/Persistence/Migrations/20260518185236_AddAuditLogEntityHistoryIndex.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OpsSphere.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAuditLogEntityHistoryIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_AuditLogs_EntityType_EntityId_CreatedAt",
+                table: "AuditLogs",
+                columns: new[] { "EntityType", "EntityId", "CreatedAt" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_AuditLogs_EntityType_EntityId_CreatedAt",
+                table: "AuditLogs");
+        }
+    }
+}

--- a/tests/OpsSphere.IntegrationTests/AuditManagement/AuditApiTests.cs
+++ b/tests/OpsSphere.IntegrationTests/AuditManagement/AuditApiTests.cs
@@ -1,0 +1,555 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using OpsSphere.Domain.Entities;
+using OpsSphere.Domain.Enums;
+using OpsSphere.Infrastructure.Persistence;
+using OpsSphere.Infrastructure.Persistence.SeedData;
+
+namespace OpsSphere.IntegrationTests.AuditManagement;
+
+public sealed class AuditApiTests
+{
+    private const string AdminEmail = "admin@opssphere.local";
+    private const string ManagerEmail = "manager.latam@opssphere.local";
+    private const string SupervisorEmail = "supervisor.novabank@opssphere.local";
+    private const string AgentEmail = "agent.novabank@opssphere.local";
+    private const string ViewerEmail = "viewer.latam@opssphere.local";
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public async Task Admin_CanQueryAuditLogs_Returns200()
+    {
+        await using var factory = await AuditApiFactory.CreateAsync();
+        var ids = await ArrangeAuditLogsAsync(factory);
+        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+
+        var response = await admin.GetAsync("/api/audit-logs");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await ReadResponseAsync<PagedAuditListResponse>(response);
+        Assert.Contains(body.Data, item => item.Id == ids.NovaBankTicketAuditId);
+        Assert.Contains(body.Data, item => item.Id == ids.UserAuditId);
+    }
+
+    [Fact]
+    public async Task OperationsManager_CanQueryAuditLogs_ScopedToRegion()
+    {
+        await using var factory = await AuditApiFactory.CreateAsync();
+        var ids = await ArrangeAuditLogsAsync(factory);
+        var manager = await CreateAuthenticatedClientAsync(factory, ManagerEmail);
+
+        var response = await manager.GetAsync("/api/audit-logs");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await ReadResponseAsync<PagedAuditListResponse>(response);
+        Assert.Contains(body.Data, item => item.Id == ids.NovaBankTicketAuditId);
+        Assert.DoesNotContain(body.Data, item => item.Id == ids.StreamlyTicketAuditId);
+        Assert.DoesNotContain(body.Data, item => item.Id == ids.UserAuditId);
+    }
+
+    [Fact]
+    public async Task Supervisor_CanQueryAuditLogs_ScopedToAccount()
+    {
+        await using var factory = await AuditApiFactory.CreateAsync();
+        var ids = await ArrangeAuditLogsAsync(factory);
+        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+
+        var response = await supervisor.GetAsync("/api/audit-logs");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await ReadResponseAsync<PagedAuditListResponse>(response);
+        Assert.Contains(body.Data, item => item.Id == ids.NovaBankTicketAuditId);
+        Assert.Contains(body.Data, item => item.Id == ids.NovaBankCustomerAuditId);
+        Assert.DoesNotContain(body.Data, item => item.Id == ids.StreamlyTicketAuditId);
+        Assert.DoesNotContain(body.Data, item => item.Id == ids.UserAuditId);
+    }
+
+    [Fact]
+    public async Task Agent_CannotQueryAuditLogs_Returns403()
+    {
+        await using var factory = await AuditApiFactory.CreateAsync();
+        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+
+        var response = await agent.GetAsync("/api/audit-logs");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Viewer_CanQueryAuditLogs_ScopedToScope()
+    {
+        await using var factory = await AuditApiFactory.CreateAsync();
+        var ids = await ArrangeAuditLogsAsync(factory);
+        var viewer = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
+
+        var response = await viewer.GetAsync("/api/audit-logs");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await ReadResponseAsync<PagedAuditListResponse>(response);
+        Assert.Contains(body.Data, item => item.Id == ids.NovaBankTicketAuditId);
+        Assert.DoesNotContain(body.Data, item => item.Id == ids.StreamlyTicketAuditId);
+    }
+
+    [Fact]
+    public async Task Unauthenticated_CannotQueryAuditLogs_Returns401()
+    {
+        await using var factory = await AuditApiFactory.CreateAsync();
+
+        var response = await factory.CreateClient().GetAsync("/api/audit-logs");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task NonAdmin_CannotGetAuditLogById_OutOfScope_Returns404()
+    {
+        await using var factory = await AuditApiFactory.CreateAsync();
+        var ids = await ArrangeAuditLogsAsync(factory);
+        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+
+        var response = await supervisor.GetAsync($"/api/audit-logs/{ids.StreamlyTicketAuditId}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Admin_CanGetAuditLogById_Returns200()
+    {
+        await using var factory = await AuditApiFactory.CreateAsync();
+        var ids = await ArrangeAuditLogsAsync(factory);
+        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+
+        var response = await admin.GetAsync($"/api/audit-logs/{ids.NovaBankTicketAuditId}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await ReadResponseAsync<ApiResponse<AuditDetailResponse>>(response);
+        Assert.Equal(ids.NovaBankTicketAuditId, body.Data.Id);
+        Assert.Equal("TicketCreated", body.Data.Action);
+        Assert.NotNull(body.Data.NewValue);
+        Assert.Equal("corr-ticket", body.Data.CorrelationId);
+    }
+
+    [Fact]
+    public async Task NonAdmin_CanGetAuditLogById_InScope_Returns200()
+    {
+        await using var factory = await AuditApiFactory.CreateAsync();
+        var ids = await ArrangeAuditLogsAsync(factory);
+        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+
+        var response = await supervisor.GetAsync($"/api/audit-logs/{ids.NovaBankTicketAuditId}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task EntityAuditHistory_Ticket_IsScopedAndPaged()
+    {
+        await using var factory = await AuditApiFactory.CreateAsync();
+        var ids = await ArrangeAuditLogsAsync(factory);
+        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+
+        var response = await supervisor.GetAsync($"/api/audit-logs/entity/Ticket/{ids.NovaBankTicketId}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await ReadResponseAsync<PagedAuditListResponse>(response);
+        Assert.Contains(body.Data, item => item.EntityId == ids.NovaBankTicketId);
+        Assert.DoesNotContain(body.Data, item => item.EntityId == ids.StreamlyTicketId);
+    }
+
+    [Fact]
+    public async Task Supervisor_CannotGetEntityAuditHistory_OutOfScope_Returns404()
+    {
+        await using var factory = await AuditApiFactory.CreateAsync();
+        var ids = await ArrangeAuditLogsAsync(factory);
+        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+
+        var response = await supervisor.GetAsync($"/api/audit-logs/entity/Ticket/{ids.StreamlyTicketId}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AuditFilters_ReturnExpectedRows()
+    {
+        await using var factory = await AuditApiFactory.CreateAsync();
+        var ids = await ArrangeAuditLogsAsync(factory);
+        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+
+        var byActor = await ReadResponseAsync<PagedAuditListResponse>(
+            await admin.GetAsync($"/api/audit-logs?actorUserId={SeedIds.Users.SupervisorNovabank}"));
+        var byAction = await ReadResponseAsync<PagedAuditListResponse>(
+            await admin.GetAsync("/api/audit-logs?action=CustomerUpdated"));
+        var byEntity = await ReadResponseAsync<PagedAuditListResponse>(
+            await admin.GetAsync($"/api/audit-logs?entityType=Ticket&entityId={ids.NovaBankTicketId}"));
+        var byAccount = await ReadResponseAsync<PagedAuditListResponse>(
+            await admin.GetAsync($"/api/audit-logs?accountId={SeedIds.Accounts.NovaBank}"));
+
+        Assert.Contains(byActor.Data, item => item.ActorUserId == SeedIds.Users.SupervisorNovabank);
+        Assert.All(byAction.Data, item => Assert.Equal("CustomerUpdated", item.Action));
+        Assert.Single(byEntity.Data);
+        Assert.Contains(byAccount.Data, item => item.Id == ids.NovaBankTicketAuditId);
+        Assert.DoesNotContain(byAccount.Data, item => item.Id == ids.StreamlyTicketAuditId);
+    }
+
+    [Fact]
+    public async Task AuditFilters_ByDateRange_ReturnExpectedRows()
+    {
+        await using var factory = await AuditApiFactory.CreateAsync();
+        var ids = await ArrangeAuditLogsAsync(factory);
+        await SetAuditCreatedAtAsync(factory, ids.NovaBankTicketAuditId, new DateTime(2026, 05, 01, 0, 0, 0, DateTimeKind.Utc));
+        await SetAuditCreatedAtAsync(factory, ids.NovaBankCustomerAuditId, new DateTime(2026, 05, 10, 0, 0, 0, DateTimeKind.Utc));
+        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+
+        var response = await admin.GetAsync("/api/audit-logs?fromUtc=2026-05-09T00:00:00Z&toUtc=2026-05-11T00:00:00Z");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await ReadResponseAsync<PagedAuditListResponse>(response);
+        Assert.Contains(body.Data, item => item.Id == ids.NovaBankCustomerAuditId);
+        Assert.DoesNotContain(body.Data, item => item.Id == ids.NovaBankTicketAuditId);
+    }
+
+    [Fact]
+    public async Task InvalidFilterDateRange_Returns400()
+    {
+        await using var factory = await AuditApiFactory.CreateAsync();
+        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+
+        var response = await admin.GetAsync("/api/audit-logs?fromUtc=2026-05-11T00:00:00Z&toUtc=2026-05-09T00:00:00Z");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AuditLogs_CannotBeModified_NoPutDeleteEndpoints()
+    {
+        await using var factory = await AuditApiFactory.CreateAsync();
+        var ids = await ArrangeAuditLogsAsync(factory);
+        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+
+        var put = await admin.PutAsJsonAsync($"/api/audit-logs/{ids.NovaBankTicketAuditId}", new { action = "Changed" });
+        var delete = await admin.DeleteAsync($"/api/audit-logs/{ids.NovaBankTicketAuditId}");
+
+        Assert.True(put.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.MethodNotAllowed);
+        Assert.True(delete.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.MethodNotAllowed);
+    }
+
+    [Fact]
+    public async Task TicketCreated_ProducesAuditRecord_QueryableViaApi()
+    {
+        await using var factory = await AuditApiFactory.CreateAsync();
+        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+
+        var createResponse = await supervisor.PostAsJsonAsync("/api/tickets", new
+        {
+            customerId = SeedIds.Customers.NovaBankCustomer1,
+            accountId = SeedIds.Accounts.NovaBank,
+            campaignId = SeedIds.Campaigns.NovaBankCreditCard,
+            category = "Support",
+            priority = "Normal",
+            subject = "Queryable audit record",
+            description = "Creates an audit log through the existing ticket write path."
+        });
+        createResponse.EnsureSuccessStatusCode();
+        var created = await ReadResponseAsync<ApiResponse<CreateTicketResponse>>(createResponse);
+
+        var auditResponse = await supervisor.GetAsync($"/api/audit-logs?entityType=Ticket&entityId={created.Data.Id}&action=TicketCreated");
+
+        Assert.Equal(HttpStatusCode.OK, auditResponse.StatusCode);
+        var auditBody = await ReadResponseAsync<PagedAuditListResponse>(auditResponse);
+        Assert.Single(auditBody.Data);
+    }
+
+    [Fact]
+    public async Task AuditList_DoesNotExposeSensitiveDetailFields()
+    {
+        await using var factory = await AuditApiFactory.CreateAsync();
+        await ArrangeAuditLogsAsync(factory);
+        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+
+        var json = await (await admin.GetAsync("/api/audit-logs")).Content.ReadAsStringAsync();
+
+        Assert.DoesNotContain("previousValue", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("newValue", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ipAddress", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("userAgent", json, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AuditDetail_ExposesPreviousNewValueAndCorrelationIdSafely()
+    {
+        await using var factory = await AuditApiFactory.CreateAsync();
+        var ids = await ArrangeAuditLogsAsync(factory);
+        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+
+        var response = await admin.GetAsync($"/api/audit-logs/{ids.NovaBankTicketAuditId}");
+
+        var json = await response.Content.ReadAsStringAsync();
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("previousValue", json, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("newValue", json, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("correlationId", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ipAddress", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("userAgent", json, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static async Task<AuditArrangement> ArrangeAuditLogsAsync(AuditApiFactory factory)
+    {
+        var novaTicketId = await AddTicketDirectlyAsync(
+            factory,
+            SeedIds.Accounts.NovaBank,
+            SeedIds.Campaigns.NovaBankCreditCard,
+            SeedIds.Customers.NovaBankCustomer1,
+            "Nova audit ticket");
+        var streamlyTicketId = await AddTicketDirectlyAsync(
+            factory,
+            SeedIds.Accounts.Streamly,
+            SeedIds.Campaigns.StreamlyCreator,
+            SeedIds.Customers.StreamlyCustomer1,
+            "Streamly audit ticket");
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+        var now = DateTime.UtcNow;
+        var novaTicketAuditId = Guid.NewGuid();
+        var streamlyTicketAuditId = Guid.NewGuid();
+        var novaCustomerAuditId = Guid.NewGuid();
+        var userAuditId = Guid.NewGuid();
+
+        db.AuditLogs.AddRange(
+            new AuditLog
+            {
+                Id = novaTicketAuditId,
+                ActorUserId = SeedIds.Users.SupervisorNovabank,
+                Action = "TicketCreated",
+                EntityType = "Ticket",
+                EntityId = novaTicketId,
+                PreviousValue = null,
+                NewValue = "{\"status\":\"Open\"}",
+                CorrelationId = "corr-ticket",
+                CreatedAt = now
+            },
+            new AuditLog
+            {
+                Id = streamlyTicketAuditId,
+                ActorUserId = SeedIds.Users.ManagerLatam,
+                Action = "TicketCreated",
+                EntityType = "Ticket",
+                EntityId = streamlyTicketId,
+                PreviousValue = null,
+                NewValue = "{\"status\":\"Open\"}",
+                CorrelationId = "corr-streamly",
+                CreatedAt = now
+            },
+            new AuditLog
+            {
+                Id = novaCustomerAuditId,
+                ActorUserId = SeedIds.Users.SupervisorNovabank,
+                Action = "CustomerUpdated",
+                EntityType = "Customer",
+                EntityId = SeedIds.Customers.NovaBankCustomer1,
+                PreviousValue = "{\"isActive\":true}",
+                NewValue = "{\"isActive\":true}",
+                CorrelationId = "corr-customer",
+                CreatedAt = now
+            },
+            new AuditLog
+            {
+                Id = userAuditId,
+                ActorUserId = SeedIds.Users.Admin,
+                Action = "UserRolesUpdated",
+                EntityType = "User",
+                EntityId = SeedIds.Users.AgentNovabank,
+                PreviousValue = "{}",
+                NewValue = "{}",
+                CorrelationId = "corr-user",
+                CreatedAt = now
+            });
+
+        await db.SaveChangesAsync();
+        return new AuditArrangement(novaTicketId, streamlyTicketId, novaTicketAuditId, streamlyTicketAuditId, novaCustomerAuditId, userAuditId);
+    }
+
+    private static async Task<Guid> AddTicketDirectlyAsync(
+        AuditApiFactory factory,
+        Guid accountId,
+        Guid campaignId,
+        Guid customerId,
+        string subject)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+        var campaign = await db.Campaigns
+            .AsNoTracking()
+            .Where(c => c.Id == campaignId)
+            .Select(c => new { c.CountryId, c.Country.RegionId })
+            .SingleAsync();
+        var ticketId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+
+        db.Tickets.Add(new Ticket
+        {
+            Id = ticketId,
+            TicketNumber = $"OPS-20990102-{Random.Shared.Next(1, 999999):D6}",
+            CustomerId = customerId,
+            RegionId = campaign.RegionId,
+            CountryId = campaign.CountryId,
+            AccountId = accountId,
+            CampaignId = campaignId,
+            CreatedByUserId = SeedIds.Users.SupervisorNovabank,
+            Category = "Support",
+            Priority = TicketPriority.Normal,
+            Status = TicketStatus.Open,
+            Subject = subject,
+            Description = $"Description for {subject}",
+            SlaState = SlaState.WithinSla,
+            SlaDueAt = now.AddHours(24),
+            IsEscalated = false,
+            IsDeleted = false,
+            CreatedAt = now
+        });
+        db.TicketStatusHistory.Add(new TicketStatusHistory
+        {
+            Id = Guid.NewGuid(),
+            TicketId = ticketId,
+            PreviousStatus = null,
+            NewStatus = TicketStatus.Open.ToString(),
+            ChangedByUserId = SeedIds.Users.SupervisorNovabank,
+            ChangeReason = "Test arrange",
+            CreatedAt = now
+        });
+        db.TicketSlaStates.Add(new TicketSlaState
+        {
+            Id = Guid.NewGuid(),
+            TicketId = ticketId,
+            SlaPolicyId = null,
+            StartedAt = now,
+            DueAt = now.AddHours(24),
+            State = SlaState.WithinSla.ToString()
+        });
+        await db.SaveChangesAsync();
+        return ticketId;
+    }
+
+    private static async Task SetAuditCreatedAtAsync(AuditApiFactory factory, Guid auditId, DateTime createdAt)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+        var audit = await db.AuditLogs.SingleAsync(a => a.Id == auditId);
+        audit.CreatedAt = createdAt;
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task<HttpClient> CreateAuthenticatedClientAsync(AuditApiFactory factory, string email)
+    {
+        var client = factory.CreateClient();
+        var loginResponse = await client.PostAsJsonAsync("/api/auth/login", new
+        {
+            email,
+            password = OpsSphereSeedData.LocalDemoPassword
+        });
+        loginResponse.EnsureSuccessStatusCode();
+        var loginBody = await ReadResponseAsync<ApiResponse<LoginData>>(loginResponse);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", loginBody.Data.AccessToken);
+        return client;
+    }
+
+    private static async Task<T> ReadResponseAsync<T>(HttpResponseMessage response)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
+        return value ?? throw new InvalidOperationException($"Could not deserialize {typeof(T).Name} from {(int)response.StatusCode}: {json}");
+    }
+
+    private sealed record AuditArrangement(
+        Guid NovaBankTicketId,
+        Guid StreamlyTicketId,
+        Guid NovaBankTicketAuditId,
+        Guid StreamlyTicketAuditId,
+        Guid NovaBankCustomerAuditId,
+        Guid UserAuditId);
+
+    private sealed record ApiResponse<T>(T Data);
+    private sealed record PagedAuditListResponse(IReadOnlyList<AuditListItemResponse> Data, int Page, int PageSize, int TotalCount, int TotalPages);
+    private sealed record AuditListItemResponse(Guid Id, Guid? ActorUserId, string? ActorDisplayName, string Action, string EntityType, Guid EntityId, DateTime CreatedAt, string? CorrelationId);
+    private sealed record AuditDetailResponse(Guid Id, Guid? ActorUserId, string? ActorDisplayName, string Action, string EntityType, Guid EntityId, string? PreviousValue, string? NewValue, string? CorrelationId, DateTime CreatedAt);
+    private sealed record LoginData(string AccessToken);
+    private sealed record CreateTicketResponse(Guid Id, string TicketNumber, string Status, string Priority, string SlaState, DateTime? SlaDueAt);
+
+    internal sealed class AuditApiFactory : WebApplicationFactory<Program>
+    {
+        public const string JwtSigningKey = "integration-testing-only-fictional-jwt-signing-key";
+
+        private readonly SqliteConnection connection = new("Data Source=:memory:");
+
+        public static async Task<AuditApiFactory> CreateAsync()
+        {
+            ConfigureEnvironment();
+            var factory = new AuditApiFactory();
+            await factory.connection.OpenAsync();
+            await factory.InitializeDatabaseAsync();
+            return factory;
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Testing");
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["ConnectionStrings:DefaultConnection"] = "Server=(local);Database=OpsSphereAuditTests;Trusted_Connection=True;TrustServerCertificate=True;",
+                    ["SeedData:Enabled"] = "false",
+                    ["Jwt:Issuer"] = "OpsSphere.Tests",
+                    ["Jwt:Audience"] = "OpsSphere.Tests.Angular",
+                    ["Jwt:ExpirationMinutes"] = "60",
+                    ["Jwt:SigningKey"] = JwtSigningKey
+                });
+            });
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<IDbContextOptionsConfiguration<OpsSphereDbContext>>();
+                services.RemoveAll<DbContextOptions<OpsSphereDbContext>>();
+                services.AddDbContext<OpsSphereDbContext>(options => options.UseSqlite(connection));
+            });
+        }
+
+        private static void ConfigureEnvironment()
+        {
+            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", "Server=(local);Database=OpsSphereAuditTests;Trusted_Connection=True;TrustServerCertificate=True;");
+            Environment.SetEnvironmentVariable("SeedData__Enabled", "false");
+            Environment.SetEnvironmentVariable("Jwt__Issuer", "OpsSphere.Tests");
+            Environment.SetEnvironmentVariable("Jwt__Audience", "OpsSphere.Tests.Angular");
+            Environment.SetEnvironmentVariable("Jwt__ExpirationMinutes", "60");
+            Environment.SetEnvironmentVariable("Jwt__SigningKey", JwtSigningKey);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await connection.DisposeAsync();
+            await base.DisposeAsync();
+        }
+
+        private async Task InitializeDatabaseAsync()
+        {
+            using var scope = Services.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+            await dbContext.Database.EnsureDeletedAsync();
+            await dbContext.Database.EnsureCreatedAsync();
+
+            var seeder = scope.ServiceProvider.GetRequiredService<OpsSphereDataSeeder>();
+            await seeder.SeedAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements scoped, read-only audit log querying and operational audit views for authorized users, including audit list/detail/entity-history APIs, Angular audit screens, ticket detail audit history, pagination, filtering, and scoped visibility enforcement.

## Added / Changed

- Added read-only audit query infrastructure with `IAuditRepository`.
- Added audit query handlers, DTOs, and paged result support.
- Added `GET /api/audit-logs`.
- Added `GET /api/audit-logs/{id}`.
- Added `GET /api/audit-logs/entity/{entityType}/{entityId}`.
- Added backend scope filtering for audit records:
  - Admin with `audit.admin_view` can view all audit records.
  - Non-admin users with `audit.view` can view scoped Ticket/Customer operational audit records only.
  - Agents are denied global audit access.
- Added audit filters for actor, action, entity type, entity id, date range, and pagination.
- Added additive audit index migration for `EntityType`, `EntityId`, and `CreatedAt`.
- Added Angular `/audit` route guarded by `AppPermissions.AuditView`.
- Added Angular audit service, models, audit list view, filters, pagination, and expandable detail panel.
- Added lazy-loaded Audit History panel to ticket detail.
- Added backend integration tests for audit APIs, scoped visibility, filters, and access control.
- Added frontend audit service/list tests and ticket detail audit history coverage.

## Validation

- [x] Reviewed changed files.
- [x] Confirmed scope matches the related issue.
- [x] Confirmed validation expectations from docs/implementation-guardrails.md were met or documented.
- [x] `dotnet restore OpsSphere.slnx`
- [x] `dotnet build OpsSphere.slnx --no-restore`
- [x] `dotnet test OpsSphere.slnx --no-build` — 392/392 passed
- [x] `dotnet ef migrations has-pending-model-changes --project src/OpsSphere.Infrastructure --startup-project src/OpsSphere.Api`
- [x] `npm ci` — passed with existing audit/deprecation warnings
- [x] `npm run build`
- [x] `npm run test -- --watch=false` — 114/114 passed

## Scope Confirmation

- [x] This PR contains no out-of-scope work.
- [x] This PR does not introduce unrelated source, package, migration, Docker, or GitHub Actions changes.
- [x] No audit update/delete endpoints were introduced.
- [x] No Serilog or technical log querying was introduced.
- [x] No audit export was introduced.
- [x] No advanced audit analytics were introduced.
- [x] No audit retention automation was introduced.
- [x] No cryptographic audit chain was introduced.
- [x] Backend scope filtering is enforced for audit queries.
- [x] Cross-scope audit records are hidden.
- [x] Audit logs remain distinct from technical logs.
- [x] Audit list responses avoid sensitive detail fields.

## Related Issue

Closes #63

## Checklist

- [x] Branch name includes the issue number.
- [x] Related issue defines scope, out of scope, acceptance criteria, and validation.
- [x] Architecture boundaries and MVP limits from docs/implementation-guardrails.md are respected.
- [x] Documentation is updated when behavior, architecture, setup, or validation expectations change.