### PR TITLE
Refactor integration tests to use OpsSphereSqliteFactory for database…

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,5 +26,6 @@
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.4.0" />
   </ItemGroup>
 </Project>

--- a/docs/smoke-test-22.md
+++ b/docs/smoke-test-22.md
@@ -1,5 +1,7 @@
 # Sprint 22 Manual Smoke Test - Angular MVP Workflow Integration
 
+> **Note:** Automated browser-level E2E tests (Playwright) are deferred to Sprint 24. The API and integration layer are covered by the automated integration tests in `tests/OpsSphere.IntegrationTests`. This document remains the authoritative manual smoke checklist for Sprint 22 UI workflows.
+
 ## Prerequisites
 - [ ] Backend API is running locally.
 - [ ] Angular frontend is running locally.

--- a/docs/testing/mvp-regression-tests.md
+++ b/docs/testing/mvp-regression-tests.md
@@ -1,0 +1,132 @@
+# MVP Regression Test Guide
+
+This document describes the automated integration test coverage for the OpsSphere MVP. All tests run against an in-memory SQLite database using fictional seed data. No real infrastructure or credentials are required.
+
+## 1. Authentication
+
+Tests in `tests/OpsSphere.IntegrationTests/Auth/AuthApiTests.cs`.
+
+- Login with a valid seeded user returns a JWT with correct claims.
+- Login with an invalid password returns the generic error message.
+- Login with an unknown email returns the generic error message.
+- Login with an inactive user returns the generic error message.
+- The error response for an inactive user and a missing user are identical (timing-safe).
+- `GET /api/auth/me` without a token returns 401.
+- `GET /api/auth/me` with a valid token returns the current user profile including roles, permissions, and scopes.
+- The JWT payload does not contain permissions, scopes, or the signing key.
+- Auth responses do not expose the password hash.
+
+## 2. Authorization and Scoping
+
+Tests in `tests/OpsSphere.IntegrationTests/Authorization/AuthorizationApiTests.cs`.
+
+- Role-based permission checks enforce access to protected endpoints.
+- Scope-based authorization filters results server-side by region, account, and campaign.
+- 403 responses do not expose the signing key or password data.
+- Admin bypasses scope restrictions and sees all data.
+
+## 3. User Management
+
+Tests in `tests/OpsSphere.IntegrationTests/UserManagement/UserManagementApiTests.cs`.
+
+- Admin can create, view, update, assign roles, and deactivate users.
+- Duplicate email on create returns 409.
+- Missing required fields on create return 400 with field-level error details.
+- A deactivated user cannot log in.
+- Non-admin roles are forbidden from all user management endpoints.
+- User management responses do not expose password hashes, temporary passwords, or signing keys.
+
+## 4. Organization Management
+
+Tests in `tests/OpsSphere.IntegrationTests/OrganizationManagement/OrganizationApiTests.cs`.
+
+- Admin can create, update, and deactivate the full hierarchy: region, country, account, campaign.
+- Duplicate codes on create return 409.
+- Missing or inactive parent entities are rejected with validation errors.
+- Deactivating a parent with active children is rejected as a business rule violation.
+- Scoped users see only the organization records within their assigned scope.
+- User scopes can be assigned and reactivated according to role constraints.
+
+## 5. Customer Management
+
+Tests in `tests/OpsSphere.IntegrationTests/CustomerManagement/CustomerManagementApiTests.cs`.
+
+- Admin can create, update, and deactivate customers.
+- Inactive or missing accounts are rejected on customer creation.
+- Scoped agents and supervisors see only customers belonging to their account scope.
+- Cross-scope customer reads and writes return 404 to non-admin users.
+- Customer ticket history is returned correctly.
+- Audit logs for customer operations do not contain PII.
+
+## 6. Ticket Management
+
+Tests in `tests/OpsSphere.IntegrationTests/TicketManagement/TicketManagementApiTests.cs` and `TicketLifecycleGapsApiTests.cs`.
+
+- Agents and supervisors can create tickets within their scope.
+- Ticket creation sets status to Open and initializes SLA state and due date.
+- Ticket creation creates a status history row and an SLA state row.
+- Invalid priority values, missing required fields, and cross-scope customers are rejected.
+- Out-of-scope campaign creates return 404.
+- `GET /api/tickets` returns only tickets within the caller's scope.
+- Cross-scope ticket reads return 404.
+- Priority updates return the previous and new priority values.
+- The escalation queue returns escalated tickets scoped to the caller.
+- Ticket status history is returned and grows after each status change.
+- Comments can be added and retrieved from `GET /api/tickets/{id}/comments`.
+
+## 7. Audit Logs
+
+Tests in `tests/OpsSphere.IntegrationTests/AuditManagement/AuditApiTests.cs` and `TicketLifecycleAuditTests.cs`.
+
+- Audit logs are written for all ticket lifecycle actions: created, assigned, status changed, priority changed, escalated, resolved, closed, comment added.
+- `GET /api/audit-logs` returns logs scoped to the caller's authorization profile.
+- `GET /api/audit-logs/{id}` returns detail with previous/new values and correlation ID.
+- `GET /api/audit-logs/entity/{entityType}/{entityId}` returns the full history for a given entity.
+- Out-of-scope entity history returns 404.
+- List responses do not expose previousValue or newValue fields.
+- Date range filters work correctly.
+- Invalid date ranges return 400.
+- Audit logs cannot be modified: PUT and DELETE return 404 or 405.
+
+## 8. SLA and Dashboard
+
+Tests in `tests/OpsSphere.IntegrationTests/TicketManagement/TicketManagementApiTests.cs`, `DashboardManagement/DashboardApiTests.cs`, and `DashboardManagement/SlaMultiStateDashboardTests.cs`.
+
+- `GET /api/sla/summary` returns evaluated counts for all four SLA states: WithinSla, AtRisk, Breached, Completed.
+- SLA state is evaluated at request time, not from the stored value.
+- SLA summary is scoped to the caller's authorization profile.
+- The operational dashboard requires the `dashboard.view` permission.
+- Dashboard totals and groupings (by status, priority, SLA state, account, campaign, agent, supervisor) are correct.
+- Dashboard filters (account, campaign, status, date range) intersect correctly with scope.
+- An out-of-scope account filter returns zero counts.
+- An invalid date range filter returns 400.
+
+## 9. Health and Middleware
+
+Tests in `tests/OpsSphere.IntegrationTests/Health/HealthCheckTests.cs` and `Middleware/ExceptionHandlingTests.cs`.
+
+- `GET /health` and `GET /health/details` return 200 with correct content type.
+- Health responses do not expose the signing key, password data, or connection string details.
+- All responses include an `X-Correlation-Id` header.
+- Unhandled exceptions return a 500 response with the standard error envelope.
+- Error responses do not expose internal exception messages, stack traces, or secrets.
+
+## 10. Persistence
+
+Tests in `tests/OpsSphere.IntegrationTests/Persistence/`.
+
+- Seed data is applied correctly: all seeded entities, roles, permissions, and scopes are present after startup.
+- Soft-deleted entities are excluded from all query results.
+- All EF Core migrations apply cleanly to a real SQL Server instance (Heavy category, CI/CD only).
+
+## Running the Tests
+
+```
+dotnet test tests/OpsSphere.IntegrationTests --filter "Category!=Heavy"
+```
+
+To run the migration smoke test (requires Docker):
+
+```
+dotnet test tests/OpsSphere.IntegrationTests --filter "Category=Heavy"
+```

--- a/tests/OpsSphere.IntegrationTests/AuditManagement/AuditApiTests.cs
+++ b/tests/OpsSphere.IntegrationTests/AuditManagement/AuditApiTests.cs
@@ -1,20 +1,13 @@
 using System.Net;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpsSphere.Domain.Entities;
 using OpsSphere.Domain.Enums;
 using OpsSphere.Infrastructure.Persistence;
 using OpsSphere.Infrastructure.Persistence.SeedData;
+using OpsSphere.IntegrationTests.TestInfrastructure;
 
 namespace OpsSphere.IntegrationTests.AuditManagement;
 
@@ -31,14 +24,14 @@ public sealed class AuditApiTests
     [Fact]
     public async Task Admin_CanQueryAuditLogs_Returns200()
     {
-        await using var factory = await AuditApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var ids = await ArrangeAuditLogsAsync(factory);
-        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        var admin = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var response = await admin.GetAsync("/api/audit-logs");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var body = await ReadResponseAsync<PagedAuditListResponse>(response);
+        var body = await OpsSphereSqliteFactory.ReadResponseAsync<PagedAuditListResponse>(response);
         Assert.Contains(body.Data, item => item.Id == ids.NovaBankTicketAuditId);
         Assert.Contains(body.Data, item => item.Id == ids.UserAuditId);
     }
@@ -46,14 +39,14 @@ public sealed class AuditApiTests
     [Fact]
     public async Task OperationsManager_CanQueryAuditLogs_ScopedToRegion()
     {
-        await using var factory = await AuditApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var ids = await ArrangeAuditLogsAsync(factory);
-        var manager = await CreateAuthenticatedClientAsync(factory, ManagerEmail);
+        var manager = await factory.CreateAuthenticatedClientAsync(ManagerEmail);
 
         var response = await manager.GetAsync("/api/audit-logs");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var body = await ReadResponseAsync<PagedAuditListResponse>(response);
+        var body = await OpsSphereSqliteFactory.ReadResponseAsync<PagedAuditListResponse>(response);
         Assert.Contains(body.Data, item => item.Id == ids.NovaBankTicketAuditId);
         Assert.DoesNotContain(body.Data, item => item.Id == ids.StreamlyTicketAuditId);
         Assert.DoesNotContain(body.Data, item => item.Id == ids.UserAuditId);
@@ -62,14 +55,14 @@ public sealed class AuditApiTests
     [Fact]
     public async Task Supervisor_CanQueryAuditLogs_ScopedToAccount()
     {
-        await using var factory = await AuditApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var ids = await ArrangeAuditLogsAsync(factory);
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
 
         var response = await supervisor.GetAsync("/api/audit-logs");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var body = await ReadResponseAsync<PagedAuditListResponse>(response);
+        var body = await OpsSphereSqliteFactory.ReadResponseAsync<PagedAuditListResponse>(response);
         Assert.Contains(body.Data, item => item.Id == ids.NovaBankTicketAuditId);
         Assert.Contains(body.Data, item => item.Id == ids.NovaBankCustomerAuditId);
         Assert.DoesNotContain(body.Data, item => item.Id == ids.StreamlyTicketAuditId);
@@ -79,8 +72,8 @@ public sealed class AuditApiTests
     [Fact]
     public async Task Agent_CannotQueryAuditLogs_Returns403()
     {
-        await using var factory = await AuditApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var response = await agent.GetAsync("/api/audit-logs");
 
@@ -90,14 +83,14 @@ public sealed class AuditApiTests
     [Fact]
     public async Task Viewer_CanQueryAuditLogs_ScopedToScope()
     {
-        await using var factory = await AuditApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var ids = await ArrangeAuditLogsAsync(factory);
-        var viewer = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
+        var viewer = await factory.CreateAuthenticatedClientAsync(ViewerEmail);
 
         var response = await viewer.GetAsync("/api/audit-logs");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var body = await ReadResponseAsync<PagedAuditListResponse>(response);
+        var body = await OpsSphereSqliteFactory.ReadResponseAsync<PagedAuditListResponse>(response);
         Assert.Contains(body.Data, item => item.Id == ids.NovaBankTicketAuditId);
         Assert.DoesNotContain(body.Data, item => item.Id == ids.StreamlyTicketAuditId);
     }
@@ -105,7 +98,7 @@ public sealed class AuditApiTests
     [Fact]
     public async Task Unauthenticated_CannotQueryAuditLogs_Returns401()
     {
-        await using var factory = await AuditApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
 
         var response = await factory.CreateClient().GetAsync("/api/audit-logs");
 
@@ -115,9 +108,9 @@ public sealed class AuditApiTests
     [Fact]
     public async Task NonAdmin_CannotGetAuditLogById_OutOfScope_Returns404()
     {
-        await using var factory = await AuditApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var ids = await ArrangeAuditLogsAsync(factory);
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
 
         var response = await supervisor.GetAsync($"/api/audit-logs/{ids.StreamlyTicketAuditId}");
 
@@ -127,14 +120,14 @@ public sealed class AuditApiTests
     [Fact]
     public async Task Admin_CanGetAuditLogById_Returns200()
     {
-        await using var factory = await AuditApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var ids = await ArrangeAuditLogsAsync(factory);
-        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        var admin = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var response = await admin.GetAsync($"/api/audit-logs/{ids.NovaBankTicketAuditId}");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var body = await ReadResponseAsync<ApiResponse<AuditDetailResponse>>(response);
+        var body = await OpsSphereSqliteFactory.ReadResponseAsync<OpsSphereSqliteFactory.ApiResponse<AuditDetailResponse>>(response);
         Assert.Equal(ids.NovaBankTicketAuditId, body.Data.Id);
         Assert.Equal("TicketCreated", body.Data.Action);
         Assert.NotNull(body.Data.NewValue);
@@ -144,9 +137,9 @@ public sealed class AuditApiTests
     [Fact]
     public async Task NonAdmin_CanGetAuditLogById_InScope_Returns200()
     {
-        await using var factory = await AuditApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var ids = await ArrangeAuditLogsAsync(factory);
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
 
         var response = await supervisor.GetAsync($"/api/audit-logs/{ids.NovaBankTicketAuditId}");
 
@@ -156,14 +149,14 @@ public sealed class AuditApiTests
     [Fact]
     public async Task EntityAuditHistory_Ticket_IsScopedAndPaged()
     {
-        await using var factory = await AuditApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var ids = await ArrangeAuditLogsAsync(factory);
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
 
         var response = await supervisor.GetAsync($"/api/audit-logs/entity/Ticket/{ids.NovaBankTicketId}");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var body = await ReadResponseAsync<PagedAuditListResponse>(response);
+        var body = await OpsSphereSqliteFactory.ReadResponseAsync<PagedAuditListResponse>(response);
         Assert.Contains(body.Data, item => item.EntityId == ids.NovaBankTicketId);
         Assert.DoesNotContain(body.Data, item => item.EntityId == ids.StreamlyTicketId);
     }
@@ -171,9 +164,9 @@ public sealed class AuditApiTests
     [Fact]
     public async Task Supervisor_CannotGetEntityAuditHistory_OutOfScope_Returns404()
     {
-        await using var factory = await AuditApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var ids = await ArrangeAuditLogsAsync(factory);
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
 
         var response = await supervisor.GetAsync($"/api/audit-logs/entity/Ticket/{ids.StreamlyTicketId}");
 
@@ -183,17 +176,17 @@ public sealed class AuditApiTests
     [Fact]
     public async Task AuditFilters_ReturnExpectedRows()
     {
-        await using var factory = await AuditApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var ids = await ArrangeAuditLogsAsync(factory);
-        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        var admin = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
-        var byActor = await ReadResponseAsync<PagedAuditListResponse>(
+        var byActor = await OpsSphereSqliteFactory.ReadResponseAsync<PagedAuditListResponse>(
             await admin.GetAsync($"/api/audit-logs?actorUserId={SeedIds.Users.SupervisorNovabank}"));
-        var byAction = await ReadResponseAsync<PagedAuditListResponse>(
+        var byAction = await OpsSphereSqliteFactory.ReadResponseAsync<PagedAuditListResponse>(
             await admin.GetAsync("/api/audit-logs?action=CustomerUpdated"));
-        var byEntity = await ReadResponseAsync<PagedAuditListResponse>(
+        var byEntity = await OpsSphereSqliteFactory.ReadResponseAsync<PagedAuditListResponse>(
             await admin.GetAsync($"/api/audit-logs?entityType=Ticket&entityId={ids.NovaBankTicketId}"));
-        var byAccount = await ReadResponseAsync<PagedAuditListResponse>(
+        var byAccount = await OpsSphereSqliteFactory.ReadResponseAsync<PagedAuditListResponse>(
             await admin.GetAsync($"/api/audit-logs?accountId={SeedIds.Accounts.NovaBank}"));
 
         Assert.Contains(byActor.Data, item => item.ActorUserId == SeedIds.Users.SupervisorNovabank);
@@ -206,16 +199,16 @@ public sealed class AuditApiTests
     [Fact]
     public async Task AuditFilters_ByDateRange_ReturnExpectedRows()
     {
-        await using var factory = await AuditApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var ids = await ArrangeAuditLogsAsync(factory);
         await SetAuditCreatedAtAsync(factory, ids.NovaBankTicketAuditId, new DateTime(2026, 05, 01, 0, 0, 0, DateTimeKind.Utc));
         await SetAuditCreatedAtAsync(factory, ids.NovaBankCustomerAuditId, new DateTime(2026, 05, 10, 0, 0, 0, DateTimeKind.Utc));
-        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        var admin = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var response = await admin.GetAsync("/api/audit-logs?fromUtc=2026-05-09T00:00:00Z&toUtc=2026-05-11T00:00:00Z");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var body = await ReadResponseAsync<PagedAuditListResponse>(response);
+        var body = await OpsSphereSqliteFactory.ReadResponseAsync<PagedAuditListResponse>(response);
         Assert.Contains(body.Data, item => item.Id == ids.NovaBankCustomerAuditId);
         Assert.DoesNotContain(body.Data, item => item.Id == ids.NovaBankTicketAuditId);
     }
@@ -223,8 +216,8 @@ public sealed class AuditApiTests
     [Fact]
     public async Task InvalidFilterDateRange_Returns400()
     {
-        await using var factory = await AuditApiFactory.CreateAsync();
-        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var admin = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var response = await admin.GetAsync("/api/audit-logs?fromUtc=2026-05-11T00:00:00Z&toUtc=2026-05-09T00:00:00Z");
 
@@ -234,9 +227,9 @@ public sealed class AuditApiTests
     [Fact]
     public async Task AuditLogs_CannotBeModified_NoPutDeleteEndpoints()
     {
-        await using var factory = await AuditApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var ids = await ArrangeAuditLogsAsync(factory);
-        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        var admin = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var put = await admin.PutAsJsonAsync($"/api/audit-logs/{ids.NovaBankTicketAuditId}", new { action = "Changed" });
         var delete = await admin.DeleteAsync($"/api/audit-logs/{ids.NovaBankTicketAuditId}");
@@ -248,8 +241,8 @@ public sealed class AuditApiTests
     [Fact]
     public async Task TicketCreated_ProducesAuditRecord_QueryableViaApi()
     {
-        await using var factory = await AuditApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
 
         var createResponse = await supervisor.PostAsJsonAsync("/api/tickets", new
         {
@@ -262,21 +255,21 @@ public sealed class AuditApiTests
             description = "Creates an audit log through the existing ticket write path."
         });
         createResponse.EnsureSuccessStatusCode();
-        var created = await ReadResponseAsync<ApiResponse<CreateTicketResponse>>(createResponse);
+        var created = await OpsSphereSqliteFactory.ReadResponseAsync<OpsSphereSqliteFactory.ApiResponse<CreateTicketResponse>>(createResponse);
 
         var auditResponse = await supervisor.GetAsync($"/api/audit-logs?entityType=Ticket&entityId={created.Data.Id}&action=TicketCreated");
 
         Assert.Equal(HttpStatusCode.OK, auditResponse.StatusCode);
-        var auditBody = await ReadResponseAsync<PagedAuditListResponse>(auditResponse);
+        var auditBody = await OpsSphereSqliteFactory.ReadResponseAsync<PagedAuditListResponse>(auditResponse);
         Assert.Single(auditBody.Data);
     }
 
     [Fact]
     public async Task AuditList_DoesNotExposeSensitiveDetailFields()
     {
-        await using var factory = await AuditApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         await ArrangeAuditLogsAsync(factory);
-        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        var admin = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var json = await (await admin.GetAsync("/api/audit-logs")).Content.ReadAsStringAsync();
 
@@ -289,9 +282,9 @@ public sealed class AuditApiTests
     [Fact]
     public async Task AuditDetail_ExposesPreviousNewValueAndCorrelationIdSafely()
     {
-        await using var factory = await AuditApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var ids = await ArrangeAuditLogsAsync(factory);
-        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        var admin = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var response = await admin.GetAsync($"/api/audit-logs/{ids.NovaBankTicketAuditId}");
 
@@ -304,7 +297,7 @@ public sealed class AuditApiTests
         Assert.DoesNotContain("userAgent", json, StringComparison.OrdinalIgnoreCase);
     }
 
-    private static async Task<AuditArrangement> ArrangeAuditLogsAsync(AuditApiFactory factory)
+    private static async Task<AuditArrangement> ArrangeAuditLogsAsync(OpsSphereSqliteFactory factory)
     {
         var novaTicketId = await AddTicketDirectlyAsync(
             factory,
@@ -382,7 +375,7 @@ public sealed class AuditApiTests
     }
 
     private static async Task<Guid> AddTicketDirectlyAsync(
-        AuditApiFactory factory,
+        OpsSphereSqliteFactory factory,
         Guid accountId,
         Guid campaignId,
         Guid customerId,
@@ -442,7 +435,7 @@ public sealed class AuditApiTests
         return ticketId;
     }
 
-    private static async Task SetAuditCreatedAtAsync(AuditApiFactory factory, Guid auditId, DateTime createdAt)
+    private static async Task SetAuditCreatedAtAsync(OpsSphereSqliteFactory factory, Guid auditId, DateTime createdAt)
     {
         using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
@@ -451,105 +444,15 @@ public sealed class AuditApiTests
         await db.SaveChangesAsync();
     }
 
-    private static async Task<HttpClient> CreateAuthenticatedClientAsync(AuditApiFactory factory, string email)
-    {
-        var client = factory.CreateClient();
-        var loginResponse = await client.PostAsJsonAsync("/api/auth/login", new
-        {
-            email,
-            password = OpsSphereSeedData.LocalDemoPassword
-        });
-        loginResponse.EnsureSuccessStatusCode();
-        var loginBody = await ReadResponseAsync<ApiResponse<LoginData>>(loginResponse);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", loginBody.Data.AccessToken);
-        return client;
-    }
-
-    private static async Task<T> ReadResponseAsync<T>(HttpResponseMessage response)
-    {
-        var json = await response.Content.ReadAsStringAsync();
-        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
-        return value ?? throw new InvalidOperationException($"Could not deserialize {typeof(T).Name} from {(int)response.StatusCode}: {json}");
-    }
-
-    private sealed record AuditArrangement(
+private sealed record AuditArrangement(
         Guid NovaBankTicketId,
         Guid StreamlyTicketId,
         Guid NovaBankTicketAuditId,
         Guid StreamlyTicketAuditId,
         Guid NovaBankCustomerAuditId,
         Guid UserAuditId);
-
-    private sealed record ApiResponse<T>(T Data);
     private sealed record PagedAuditListResponse(IReadOnlyList<AuditListItemResponse> Data, int Page, int PageSize, int TotalCount, int TotalPages);
     private sealed record AuditListItemResponse(Guid Id, Guid? ActorUserId, string? ActorDisplayName, string Action, string EntityType, Guid EntityId, DateTime CreatedAt, string? CorrelationId);
     private sealed record AuditDetailResponse(Guid Id, Guid? ActorUserId, string? ActorDisplayName, string Action, string EntityType, Guid EntityId, string? PreviousValue, string? NewValue, string? CorrelationId, DateTime CreatedAt);
-    private sealed record LoginData(string AccessToken);
     private sealed record CreateTicketResponse(Guid Id, string TicketNumber, string Status, string Priority, string SlaState, DateTime? SlaDueAt);
-
-    internal sealed class AuditApiFactory : WebApplicationFactory<Program>
-    {
-        public const string JwtSigningKey = "integration-testing-only-fictional-jwt-signing-key";
-
-        private readonly SqliteConnection connection = new("Data Source=:memory:");
-
-        public static async Task<AuditApiFactory> CreateAsync()
-        {
-            ConfigureEnvironment();
-            var factory = new AuditApiFactory();
-            await factory.connection.OpenAsync();
-            await factory.InitializeDatabaseAsync();
-            return factory;
-        }
-
-        protected override void ConfigureWebHost(IWebHostBuilder builder)
-        {
-            builder.UseEnvironment("Testing");
-            builder.ConfigureAppConfiguration((_, config) =>
-            {
-                config.AddInMemoryCollection(new Dictionary<string, string?>
-                {
-                    ["ConnectionStrings:DefaultConnection"] = "Server=(local);Database=OpsSphereAuditTests;Trusted_Connection=True;TrustServerCertificate=True;",
-                    ["SeedData:Enabled"] = "false",
-                    ["Jwt:Issuer"] = "OpsSphere.Tests",
-                    ["Jwt:Audience"] = "OpsSphere.Tests.Angular",
-                    ["Jwt:ExpirationMinutes"] = "60",
-                    ["Jwt:SigningKey"] = JwtSigningKey
-                });
-            });
-            builder.ConfigureTestServices(services =>
-            {
-                services.RemoveAll<IDbContextOptionsConfiguration<OpsSphereDbContext>>();
-                services.RemoveAll<DbContextOptions<OpsSphereDbContext>>();
-                services.AddDbContext<OpsSphereDbContext>(options => options.UseSqlite(connection));
-            });
-        }
-
-        private static void ConfigureEnvironment()
-        {
-            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", "Server=(local);Database=OpsSphereAuditTests;Trusted_Connection=True;TrustServerCertificate=True;");
-            Environment.SetEnvironmentVariable("SeedData__Enabled", "false");
-            Environment.SetEnvironmentVariable("Jwt__Issuer", "OpsSphere.Tests");
-            Environment.SetEnvironmentVariable("Jwt__Audience", "OpsSphere.Tests.Angular");
-            Environment.SetEnvironmentVariable("Jwt__ExpirationMinutes", "60");
-            Environment.SetEnvironmentVariable("Jwt__SigningKey", JwtSigningKey);
-        }
-
-        public override async ValueTask DisposeAsync()
-        {
-            await connection.DisposeAsync();
-            await base.DisposeAsync();
-        }
-
-        private async Task InitializeDatabaseAsync()
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            await dbContext.Database.EnsureDeletedAsync();
-            await dbContext.Database.EnsureCreatedAsync();
-
-            var seeder = scope.ServiceProvider.GetRequiredService<OpsSphereDataSeeder>();
-            await seeder.SeedAsync();
-        }
-    }
 }

--- a/tests/OpsSphere.IntegrationTests/AuditManagement/TicketLifecycleAuditTests.cs
+++ b/tests/OpsSphere.IntegrationTests/AuditManagement/TicketLifecycleAuditTests.cs
@@ -1,0 +1,202 @@
+using System.Net;
+using System.Net.Http.Json;
+using OpsSphere.Infrastructure.Persistence.SeedData;
+using OpsSphere.IntegrationTests.TestInfrastructure;
+
+namespace OpsSphere.IntegrationTests.AuditManagement;
+
+public sealed class TicketLifecycleAuditTests
+{
+    private const string AgentEmail = "agent.novabank@opssphere.local";
+    private const string SupervisorEmail = "supervisor.novabank@opssphere.local";
+
+    [Fact]
+    public async Task StatusUpdate_ProducesAuditLog_WithAction_TicketStatusChanged()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+
+        var created = await CreateAndAssignTicketAsync(supervisor);
+        var statusResponse = await supervisor.PutAsJsonAsync($"/api/tickets/{created.Id}/status", new
+        {
+            status = "InProgress",
+            changeReason = "Audit test status update"
+        });
+        statusResponse.EnsureSuccessStatusCode();
+
+        await factory.AssertAuditAsync("TicketStatusChanged", "Ticket", created.Id);
+    }
+
+    [Fact]
+    public async Task PriorityUpdate_ProducesAuditLog_WithAction_TicketPriorityChanged()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
+
+        var created = await CreateTicketAsync(agent);
+        var priorityResponse = await agent.PutAsJsonAsync($"/api/tickets/{created.Id}/priority", new
+        {
+            priority = "High",
+            changeReason = "Audit test priority update"
+        });
+        priorityResponse.EnsureSuccessStatusCode();
+
+        await factory.AssertAuditAsync("TicketPriorityChanged", "Ticket", created.Id);
+    }
+
+    [Fact]
+    public async Task Escalation_ProducesAuditLog_WithAction_TicketEscalated()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+
+        var created = await CreateAndAssignTicketAsync(supervisor);
+        var escalateResponse = await supervisor.PostAsJsonAsync($"/api/tickets/{created.Id}/escalate", new
+        {
+            escalationReason = "Audit test escalation"
+        });
+        escalateResponse.EnsureSuccessStatusCode();
+
+        await factory.AssertAuditAsync("TicketEscalated", "Ticket", created.Id);
+    }
+
+    [Fact]
+    public async Task Resolve_ProducesAuditLog_WithAction_TicketResolved()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+
+        var created = await CreateAndAssignTicketAsync(supervisor);
+        var resolveResponse = await supervisor.PostAsJsonAsync($"/api/tickets/{created.Id}/resolve", new
+        {
+            resolutionSummary = "Audit test resolution",
+            resolutionCode = "RESOLVED"
+        });
+        resolveResponse.EnsureSuccessStatusCode();
+
+        await factory.AssertAuditAsync("TicketResolved", "Ticket", created.Id);
+    }
+
+    [Fact]
+    public async Task Close_ProducesAuditLog_WithAction_TicketClosed()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+
+        var created = await CreateAndAssignTicketAsync(supervisor);
+        var resolveResponse = await supervisor.PostAsJsonAsync($"/api/tickets/{created.Id}/resolve", new
+        {
+            resolutionSummary = "Resolved before close",
+            resolutionCode = "RESOLVED"
+        });
+        resolveResponse.EnsureSuccessStatusCode();
+
+        var closeResponse = await supervisor.PostAsync($"/api/tickets/{created.Id}/close", null);
+        closeResponse.EnsureSuccessStatusCode();
+
+        await factory.AssertAuditAsync("TicketClosed", "Ticket", created.Id);
+    }
+
+    [Fact]
+    public async Task AddComment_ProducesAuditLog_WithAction_InternalCommentAdded()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+
+        var created = await CreateTicketAsync(supervisor);
+        var commentResponse = await supervisor.PostAsJsonAsync($"/api/tickets/{created.Id}/comments", new
+        {
+            body = "Audit test internal comment"
+        });
+        commentResponse.EnsureSuccessStatusCode();
+
+        await factory.AssertAuditAsync("InternalCommentAdded", "Ticket", created.Id);
+    }
+
+    [Fact]
+    public async Task TicketAuditLogs_QueryableViaEntityEndpoint_ReturnAllLifecycleActions()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+
+        var created = await CreateAndAssignTicketAsync(supervisor);
+        var priorityResponse = await supervisor.PutAsJsonAsync($"/api/tickets/{created.Id}/priority", new
+        {
+            priority = "Critical",
+            changeReason = "Lifecycle query test"
+        });
+        priorityResponse.EnsureSuccessStatusCode();
+
+        var entityAuditResponse = await supervisor.GetAsync($"/api/audit-logs/entity/Ticket/{created.Id}");
+        Assert.Equal(HttpStatusCode.OK, entityAuditResponse.StatusCode);
+        var body = await OpsSphereSqliteFactory.ReadResponseAsync<PagedAuditListResponse>(entityAuditResponse);
+
+        Assert.Contains(body.Data, item => item.Action == "TicketCreated");
+        Assert.Contains(body.Data, item => item.Action == "TicketAssigned");
+        Assert.Contains(body.Data, item => item.Action == "TicketPriorityChanged");
+    }
+
+    [Fact]
+    public async Task TicketAuditLog_ById_ReturnsDetail_WithoutSensitiveData()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+
+        var created = await CreateTicketAsync(supervisor);
+        var priorityResponse = await supervisor.PutAsJsonAsync($"/api/tickets/{created.Id}/priority", new
+        {
+            priority = "High",
+            changeReason = "Sensitive data audit check"
+        });
+        priorityResponse.EnsureSuccessStatusCode();
+
+        var auditListResponse = await supervisor.GetAsync($"/api/audit-logs?entityType=Ticket&entityId={created.Id}&action=TicketPriorityChanged");
+        Assert.Equal(HttpStatusCode.OK, auditListResponse.StatusCode);
+        var auditList = await OpsSphereSqliteFactory.ReadResponseAsync<PagedAuditListResponse>(auditListResponse);
+        var auditItem = Assert.Single(auditList.Data);
+
+        var detailResponse = await supervisor.GetAsync($"/api/audit-logs/{auditItem.Id}");
+        Assert.Equal(HttpStatusCode.OK, detailResponse.StatusCode);
+        var detail = await OpsSphereSqliteFactory.ReadDataAsync<AuditLogDetailResponse>(detailResponse);
+
+        Assert.Equal("TicketPriorityChanged", detail.Action);
+        Assert.Equal("Ticket", detail.EntityType);
+        Assert.Equal(created.Id, detail.EntityId);
+        Assert.DoesNotContain("password", detail.NewValue ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("password", detail.PreviousValue ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(OpsSphereSqliteFactory.JwtSigningKey, detail.NewValue ?? string.Empty, StringComparison.Ordinal);
+    }
+
+    private static async Task<CreateTicketResult> CreateTicketAsync(HttpClient client)
+    {
+        var response = await client.PostAsJsonAsync("/api/tickets", new
+        {
+            customerId = SeedIds.Customers.NovaBankCustomer1,
+            accountId = SeedIds.Accounts.NovaBank,
+            campaignId = SeedIds.Campaigns.NovaBankCreditCard,
+            category = "Support",
+            priority = "Normal",
+            subject = "Lifecycle audit test ticket",
+            description = "Testing ticket lifecycle audit log production"
+        });
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        return await OpsSphereSqliteFactory.ReadDataAsync<CreateTicketResult>(response);
+    }
+
+    private static async Task<CreateTicketResult> CreateAndAssignTicketAsync(HttpClient supervisorClient)
+    {
+        var created = await CreateTicketAsync(supervisorClient);
+        var assignResponse = await supervisorClient.PostAsJsonAsync($"/api/tickets/{created.Id}/assign", new
+        {
+            targetAgentUserId = SeedIds.Users.AgentNovabank,
+            reassignmentReason = (string?)null
+        });
+        assignResponse.EnsureSuccessStatusCode();
+        return created;
+    }
+
+    private sealed record CreateTicketResult(Guid Id, string TicketNumber, string Status, string Priority);
+    private sealed record PagedAuditListResponse(IReadOnlyList<AuditListItemResponse> Data, int Page, int PageSize, int TotalCount, int TotalPages);
+    private sealed record AuditListItemResponse(Guid Id, Guid? ActorUserId, string? ActorDisplayName, string Action, string EntityType, Guid EntityId, DateTime CreatedAt, string? CorrelationId);
+    private sealed record AuditLogDetailResponse(Guid Id, Guid? ActorUserId, string? ActorDisplayName, string Action, string EntityType, Guid EntityId, string? PreviousValue, string? NewValue, string? CorrelationId, DateTime CreatedAt);
+}

--- a/tests/OpsSphere.IntegrationTests/Auth/AuthApiTests.cs
+++ b/tests/OpsSphere.IntegrationTests/Auth/AuthApiTests.cs
@@ -3,18 +3,12 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpsSphere.Domain.Entities;
 using OpsSphere.Infrastructure.Persistence;
 using OpsSphere.Infrastructure.Persistence.SeedData;
+using OpsSphere.IntegrationTests.TestInfrastructure;
 
 namespace OpsSphere.IntegrationTests.Auth;
 
@@ -28,7 +22,7 @@ public sealed class AuthApiTests
     [Fact]
     public async Task Login_WithValidSeededUser_ReturnsJwt()
     {
-        await using var factory = await AuthApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var client = factory.CreateClient();
 
         var result = await LoginAsync(client, AgentEmail, OpsSphereSeedData.LocalDemoPassword);
@@ -44,7 +38,7 @@ public sealed class AuthApiTests
     [Fact]
     public async Task Login_WithInvalidPassword_ReturnsGenericError()
     {
-        await using var factory = await AuthApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var client = factory.CreateClient();
 
         var response = await client.PostAsJsonAsync("/api/auth/login", new
@@ -53,7 +47,7 @@ public sealed class AuthApiTests
             password = "wrong-password"
         });
 
-        var error = await ReadResponseAsync<ApiErrorResponse>(response);
+        var error = await OpsSphereSqliteFactory.ReadResponseAsync<OpsSphereSqliteFactory.ApiErrorResponse>(response);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         Assert.Equal(GenericLoginError, error.Error.Message);
@@ -62,7 +56,7 @@ public sealed class AuthApiTests
     [Fact]
     public async Task Login_WithUnknownEmail_ReturnsGenericError()
     {
-        await using var factory = await AuthApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var client = factory.CreateClient();
 
         var response = await client.PostAsJsonAsync("/api/auth/login", new
@@ -71,7 +65,7 @@ public sealed class AuthApiTests
             password = OpsSphereSeedData.LocalDemoPassword
         });
 
-        var error = await ReadResponseAsync<ApiErrorResponse>(response);
+        var error = await OpsSphereSqliteFactory.ReadResponseAsync<OpsSphereSqliteFactory.ApiErrorResponse>(response);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         Assert.Equal(GenericLoginError, error.Error.Message);
@@ -80,9 +74,10 @@ public sealed class AuthApiTests
     [Fact]
     public async Task Login_WithInactiveUser_ReturnsGenericError()
     {
-        await using var factory = await AuthApiFactory.CreateAsync();
-        await factory.DeactivateUserAsync(AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        await DeactivateUserAsync(factory, AgentEmail);
         var client = factory.CreateClient();
+
 
         var response = await client.PostAsJsonAsync("/api/auth/login", new
         {
@@ -90,7 +85,7 @@ public sealed class AuthApiTests
             password = OpsSphereSeedData.LocalDemoPassword
         });
 
-        var error = await ReadResponseAsync<ApiErrorResponse>(response);
+        var error = await OpsSphereSqliteFactory.ReadResponseAsync<OpsSphereSqliteFactory.ApiErrorResponse>(response);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         Assert.Equal(GenericLoginError, error.Error.Message);
@@ -99,7 +94,7 @@ public sealed class AuthApiTests
     [Fact]
     public async Task Login_DoesNotRevealInactiveOrMissingUserReason()
     {
-        await using var inactiveFactory = await AuthApiFactory.CreateAsync();
+        await using var inactiveFactory = await OpsSphereSqliteFactory.CreateAsync();
         await inactiveFactory.DeactivateUserAsync(AgentEmail);
         var inactiveResponse = await inactiveFactory.CreateClient().PostAsJsonAsync("/api/auth/login", new
         {
@@ -108,7 +103,7 @@ public sealed class AuthApiTests
         });
         var inactiveBody = await inactiveResponse.Content.ReadAsStringAsync();
 
-        await using var missingFactory = await AuthApiFactory.CreateAsync();
+        await using var missingFactory = await OpsSphereSqliteFactory.CreateAsync();
         var missingResponse = await missingFactory.CreateClient().PostAsJsonAsync("/api/auth/login", new
         {
             email = "missing@opssphere.local",
@@ -119,9 +114,9 @@ public sealed class AuthApiTests
         Assert.Equal(HttpStatusCode.Unauthorized, inactiveResponse.StatusCode);
         Assert.Equal(HttpStatusCode.Unauthorized, missingResponse.StatusCode);
 
-        // Compare error code and message only — correlationId differs per-request by design
-        var inactiveError = JsonSerializer.Deserialize<ApiErrorResponse>(inactiveBody, JsonOptions)!;
-        var missingError = JsonSerializer.Deserialize<ApiErrorResponse>(missingBody, JsonOptions)!;
+        // Compare error code and message only � correlationId differs per-request by design
+        var inactiveError = JsonSerializer.Deserialize<OpsSphereSqliteFactory.ApiErrorResponse>(inactiveBody, JsonOptions)!;
+        var missingError = JsonSerializer.Deserialize<OpsSphereSqliteFactory.ApiErrorResponse>(missingBody, JsonOptions)!;
         Assert.Equal(inactiveError.Error.Code, missingError.Error.Code);
         Assert.Equal(inactiveError.Error.Message, missingError.Error.Message);
     }
@@ -129,7 +124,7 @@ public sealed class AuthApiTests
     [Fact]
     public async Task GetMe_WithoutToken_Returns401()
     {
-        await using var factory = await AuthApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
 
         var response = await factory.CreateClient().GetAsync("/api/auth/me");
 
@@ -139,13 +134,13 @@ public sealed class AuthApiTests
     [Fact]
     public async Task GetMe_WithValidToken_ReturnsCurrentUserProfile()
     {
-        await using var factory = await AuthApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var client = factory.CreateClient();
         var login = await LoginAsync(client, AgentEmail, OpsSphereSeedData.LocalDemoPassword);
 
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", login.Body.Data.AccessToken);
         var response = await client.GetAsync("/api/auth/me");
-        var body = await ReadResponseAsync<ApiResponse<CurrentUserProfile>>(response);
+        var body = await OpsSphereSqliteFactory.ReadResponseAsync<OpsSphereSqliteFactory.ApiResponse<CurrentUserProfile>>(response);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal(AgentEmail, body.Data.Email);
@@ -157,7 +152,7 @@ public sealed class AuthApiTests
     [Fact]
     public async Task ProtectedSmoke_WithoutToken_Returns401()
     {
-        await using var factory = await AuthApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
 
         var response = await factory.CreateClient().GetAsync("/api/auth/protected-smoke");
 
@@ -167,7 +162,7 @@ public sealed class AuthApiTests
     [Fact]
     public async Task ProtectedSmoke_WithValidToken_Returns200()
     {
-        await using var factory = await AuthApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var client = factory.CreateClient();
         var login = await LoginAsync(client, AgentEmail, OpsSphereSeedData.LocalDemoPassword);
 
@@ -180,7 +175,7 @@ public sealed class AuthApiTests
     [Fact]
     public async Task JwtPayload_DoesNotContainSensitiveData()
     {
-        await using var factory = await AuthApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var client = factory.CreateClient();
         var login = await LoginAsync(client, AgentEmail, OpsSphereSeedData.LocalDemoPassword);
 
@@ -194,14 +189,14 @@ public sealed class AuthApiTests
         Assert.DoesNotContain(token.Claims, claim => claim.Value.Contains("tickets.view", StringComparison.OrdinalIgnoreCase));
         Assert.DoesNotContain(token.Claims, claim => claim.Type.Contains("permission", StringComparison.OrdinalIgnoreCase));
         Assert.DoesNotContain(token.Claims, claim => claim.Type.Contains("scope", StringComparison.OrdinalIgnoreCase));
-        Assert.DoesNotContain(AuthApiFactory.JwtSigningKey, login.Body.Data.AccessToken, StringComparison.Ordinal);
+        Assert.DoesNotContain(OpsSphereSqliteFactory.JwtSigningKey, login.Body.Data.AccessToken, StringComparison.Ordinal);
     }
 
     [Fact]
     public async Task Auth_DoesNotReturnPasswordHash()
     {
-        await using var factory = await AuthApiFactory.CreateAsync();
-        var passwordHash = await factory.GetPasswordHashAsync(AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var passwordHash = await GetPasswordHashAsync(factory, AgentEmail);
         var client = factory.CreateClient();
         var login = await LoginAsync(client, AgentEmail, OpsSphereSeedData.LocalDemoPassword);
         var loginJson = await login.Response.Content.ReadAsStringAsync();
@@ -219,23 +214,12 @@ public sealed class AuthApiTests
     private static async Task<LoginApiResult> LoginAsync(HttpClient client, string email, string password)
     {
         var response = await client.PostAsJsonAsync("/api/auth/login", new { email, password });
-        var body = await ReadResponseAsync<ApiResponse<LoginResponse>>(response);
+        var body = await OpsSphereSqliteFactory.ReadResponseAsync<OpsSphereSqliteFactory.ApiResponse<LoginResponse>>(response);
 
         return new LoginApiResult(response, body);
     }
 
-    private static async Task<T> ReadResponseAsync<T>(HttpResponseMessage response)
-    {
-        var json = await response.Content.ReadAsStringAsync();
-        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
-
-        return value ?? throw new InvalidOperationException($"Response body could not be deserialized as {typeof(T).Name}.");
-    }
-
-    private sealed record LoginApiResult(HttpResponseMessage Response, ApiResponse<LoginResponse> Body);
-    private sealed record ApiResponse<T>(T Data);
-    private sealed record ApiErrorResponse(ApiError Error);
-    private sealed record ApiError(string Code, string Message);
+    private sealed record LoginApiResult(HttpResponseMessage Response, OpsSphereSqliteFactory.ApiResponse<LoginResponse> Body);
     private sealed record LoginResponse(string AccessToken, string TokenType, int ExpiresIn, AuthUserSummary User);
     private sealed record AuthUserSummary(Guid Id, string Email, string DisplayName, IReadOnlyList<string> Roles);
     private sealed record CurrentUserProfile(
@@ -256,91 +240,21 @@ public sealed class AuthApiTests
         Guid? CampaignId,
         string? CampaignCode);
 
-    private sealed class AuthApiFactory : WebApplicationFactory<Program>
+    private static async Task DeactivateUserAsync(OpsSphereSqliteFactory factory, string email)
     {
-        public const string JwtSigningKey = "integration-testing-only-fictional-jwt-signing-key";
+        using var scope = factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+        var user = await dbContext.Users.SingleAsync(u => u.Email == email);
+        user.IsActive = false;
+        user.DeactivatedAt = DateTime.UtcNow;
+        await dbContext.SaveChangesAsync();
+    }
 
-        private readonly SqliteConnection connection = new("Data Source=:memory:");
-
-        public static async Task<AuthApiFactory> CreateAsync()
-        {
-            ConfigureEnvironment();
-            var factory = new AuthApiFactory();
-            await factory.connection.OpenAsync();
-            await factory.InitializeDatabaseAsync();
-
-            return factory;
-        }
-
-        public async Task DeactivateUserAsync(string email)
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            var user = await dbContext.Users.SingleAsync(u => u.Email == email);
-            user.IsActive = false;
-            user.DeactivatedAt = DateTime.UtcNow;
-            await dbContext.SaveChangesAsync();
-        }
-
-        public async Task<string> GetPasswordHashAsync(string email)
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            var user = await dbContext.Users.AsNoTracking().SingleAsync(u => u.Email == email);
-
-            return user.PasswordHash;
-        }
-
-        protected override void ConfigureWebHost(IWebHostBuilder builder)
-        {
-            builder.UseEnvironment("Testing");
-            builder.ConfigureAppConfiguration((_, configuration) =>
-            {
-                configuration.AddInMemoryCollection(new Dictionary<string, string?>
-                {
-                    ["ConnectionStrings:DefaultConnection"] = "Server=(local);Database=OpsSphereAuthTests;Trusted_Connection=True;TrustServerCertificate=True;",
-                    ["SeedData:Enabled"] = "false",
-                    ["Jwt:Issuer"] = "OpsSphere.Tests",
-                    ["Jwt:Audience"] = "OpsSphere.Tests.Angular",
-                    ["Jwt:ExpirationMinutes"] = "60",
-                    ["Jwt:SigningKey"] = JwtSigningKey
-                });
-            });
-            builder.ConfigureTestServices(services =>
-            {
-                services.RemoveAll<IDbContextOptionsConfiguration<OpsSphereDbContext>>();
-                services.RemoveAll<DbContextOptions<OpsSphereDbContext>>();
-                services.AddDbContext<OpsSphereDbContext>(options => options.UseSqlite(connection));
-            });
-        }
-
-        private static void ConfigureEnvironment()
-        {
-            Environment.SetEnvironmentVariable(
-                "ConnectionStrings__DefaultConnection",
-                "Server=(local);Database=OpsSphereAuthTests;Trusted_Connection=True;TrustServerCertificate=True;");
-            Environment.SetEnvironmentVariable("SeedData__Enabled", "false");
-            Environment.SetEnvironmentVariable("Jwt__Issuer", "OpsSphere.Tests");
-            Environment.SetEnvironmentVariable("Jwt__Audience", "OpsSphere.Tests.Angular");
-            Environment.SetEnvironmentVariable("Jwt__ExpirationMinutes", "60");
-            Environment.SetEnvironmentVariable("Jwt__SigningKey", JwtSigningKey);
-        }
-
-        public override async ValueTask DisposeAsync()
-        {
-            await connection.DisposeAsync();
-            await base.DisposeAsync();
-        }
-
-        private async Task InitializeDatabaseAsync()
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            await dbContext.Database.EnsureDeletedAsync();
-            await dbContext.Database.EnsureCreatedAsync();
-
-            var seeder = scope.ServiceProvider.GetRequiredService<OpsSphereDataSeeder>();
-            await seeder.SeedAsync();
-        }
+    private static async Task<string> GetPasswordHashAsync(OpsSphereSqliteFactory factory, string email)
+    {
+        using var scope = factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+        var user = await dbContext.Users.AsNoTracking().SingleAsync(u => u.Email == email);
+        return user.PasswordHash;
     }
 }

--- a/tests/OpsSphere.IntegrationTests/Authorization/AuthorizationApiTests.cs
+++ b/tests/OpsSphere.IntegrationTests/Authorization/AuthorizationApiTests.cs
@@ -1,24 +1,17 @@
 using System.Net;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpsSphere.Infrastructure.Persistence;
 using OpsSphere.Infrastructure.Persistence.SeedData;
+using OpsSphere.IntegrationTests.TestInfrastructure;
 
 namespace OpsSphere.IntegrationTests.Authorization;
 
 /// <summary>
 /// Integration tests for RBAC, permission checks, and scope authorization.
-/// Backend authorization is the source of truth — frontend visibility is UX only.
+/// Backend authorization is the source of truth � frontend visibility is UX only.
 /// </summary>
 public sealed class AuthorizationApiTests
 {
@@ -38,51 +31,51 @@ public sealed class AuthorizationApiTests
     private static readonly Guid NovaBankCampaignId = SeedIds.Campaigns.NovaBankCreditCard;
     private static readonly Guid StreamlyCampaignId = SeedIds.Campaigns.StreamlyCreator;
 
-    // 1. Viewer cannot execute write action → 403
+    // 1. Viewer cannot execute write action ? 403
     [Fact]
     public async Task WriteSmoke_WithViewer_Returns403()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(ViewerEmail);
 
         var response = await client.GetAsync("/api/authz/smoke/write");
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 
-    // 2. Agent cannot access admin-only action → 403
+    // 2. Agent cannot access admin-only action ? 403
     [Fact]
     public async Task AdminSmoke_WithAgent_Returns403()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var response = await client.GetAsync("/api/authz/smoke/admin");
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 
-    // 3. Supervisor cannot access records outside assigned account/campaign → 403
+    // 3. Supervisor cannot access records outside assigned account/campaign ? 403
     [Fact]
     public async Task ScopedCampaign_Supervisor_OutsideScope_Returns403()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
 
-        // Supervisor is scoped to NOVABANK account — Streamly campaign is outside scope
+        // Supervisor is scoped to NOVABANK account � Streamly campaign is outside scope
         var response = await client.GetAsync($"/api/authz/smoke/scoped/campaigns/{StreamlyCampaignId}");
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 
-    // 4. Supervisor can access records inside assigned account/campaign → 200
+    // 4. Supervisor can access records inside assigned account/campaign ? 200
     [Fact]
     public async Task ScopedCampaign_Supervisor_InsideScope_Returns200()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
 
-        // Supervisor has NOVABANK account scope — NovaBankCreditCard is under NOVABANK
+        // Supervisor has NOVABANK account scope � NovaBankCreditCard is under NOVABANK
         var response = await client.GetAsync($"/api/authz/smoke/scoped/campaigns/{NovaBankCampaignId}");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -92,8 +85,8 @@ public sealed class AuthorizationApiTests
     [Fact]
     public async Task ScopedAccount_Supervisor_InsideScope_Returns200()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
 
         var response = await client.GetAsync($"/api/authz/smoke/scoped/accounts/{NovaBankAccountId}");
 
@@ -104,20 +97,20 @@ public sealed class AuthorizationApiTests
     [Fact]
     public async Task ScopedAccount_Supervisor_OutsideScope_Returns403()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
 
         var response = await client.GetAsync($"/api/authz/smoke/scoped/accounts/{StreamlyAccountId}");
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 
-    // 5. OperationsManager can read data within assigned region → 200
+    // 5. OperationsManager can read data within assigned region ? 200
     [Fact]
     public async Task ScopedRegion_Manager_InsideScope_Returns200()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, ManagerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(ManagerEmail);
 
         // Manager has LATAM region scope
         var response = await client.GetAsync($"/api/authz/smoke/scoped/regions/{LatamRegionId}");
@@ -125,14 +118,14 @@ public sealed class AuthorizationApiTests
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
-    // 6. OperationsManager cannot read data outside assigned region → 403
+    // 6. OperationsManager cannot read data outside assigned region ? 403
     [Fact]
     public async Task ScopedRegion_Manager_OutsideScope_Returns403()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, ManagerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(ManagerEmail);
 
-        // Manager has LATAM scope — NA region is outside scope
+        // Manager has LATAM scope � NA region is outside scope
         var response = await client.GetAsync($"/api/authz/smoke/scoped/regions/{NaRegionId}");
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -142,8 +135,8 @@ public sealed class AuthorizationApiTests
     [Fact]
     public async Task ScopedAccount_Manager_InsideRegionScope_Returns200()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, ManagerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(ManagerEmail);
 
         // Manager has LATAM region scope; NOVABANK is in MX which is in LATAM
         var response = await client.GetAsync($"/api/authz/smoke/scoped/accounts/{NovaBankAccountId}");
@@ -151,26 +144,26 @@ public sealed class AuthorizationApiTests
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
-    // 7. User without required permission is denied → 403
+    // 7. User without required permission is denied ? 403
     [Fact]
     public async Task AdminSmoke_WithViewer_Returns403()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(ViewerEmail);
 
         var response = await client.GetAsync("/api/authz/smoke/admin");
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 
-    // 8. User without required scope is denied → 403
+    // 8. User without required scope is denied ? 403
     [Fact]
     public async Task ScopedCampaign_Agent_OutsideScope_Returns403()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
-        // Agent has NOVABANK-CC campaign scope only — Streamly campaign is out of scope
+        // Agent has NOVABANK-CC campaign scope only � Streamly campaign is out of scope
         var response = await client.GetAsync($"/api/authz/smoke/scoped/campaigns/{StreamlyCampaignId}");
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -180,8 +173,8 @@ public sealed class AuthorizationApiTests
     [Fact]
     public async Task ScopedCampaign_Agent_InsideScope_Returns200()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         // Agent is scoped to NOVABANK-CC campaign
         var response = await client.GetAsync($"/api/authz/smoke/scoped/campaigns/{NovaBankCampaignId}");
@@ -193,14 +186,14 @@ public sealed class AuthorizationApiTests
     [Fact]
     public async Task ScopedCampaigns_ReturnsScopeRestrictedResult()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var response = await client.GetAsync("/api/authz/smoke/scoped/campaigns");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        var body = await ReadResponseAsync<SmokeResponse>(response);
+        var body = await OpsSphereSqliteFactory.ReadResponseAsync<SmokeResponse>(response);
         Assert.Equal("ok", body.Status);
     }
 
@@ -208,7 +201,7 @@ public sealed class AuthorizationApiTests
     [Fact]
     public async Task AdminSmoke_WithoutToken_Returns401()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
 
         var response = await factory.CreateClient().GetAsync("/api/authz/smoke/admin");
 
@@ -218,7 +211,7 @@ public sealed class AuthorizationApiTests
     [Fact]
     public async Task WriteSmoke_WithoutToken_Returns401()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
 
         var response = await factory.CreateClient().GetAsync("/api/authz/smoke/write");
 
@@ -228,7 +221,7 @@ public sealed class AuthorizationApiTests
     [Fact]
     public async Task ScopedRegion_WithoutToken_Returns401()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
 
         var response = await factory.CreateClient().GetAsync($"/api/authz/smoke/scoped/regions/{LatamRegionId}");
 
@@ -239,8 +232,8 @@ public sealed class AuthorizationApiTests
     [Fact]
     public async Task AdminSmoke_WithManager_Returns403()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, ManagerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(ManagerEmail);
 
         // Manager does not have users.manage permission
         var response = await client.GetAsync("/api/authz/smoke/admin");
@@ -251,8 +244,8 @@ public sealed class AuthorizationApiTests
     [Fact]
     public async Task WriteSmoke_WithManager_Returns403()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, ManagerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(ManagerEmail);
 
         // OperationsManager does not have tickets.create permission
         var response = await client.GetAsync("/api/authz/smoke/write");
@@ -266,9 +259,9 @@ public sealed class AuthorizationApiTests
     [Fact]
     public async Task BackendAuthz_IsEnforcedWithoutFrontend()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        // Viewer — no frontend, raw HTTP call to a write endpoint
-        var client = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        // Viewer � no frontend, raw HTTP call to a write endpoint
+        var client = await factory.CreateAuthenticatedClientAsync(ViewerEmail);
 
         var response = await client.GetAsync("/api/authz/smoke/write");
 
@@ -280,8 +273,8 @@ public sealed class AuthorizationApiTests
     [Fact]
     public async Task AuthorizationDenial_LogsDoNotExposeSecrets()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(ViewerEmail);
 
         // Trigger a 403 denial
         var response = await client.GetAsync("/api/authz/smoke/admin");
@@ -289,7 +282,7 @@ public sealed class AuthorizationApiTests
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         // Response body must not contain signing key, password-related data, or token
-        Assert.DoesNotContain(AuthzApiFactory.JwtSigningKey, responseBody, StringComparison.Ordinal);
+        Assert.DoesNotContain(OpsSphereSqliteFactory.JwtSigningKey, responseBody, StringComparison.Ordinal);
         Assert.DoesNotContain("passwordHash", responseBody, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("password", responseBody, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("Authorization", responseBody, StringComparison.OrdinalIgnoreCase);
@@ -299,8 +292,8 @@ public sealed class AuthorizationApiTests
     [Fact]
     public async Task ScopedRegion_Admin_BypassesScopeRestriction_Returns200()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         // Admin accesses NA region even though Admin has no region scope row
         var response = await client.GetAsync($"/api/authz/smoke/scoped/regions/{NaRegionId}");
@@ -311,20 +304,20 @@ public sealed class AuthorizationApiTests
     [Fact]
     public async Task ScopedAccount_Admin_BypassesScopeRestriction_Returns200()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var response = await client.GetAsync($"/api/authz/smoke/scoped/accounts/{StreamlyAccountId}");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
-    // Viewer scope test — Viewer has LATAM region scope
+    // Viewer scope test � Viewer has LATAM region scope
     [Fact]
     public async Task ScopedRegion_Viewer_InsideScope_Returns200()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(ViewerEmail);
 
         var response = await client.GetAsync($"/api/authz/smoke/scoped/regions/{LatamRegionId}");
 
@@ -334,10 +327,10 @@ public sealed class AuthorizationApiTests
     [Fact]
     public async Task ScopedRegion_Viewer_OutsideScope_Returns403()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(ViewerEmail);
 
-        // Viewer has LATAM scope — NA is outside scope
+        // Viewer has LATAM scope � NA is outside scope
         var response = await client.GetAsync($"/api/authz/smoke/scoped/regions/{NaRegionId}");
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -347,8 +340,8 @@ public sealed class AuthorizationApiTests
     [Fact]
     public async Task AdminSmoke_WithAdmin_Returns200()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var response = await client.GetAsync("/api/authz/smoke/admin");
 
@@ -359,8 +352,8 @@ public sealed class AuthorizationApiTests
     [Fact]
     public async Task WriteSmoke_WithSupervisor_Returns200()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
 
         var response = await client.GetAsync("/api/authz/smoke/write");
 
@@ -370,105 +363,13 @@ public sealed class AuthorizationApiTests
     [Fact]
     public async Task WriteSmoke_WithAgent_Returns200()
     {
-        await using var factory = await AuthzApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var response = await client.GetAsync("/api/authz/smoke/write");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
-    private static async Task<HttpClient> CreateAuthenticatedClientAsync(AuthzApiFactory factory, string email)
-    {
-        var client = factory.CreateClient();
-        var loginResponse = await client.PostAsJsonAsync("/api/auth/login", new
-        {
-            email,
-            password = OpsSphereSeedData.LocalDemoPassword
-        });
-        loginResponse.EnsureSuccessStatusCode();
-        var loginBody = await ReadResponseAsync<LoginApiResponse>(loginResponse);
-        client.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", loginBody.Data.AccessToken);
-        return client;
-    }
-
-    private static async Task<T> ReadResponseAsync<T>(HttpResponseMessage response)
-    {
-        var json = await response.Content.ReadAsStringAsync();
-        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
-        return value ?? throw new InvalidOperationException($"Could not deserialize {typeof(T).Name}.");
-    }
-
-    private sealed record LoginApiResponse(LoginData Data);
-    private sealed record LoginData(string AccessToken);
     private sealed record SmokeResponse(string Status);
-
-    internal sealed class AuthzApiFactory : WebApplicationFactory<Program>
-    {
-        public const string JwtSigningKey = "integration-testing-only-fictional-jwt-signing-key";
-
-        private readonly SqliteConnection connection = new("Data Source=:memory:");
-
-        public static async Task<AuthzApiFactory> CreateAsync()
-        {
-            ConfigureEnvironment();
-            var factory = new AuthzApiFactory();
-            await factory.connection.OpenAsync();
-            await factory.InitializeDatabaseAsync();
-            return factory;
-        }
-
-        protected override void ConfigureWebHost(IWebHostBuilder builder)
-        {
-            builder.UseEnvironment("Testing");
-            builder.ConfigureAppConfiguration((_, config) =>
-            {
-                config.AddInMemoryCollection(new Dictionary<string, string?>
-                {
-                    ["ConnectionStrings:DefaultConnection"] = "Server=(local);Database=OpsSphereAuthzTests;Trusted_Connection=True;TrustServerCertificate=True;",
-                    ["SeedData:Enabled"] = "false",
-                    ["Jwt:Issuer"] = "OpsSphere.Tests",
-                    ["Jwt:Audience"] = "OpsSphere.Tests.Angular",
-                    ["Jwt:ExpirationMinutes"] = "60",
-                    ["Jwt:SigningKey"] = JwtSigningKey
-                });
-            });
-            builder.ConfigureTestServices(services =>
-            {
-                services.RemoveAll<IDbContextOptionsConfiguration<OpsSphereDbContext>>();
-                services.RemoveAll<DbContextOptions<OpsSphereDbContext>>();
-                services.AddDbContext<OpsSphereDbContext>(options => options.UseSqlite(connection));
-            });
-        }
-
-        private static void ConfigureEnvironment()
-        {
-            Environment.SetEnvironmentVariable(
-                "ConnectionStrings__DefaultConnection",
-                "Server=(local);Database=OpsSphereAuthzTests;Trusted_Connection=True;TrustServerCertificate=True;");
-            Environment.SetEnvironmentVariable("SeedData__Enabled", "false");
-            Environment.SetEnvironmentVariable("Jwt__Issuer", "OpsSphere.Tests");
-            Environment.SetEnvironmentVariable("Jwt__Audience", "OpsSphere.Tests.Angular");
-            Environment.SetEnvironmentVariable("Jwt__ExpirationMinutes", "60");
-            Environment.SetEnvironmentVariable("Jwt__SigningKey", JwtSigningKey);
-        }
-
-        public override async ValueTask DisposeAsync()
-        {
-            await connection.DisposeAsync();
-            await base.DisposeAsync();
-        }
-
-        private async Task InitializeDatabaseAsync()
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            await dbContext.Database.EnsureDeletedAsync();
-            await dbContext.Database.EnsureCreatedAsync();
-
-            var seeder = scope.ServiceProvider.GetRequiredService<OpsSphereDataSeeder>();
-            await seeder.SeedAsync();
-        }
-    }
 }

--- a/tests/OpsSphere.IntegrationTests/CustomerManagement/CustomerManagementApiTests.cs
+++ b/tests/OpsSphere.IntegrationTests/CustomerManagement/CustomerManagementApiTests.cs
@@ -1,19 +1,12 @@
 using System.Net;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpsSphere.Domain.Entities;
 using OpsSphere.Infrastructure.Persistence;
 using OpsSphere.Infrastructure.Persistence.SeedData;
+using OpsSphere.IntegrationTests.TestInfrastructure;
 
 namespace OpsSphere.IntegrationTests.CustomerManagement;
 
@@ -29,8 +22,8 @@ public sealed class CustomerManagementApiTests
     [Fact]
     public async Task Admin_CanCreateUpdateAndDeactivateCustomer()
     {
-        await using var factory = await CustomerApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var customer = await CreateCustomerAsync(client, SeedIds.Accounts.NovaBank, "Lucia", "Reyes", "l.reyes@fictional.test", null, "NB-NEW-001");
         Assert.Equal("Lucia", customer.FirstName);
@@ -48,7 +41,7 @@ public sealed class CustomerManagementApiTests
             phoneNumber = (string?)null,
             externalReference = "NB-NEW-001-U"
         });
-        var updated = await ReadDataAsync<CustomerResponse>(updateResponse);
+        var updated = await OpsSphereSqliteFactory.ReadDataAsync<CustomerResponse>(updateResponse);
         Assert.Equal(HttpStatusCode.OK, updateResponse.StatusCode);
         Assert.Equal("Reyes-Updated", updated.LastName);
         Assert.Equal("NB-NEW-001-U", updated.ExternalReference);
@@ -64,8 +57,8 @@ public sealed class CustomerManagementApiTests
     [Fact]
     public async Task Viewer_CanReadCustomersButNotWriteThem()
     {
-        await using var factory = await CustomerApiFactory.CreateAsync();
-        var viewer = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var viewer = await factory.CreateAuthenticatedClientAsync(ViewerEmail);
 
         var listResponse = await viewer.GetAsync("/api/customers");
         Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
@@ -99,8 +92,8 @@ public sealed class CustomerManagementApiTests
     [Fact]
     public async Task CustomerValidation_RejectsRequiredFieldFailures()
     {
-        await using var factory = await CustomerApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var missing = await client.PostAsJsonAsync("/api/customers", new
         {
@@ -111,7 +104,7 @@ public sealed class CustomerManagementApiTests
             phoneNumber = (string?)null,
             externalReference = (string?)null
         });
-        var missingError = await ReadErrorAsync(missing);
+        var missingError = await OpsSphereSqliteFactory.ReadErrorAsync(missing);
         Assert.Equal(HttpStatusCode.BadRequest, missing.StatusCode);
         Assert.Equal("validation_error", missingError.Error.Code);
         Assert.Contains(missingError.Error.Details, d => d.Field == "firstName");
@@ -121,8 +114,8 @@ public sealed class CustomerManagementApiTests
     [Fact]
     public async Task CustomerCreate_RejectsInactiveOrMissingAccount()
     {
-        await using var factory = await CustomerApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var inactiveAccountId = await factory.AddInactiveAccountAsync("VOID-CA", "Void Customer Account");
 
@@ -152,12 +145,12 @@ public sealed class CustomerManagementApiTests
     [Fact]
     public async Task ScopedReads_FilterCustomersByAccountScope()
     {
-        await using var factory = await CustomerApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
 
-        var agentCustomers = await ReadDataAsync<IReadOnlyList<CustomerResponse>>(await agent.GetAsync("/api/customers"));
-        var supervisorCustomers = await ReadDataAsync<IReadOnlyList<CustomerResponse>>(await supervisor.GetAsync("/api/customers"));
+        var agentCustomers = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<CustomerResponse>>(await agent.GetAsync("/api/customers"));
+        var supervisorCustomers = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<CustomerResponse>>(await supervisor.GetAsync("/api/customers"));
 
         Assert.All(agentCustomers, c => Assert.Equal(SeedIds.Accounts.NovaBank, c.AccountId));
         Assert.All(supervisorCustomers, c => Assert.Equal(SeedIds.Accounts.NovaBank, c.AccountId));
@@ -167,8 +160,8 @@ public sealed class CustomerManagementApiTests
     [Fact]
     public async Task CrossScopeCustomer_ReturnsNotFoundToNonAdmin()
     {
-        await using var factory = await CustomerApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var getResponse = await agent.GetAsync($"/api/customers/{SeedIds.Customers.StreamlyCustomer1}");
         Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
@@ -191,11 +184,11 @@ public sealed class CustomerManagementApiTests
     [Fact]
     public async Task CustomerTickets_ReturnsSeededDemoHistory()
     {
-        await using var factory = await CustomerApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var response = await client.GetAsync($"/api/customers/{SeedIds.Customers.NovaBankCustomer1}/tickets");
-        var tickets = await ReadDataAsync<IReadOnlyList<CustomerTicketSummaryResponse>>(response);
+        var tickets = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<CustomerTicketSummaryResponse>>(response);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal(6, tickets.Count);
@@ -206,8 +199,8 @@ public sealed class CustomerManagementApiTests
     [Fact]
     public async Task CustomerAuditLogs_DoNotContainPii()
     {
-        await using var factory = await CustomerApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var customer = await CreateCustomerAsync(client, SeedIds.Accounts.NovaBank, "AuditTest", "PiiCheck", "pii.test@fictional.test", "+1-555-000-0001", "AUDIT-001");
         await factory.AssertAuditDoesNotContainPiiAsync(customer.Id);
@@ -216,8 +209,8 @@ public sealed class CustomerManagementApiTests
     [Fact]
     public async Task CustomerResponses_UseEnvelopeAndDoNotExposeSecrets()
     {
-        await using var factory = await CustomerApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var response = await client.GetAsync("/api/customers");
         var json = await response.Content.ReadAsStringAsync();
@@ -231,177 +224,25 @@ public sealed class CustomerManagementApiTests
     {
         var response = await client.PostAsJsonAsync("/api/customers", new { accountId, firstName, lastName, email, phoneNumber, externalReference });
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        return await ReadDataAsync<CustomerResponse>(response);
+        return await OpsSphereSqliteFactory.ReadDataAsync<CustomerResponse>(response);
     }
 
     private static async Task AssertValidationAsync(HttpResponseMessage response, string field)
     {
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         Assert.Equal("validation_error", error.Error.Code);
         Assert.Contains(error.Error.Details, detail => detail.Field == field);
     }
 
-    private static async Task<HttpClient> CreateAuthenticatedClientAsync(CustomerApiFactory factory, string email)
-    {
-        var client = factory.CreateClient();
-        var loginResponse = await client.PostAsJsonAsync("/api/auth/login", new
-        {
-            email,
-            password = OpsSphereSeedData.LocalDemoPassword
-        });
-        loginResponse.EnsureSuccessStatusCode();
-        var loginBody = await ReadResponseAsync<ApiResponse<LoginData>>(loginResponse);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", loginBody.Data.AccessToken);
-        return client;
-    }
-
-    private static async Task<T> ReadDataAsync<T>(HttpResponseMessage response)
-    {
-        var envelope = await ReadResponseAsync<ApiResponse<T>>(response);
-        return envelope.Data;
-    }
-
-    private static async Task<ApiErrorResponse> ReadErrorAsync(HttpResponseMessage response) =>
-        await ReadResponseAsync<ApiErrorResponse>(response);
-
-    private static async Task<T> ReadResponseAsync<T>(HttpResponseMessage response)
+private static async Task AssertResponseDoesNotExposeSensitiveDataAsync(HttpResponseMessage response)
     {
         var json = await response.Content.ReadAsStringAsync();
-        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
-        return value ?? throw new InvalidOperationException($"Could not deserialize {typeof(T).Name} from {(int)response.StatusCode}: {json}");
-    }
-
-    private static async Task AssertResponseDoesNotExposeSensitiveDataAsync(HttpResponseMessage response)
-    {
-        var json = await response.Content.ReadAsStringAsync();
-        foreach (var term in new[] { "passwordHash", "temporaryPassword", "accessToken", "refreshToken", "jwt", "secret", CustomerApiFactory.JwtSigningKey })
+        foreach (var term in new[] { "passwordHash", "temporaryPassword", "accessToken", "refreshToken", "jwt", "secret", OpsSphereSqliteFactory.JwtSigningKey })
         {
             Assert.DoesNotContain(term, json, StringComparison.OrdinalIgnoreCase);
         }
     }
-
-    private sealed record ApiResponse<T>(T Data);
-    private sealed record ApiErrorResponse(ApiError Error);
-    private sealed record ApiError(string Code, string Message, IReadOnlyList<ApiErrorDetail> Details);
-    private sealed record ApiErrorDetail(string? Field, string Message);
-    private sealed record LoginData(string AccessToken);
     private sealed record CustomerResponse(Guid Id, Guid AccountId, string AccountCode, string AccountName, string FirstName, string LastName, string? Email, string? PhoneNumber, string? ExternalReference, bool IsActive);
     private sealed record CustomerTicketSummaryResponse(Guid Id, string TicketNumber, string Status, string Priority, string SlaState, DateTime CreatedAt, DateTime? ResolvedAt, DateTime? ClosedAt);
-
-    internal sealed class CustomerApiFactory : WebApplicationFactory<Program>
-    {
-        public const string JwtSigningKey = "integration-testing-only-fictional-jwt-signing-key";
-
-        private readonly SqliteConnection connection = new("Data Source=:memory:");
-
-        public static async Task<CustomerApiFactory> CreateAsync()
-        {
-            ConfigureEnvironment();
-            var factory = new CustomerApiFactory();
-            await factory.connection.OpenAsync();
-            await factory.InitializeDatabaseAsync();
-            return factory;
-        }
-
-        public async Task<Guid> AddInactiveAccountAsync(string code, string name)
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            var mexicoId = await dbContext.Countries.Where(c => c.Code == "MX").Select(c => c.Id).SingleAsync();
-            var account = new Account { Id = Guid.NewGuid(), CountryId = mexicoId, Code = code, Name = name, IsActive = false, CreatedAt = DateTime.UtcNow };
-            dbContext.Accounts.Add(account);
-            await dbContext.SaveChangesAsync();
-            return account.Id;
-        }
-
-        public async Task AssertAuditAsync(string action, string entityType, Guid entityId)
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-
-            var audit = await dbContext.AuditLogs
-                .AsNoTracking()
-                .Where(log => log.Action == action && log.EntityType == entityType && log.EntityId == entityId)
-                .OrderByDescending(log => log.CreatedAt)
-                .FirstOrDefaultAsync();
-
-            Assert.NotNull(audit);
-            Assert.False(string.IsNullOrWhiteSpace(audit.CorrelationId));
-            Assert.DoesNotContain("password", audit.PreviousValue ?? string.Empty, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain("password", audit.NewValue ?? string.Empty, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain(JwtSigningKey, audit.PreviousValue ?? string.Empty, StringComparison.Ordinal);
-            Assert.DoesNotContain(JwtSigningKey, audit.NewValue ?? string.Empty, StringComparison.Ordinal);
-        }
-
-        public async Task AssertAuditDoesNotContainPiiAsync(Guid customerId)
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            var customer = await dbContext.Customers.AsNoTracking().FirstAsync(c => c.Id == customerId);
-
-            var auditLogs = await dbContext.AuditLogs.AsNoTracking()
-                .Where(log => log.EntityId == customerId)
-                .ToListAsync();
-
-            foreach (var log in auditLogs)
-            {
-                var combined = $"{log.PreviousValue}{log.NewValue}";
-                if (customer.Email is not null) Assert.DoesNotContain(customer.Email, combined, StringComparison.OrdinalIgnoreCase);
-                if (customer.PhoneNumber is not null) Assert.DoesNotContain(customer.PhoneNumber, combined, StringComparison.OrdinalIgnoreCase);
-                Assert.DoesNotContain(customer.FirstName, combined, StringComparison.OrdinalIgnoreCase);
-                Assert.DoesNotContain(customer.LastName, combined, StringComparison.OrdinalIgnoreCase);
-            }
-        }
-
-        protected override void ConfigureWebHost(IWebHostBuilder builder)
-        {
-            builder.UseEnvironment("Testing");
-            builder.ConfigureAppConfiguration((_, config) =>
-            {
-                config.AddInMemoryCollection(new Dictionary<string, string?>
-                {
-                    ["ConnectionStrings:DefaultConnection"] = "Server=(local);Database=OpsSphereCustomerTests;Trusted_Connection=True;TrustServerCertificate=True;",
-                    ["SeedData:Enabled"] = "false",
-                    ["Jwt:Issuer"] = "OpsSphere.Tests",
-                    ["Jwt:Audience"] = "OpsSphere.Tests.Angular",
-                    ["Jwt:ExpirationMinutes"] = "60",
-                    ["Jwt:SigningKey"] = JwtSigningKey
-                });
-            });
-            builder.ConfigureTestServices(services =>
-            {
-                services.RemoveAll<IDbContextOptionsConfiguration<OpsSphereDbContext>>();
-                services.RemoveAll<DbContextOptions<OpsSphereDbContext>>();
-                services.AddDbContext<OpsSphereDbContext>(options => options.UseSqlite(connection));
-            });
-        }
-
-        private static void ConfigureEnvironment()
-        {
-            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", "Server=(local);Database=OpsSphereCustomerTests;Trusted_Connection=True;TrustServerCertificate=True;");
-            Environment.SetEnvironmentVariable("SeedData__Enabled", "false");
-            Environment.SetEnvironmentVariable("Jwt__Issuer", "OpsSphere.Tests");
-            Environment.SetEnvironmentVariable("Jwt__Audience", "OpsSphere.Tests.Angular");
-            Environment.SetEnvironmentVariable("Jwt__ExpirationMinutes", "60");
-            Environment.SetEnvironmentVariable("Jwt__SigningKey", JwtSigningKey);
-        }
-
-        public override async ValueTask DisposeAsync()
-        {
-            await connection.DisposeAsync();
-            await base.DisposeAsync();
-        }
-
-        private async Task InitializeDatabaseAsync()
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            await dbContext.Database.EnsureDeletedAsync();
-            await dbContext.Database.EnsureCreatedAsync();
-
-            var seeder = scope.ServiceProvider.GetRequiredService<OpsSphereDataSeeder>();
-            await seeder.SeedAsync();
-        }
-    }
 }

--- a/tests/OpsSphere.IntegrationTests/DashboardManagement/DashboardApiTests.cs
+++ b/tests/OpsSphere.IntegrationTests/DashboardManagement/DashboardApiTests.cs
@@ -1,20 +1,13 @@
-using System.Net;
-using System.Net.Http.Headers;
+﻿using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpsSphere.Domain.Entities;
 using OpsSphere.Domain.Enums;
 using OpsSphere.Infrastructure.Persistence;
 using OpsSphere.Infrastructure.Persistence.SeedData;
+using OpsSphere.IntegrationTests.TestInfrastructure;
 
 namespace OpsSphere.IntegrationTests.DashboardManagement;
 
@@ -32,7 +25,7 @@ public sealed class DashboardApiTests
     [Fact]
     public async Task GetOperationalDashboard_WithoutAuth_Returns401()
     {
-        await using var factory = await DashboardApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
 
         var response = await factory.CreateClient().GetAsync("/api/dashboard/operational");
 
@@ -42,8 +35,8 @@ public sealed class DashboardApiTests
     [Fact]
     public async Task GetOperationalDashboard_WithAgent_Returns200()
     {
-        await using var factory = await DashboardApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var response = await agent.GetAsync("/api/dashboard/operational");
 
@@ -53,8 +46,8 @@ public sealed class DashboardApiTests
     [Fact]
     public async Task GetOperationalDashboard_WithViewer_Returns200()
     {
-        await using var factory = await DashboardApiFactory.CreateAsync();
-        var viewer = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var viewer = await factory.CreateAuthenticatedClientAsync(ViewerEmail);
 
         var response = await viewer.GetAsync("/api/dashboard/operational");
 
@@ -64,12 +57,12 @@ public sealed class DashboardApiTests
     [Fact]
     public async Task GetOperationalDashboard_Manager_SeesOnlyRegionalTickets()
     {
-        await using var factory = await DashboardApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         await AddTicketDirectlyAsync(factory, SeedIds.Accounts.NovaBank, SeedIds.Campaigns.NovaBankCreditCard, SeedIds.Customers.NovaBankCustomer1);
         await AddTicketDirectlyAsync(factory, SeedIds.Accounts.Streamly, SeedIds.Campaigns.StreamlyCreator, SeedIds.Customers.StreamlyCustomer1);
-        var manager = await CreateAuthenticatedClientAsync(factory, ManagerEmail);
+        var manager = await factory.CreateAuthenticatedClientAsync(ManagerEmail);
 
-        var dashboard = await ReadDataAsync<OperationalDashboardResponse>(
+        var dashboard = await OpsSphereSqliteFactory.ReadDataAsync<OperationalDashboardResponse>(
             await manager.GetAsync("/api/dashboard/operational"));
 
         Assert.Equal(SeededNovaBankTicketCount + 1, dashboard.TotalTicketCount);
@@ -80,12 +73,12 @@ public sealed class DashboardApiTests
     [Fact]
     public async Task GetOperationalDashboard_Supervisor_SeesOnlyAccountScope()
     {
-        await using var factory = await DashboardApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         await AddTicketDirectlyAsync(factory, SeedIds.Accounts.NovaBank, SeedIds.Campaigns.NovaBankCreditCard, SeedIds.Customers.NovaBankCustomer1);
         await AddTicketDirectlyAsync(factory, SeedIds.Accounts.Streamly, SeedIds.Campaigns.StreamlyCreator, SeedIds.Customers.StreamlyCustomer1);
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
 
-        var dashboard = await ReadDataAsync<OperationalDashboardResponse>(
+        var dashboard = await OpsSphereSqliteFactory.ReadDataAsync<OperationalDashboardResponse>(
             await supervisor.GetAsync("/api/dashboard/operational"));
 
         Assert.Equal(SeededNovaBankTicketCount + 1, dashboard.TotalTicketCount);
@@ -95,12 +88,12 @@ public sealed class DashboardApiTests
     [Fact]
     public async Task GetOperationalDashboard_Agent_SeesOnlyCampaignScope()
     {
-        await using var factory = await DashboardApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         await AddTicketDirectlyAsync(factory, SeedIds.Accounts.NovaBank, SeedIds.Campaigns.NovaBankCreditCard, SeedIds.Customers.NovaBankCustomer1);
         await AddTicketDirectlyAsync(factory, SeedIds.Accounts.NovaBank, SeedIds.Campaigns.NovaBankFraud, SeedIds.Customers.NovaBankCustomer1);
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
-        var dashboard = await ReadDataAsync<OperationalDashboardResponse>(
+        var dashboard = await OpsSphereSqliteFactory.ReadDataAsync<OperationalDashboardResponse>(
             await agent.GetAsync("/api/dashboard/operational"));
 
         Assert.Equal(SeededNovaBankTicketCount + 1, dashboard.TotalTicketCount);
@@ -110,12 +103,12 @@ public sealed class DashboardApiTests
     [Fact]
     public async Task GetOperationalDashboard_WithOutOfScopeAccountFilter_ReturnsZeroCounts()
     {
-        await using var factory = await DashboardApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         await AddTicketDirectlyAsync(factory, SeedIds.Accounts.NovaBank, SeedIds.Campaigns.NovaBankCreditCard, SeedIds.Customers.NovaBankCustomer1);
         await AddTicketDirectlyAsync(factory, SeedIds.Accounts.Streamly, SeedIds.Campaigns.StreamlyCreator, SeedIds.Customers.StreamlyCustomer1);
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
 
-        var dashboard = await ReadDataAsync<OperationalDashboardResponse>(
+        var dashboard = await OpsSphereSqliteFactory.ReadDataAsync<OperationalDashboardResponse>(
             await supervisor.GetAsync($"/api/dashboard/operational?accountId={SeedIds.Accounts.Streamly}"));
 
         Assert.Equal(0, dashboard.TotalTicketCount);
@@ -125,7 +118,7 @@ public sealed class DashboardApiTests
     [Fact]
     public async Task GetOperationalDashboard_Aggregates_AreCorrect()
     {
-        await using var factory = await DashboardApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         await AddTicketDirectlyAsync(
             factory,
             SeedIds.Accounts.NovaBank,
@@ -144,9 +137,9 @@ public sealed class DashboardApiTests
             status: TicketStatus.Assigned,
             priority: TicketPriority.Normal,
             assignedAgentUserId: SeedIds.Users.AgentNovabank);
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
-        var dashboard = await ReadDataAsync<OperationalDashboardResponse>(
+        var dashboard = await OpsSphereSqliteFactory.ReadDataAsync<OperationalDashboardResponse>(
             await agent.GetAsync("/api/dashboard/operational"));
 
         Assert.Equal(SeededNovaBankTicketCount + 2, dashboard.TotalTicketCount);
@@ -163,7 +156,7 @@ public sealed class DashboardApiTests
     [Fact]
     public async Task GetOperationalDashboard_SlaAggregates_UseRequestTimeEvaluation()
     {
-        await using var factory = await DashboardApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         await AddTicketDirectlyAsync(
             factory,
             SeedIds.Accounts.NovaBank,
@@ -172,9 +165,9 @@ public sealed class DashboardApiTests
             slaStartedAt: DateTime.UtcNow.AddHours(-6),
             slaDueAt: DateTime.UtcNow.AddHours(-1),
             storedSlaState: SlaState.WithinSla);
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
-        var dashboard = await ReadDataAsync<OperationalDashboardResponse>(
+        var dashboard = await OpsSphereSqliteFactory.ReadDataAsync<OperationalDashboardResponse>(
             await agent.GetAsync("/api/dashboard/operational"));
 
         Assert.Equal(3, dashboard.BreachedTicketCount);
@@ -184,12 +177,12 @@ public sealed class DashboardApiTests
     [Fact]
     public async Task GetOperationalDashboard_WithAccountFilter_IntersectsScope()
     {
-        await using var factory = await DashboardApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         await AddTicketDirectlyAsync(factory, SeedIds.Accounts.NovaBank, SeedIds.Campaigns.NovaBankCreditCard, SeedIds.Customers.NovaBankCustomer1);
         await AddTicketDirectlyAsync(factory, SeedIds.Accounts.NovaBank, SeedIds.Campaigns.NovaBankFraud, SeedIds.Customers.NovaBankCustomer1);
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
 
-        var dashboard = await ReadDataAsync<OperationalDashboardResponse>(
+        var dashboard = await OpsSphereSqliteFactory.ReadDataAsync<OperationalDashboardResponse>(
             await supervisor.GetAsync($"/api/dashboard/operational?accountId={SeedIds.Accounts.NovaBank}"));
 
         Assert.Equal(SeededNovaBankTicketCount + 2, dashboard.TotalTicketCount);
@@ -199,8 +192,8 @@ public sealed class DashboardApiTests
     [Fact]
     public async Task GetOperationalDashboard_WithInvalidDateRange_Returns400()
     {
-        await using var factory = await DashboardApiFactory.CreateAsync();
-        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var admin = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var response = await admin.GetAsync("/api/dashboard/operational?dateFrom=2026-05-18T00:00:00Z&dateTo=2026-05-17T00:00:00Z");
 
@@ -210,9 +203,9 @@ public sealed class DashboardApiTests
     [Fact]
     public async Task GetOperationalDashboard_WithoutDashboardView_Returns403()
     {
-        await using var factory = await DashboardApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         await RemoveDashboardPermissionFromAgentRoleAsync(factory);
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var response = await agent.GetAsync("/api/dashboard/operational");
 
@@ -220,7 +213,7 @@ public sealed class DashboardApiTests
     }
 
     private static async Task<Guid> AddTicketDirectlyAsync(
-        DashboardApiFactory factory,
+        OpsSphereSqliteFactory factory,
         Guid accountId,
         Guid campaignId,
         Guid customerId,
@@ -282,7 +275,7 @@ public sealed class DashboardApiTests
         return ticketId;
     }
 
-    private static async Task RemoveDashboardPermissionFromAgentRoleAsync(DashboardApiFactory factory)
+    private static async Task RemoveDashboardPermissionFromAgentRoleAsync(OpsSphereSqliteFactory factory)
     {
         using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
@@ -291,37 +284,6 @@ public sealed class DashboardApiTests
         db.RolePermissions.Remove(mapping);
         await db.SaveChangesAsync();
     }
-
-    private static async Task<HttpClient> CreateAuthenticatedClientAsync(DashboardApiFactory factory, string email)
-    {
-        var client = factory.CreateClient();
-        var loginResponse = await client.PostAsJsonAsync("/api/auth/login", new
-        {
-            email,
-            password = OpsSphereSeedData.LocalDemoPassword
-        });
-        loginResponse.EnsureSuccessStatusCode();
-        var loginBody = await ReadResponseAsync<ApiResponse<LoginData>>(loginResponse);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", loginBody.Data.AccessToken);
-        return client;
-    }
-
-    private static async Task<T> ReadDataAsync<T>(HttpResponseMessage response)
-    {
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var envelope = await ReadResponseAsync<ApiResponse<T>>(response);
-        return envelope.Data;
-    }
-
-    private static async Task<T> ReadResponseAsync<T>(HttpResponseMessage response)
-    {
-        var json = await response.Content.ReadAsStringAsync();
-        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
-        return value ?? throw new InvalidOperationException($"Could not deserialize {typeof(T).Name} from {(int)response.StatusCode}: {json}");
-    }
-
-    private sealed record ApiResponse<T>(T Data);
-    private sealed record LoginData(string AccessToken);
 
     private sealed record OperationalDashboardResponse(
         DateTime GeneratedAtUtc,
@@ -381,70 +343,4 @@ public sealed class DashboardApiTests
         string? SlaState,
         DateTime? DateFrom,
         DateTime? DateTo);
-
-    internal sealed class DashboardApiFactory : WebApplicationFactory<Program>
-    {
-        public const string JwtSigningKey = "integration-testing-only-fictional-jwt-signing-key";
-
-        private readonly SqliteConnection connection = new("Data Source=:memory:");
-
-        public static async Task<DashboardApiFactory> CreateAsync()
-        {
-            ConfigureEnvironment();
-            var factory = new DashboardApiFactory();
-            await factory.connection.OpenAsync();
-            await factory.InitializeDatabaseAsync();
-            return factory;
-        }
-
-        protected override void ConfigureWebHost(IWebHostBuilder builder)
-        {
-            builder.UseEnvironment("Testing");
-            builder.ConfigureAppConfiguration((_, config) =>
-            {
-                config.AddInMemoryCollection(new Dictionary<string, string?>
-                {
-                    ["ConnectionStrings:DefaultConnection"] = "Server=(local);Database=OpsSphereDashboardTests;Trusted_Connection=True;TrustServerCertificate=True;",
-                    ["SeedData:Enabled"] = "false",
-                    ["Jwt:Issuer"] = "OpsSphere.Tests",
-                    ["Jwt:Audience"] = "OpsSphere.Tests.Angular",
-                    ["Jwt:ExpirationMinutes"] = "60",
-                    ["Jwt:SigningKey"] = JwtSigningKey
-                });
-            });
-            builder.ConfigureTestServices(services =>
-            {
-                services.RemoveAll<IDbContextOptionsConfiguration<OpsSphereDbContext>>();
-                services.RemoveAll<DbContextOptions<OpsSphereDbContext>>();
-                services.AddDbContext<OpsSphereDbContext>(options => options.UseSqlite(connection));
-            });
-        }
-
-        private static void ConfigureEnvironment()
-        {
-            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", "Server=(local);Database=OpsSphereDashboardTests;Trusted_Connection=True;TrustServerCertificate=True;");
-            Environment.SetEnvironmentVariable("SeedData__Enabled", "false");
-            Environment.SetEnvironmentVariable("Jwt__Issuer", "OpsSphere.Tests");
-            Environment.SetEnvironmentVariable("Jwt__Audience", "OpsSphere.Tests.Angular");
-            Environment.SetEnvironmentVariable("Jwt__ExpirationMinutes", "60");
-            Environment.SetEnvironmentVariable("Jwt__SigningKey", JwtSigningKey);
-        }
-
-        public override async ValueTask DisposeAsync()
-        {
-            await connection.DisposeAsync();
-            await base.DisposeAsync();
-        }
-
-        private async Task InitializeDatabaseAsync()
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            await dbContext.Database.EnsureDeletedAsync();
-            await dbContext.Database.EnsureCreatedAsync();
-
-            var seeder = scope.ServiceProvider.GetRequiredService<OpsSphereDataSeeder>();
-            await seeder.SeedAsync();
-        }
-    }
 }

--- a/tests/OpsSphere.IntegrationTests/DashboardManagement/SlaMultiStateDashboardTests.cs
+++ b/tests/OpsSphere.IntegrationTests/DashboardManagement/SlaMultiStateDashboardTests.cs
@@ -1,0 +1,220 @@
+using System.Net;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using OpsSphere.Domain.Enums;
+using OpsSphere.Infrastructure.Persistence;
+using OpsSphere.Infrastructure.Persistence.SeedData;
+using OpsSphere.IntegrationTests.TestInfrastructure;
+
+namespace OpsSphere.IntegrationTests.DashboardManagement;
+
+public sealed class SlaMultiStateDashboardTests
+{
+    private const string AgentEmail = "agent.novabank@opssphere.local";
+    private const string SupervisorEmail = "supervisor.novabank@opssphere.local";
+    private const int SeededNovaBankTicketCount = 6;
+
+    [Fact]
+    public async Task SlaSummary_WithAllFourStates_ReturnsCorrectCounts()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        await SetupAllFourSlaStatesAsync(factory);
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
+
+        var response = await agent.GetAsync("/api/sla/summary");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var summary = await OpsSphereSqliteFactory.ReadDataAsync<SlaSummaryResponse>(response);
+
+        Assert.Equal(2, summary.WithinSlaCount);
+        Assert.Equal(1, summary.AtRiskCount);
+        Assert.Equal(1, summary.BreachedCount);
+        Assert.True(summary.CompletedCount >= 2);
+    }
+
+    [Fact]
+    public async Task SlaSummary_WithoutAuth_Returns401()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+
+        var response = await factory.CreateClient().GetAsync("/api/sla/summary");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SlaSummary_IsScopedByCampaign_ForAgent()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        await AddOutOfScopeBreachedTicketAsync(factory);
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
+
+        var response = await agent.GetAsync("/api/sla/summary");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var summary = await OpsSphereSqliteFactory.ReadDataAsync<SlaSummaryResponse>(response);
+        Assert.Equal(2, summary.BreachedCount);
+    }
+
+    [Fact]
+    public async Task OperationalDashboard_WithCampaignFilter_IntersectsScope()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+
+        var response = await supervisor.GetAsync($"/api/dashboard/operational?campaignId={SeedIds.Campaigns.NovaBankCreditCard}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var dashboard = await OpsSphereSqliteFactory.ReadDataAsync<OperationalDashboardResponse>(response);
+        Assert.All(dashboard.TicketsByCampaign, item => Assert.Equal(SeedIds.Campaigns.NovaBankCreditCard, item.EntityId));
+    }
+
+    [Fact]
+    public async Task OperationalDashboard_WithStatusFilter_ReturnsFilteredCounts()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
+
+        var response = await agent.GetAsync("/api/dashboard/operational?status=Open");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var dashboard = await OpsSphereSqliteFactory.ReadDataAsync<OperationalDashboardResponse>(response);
+        Assert.Equal(1, dashboard.TotalTicketCount);
+        Assert.Equal(1, dashboard.OpenTicketCount);
+        Assert.Equal(0, dashboard.AssignedTicketCount);
+    }
+
+    [Fact]
+    public async Task OperationalDashboard_WithDateRangeFilter_ReturnsCorrectCounts()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
+
+        var dateFrom = DateTime.UtcNow.AddDays(-365).ToString("yyyy-MM-ddTHH:mm:ssZ");
+        var dateTo = DateTime.UtcNow.AddDays(1).ToString("yyyy-MM-ddTHH:mm:ssZ");
+
+        var response = await agent.GetAsync($"/api/dashboard/operational?dateFrom={dateFrom}&dateTo={dateTo}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var dashboard = await OpsSphereSqliteFactory.ReadDataAsync<OperationalDashboardResponse>(response);
+        Assert.Equal(SeededNovaBankTicketCount, dashboard.TotalTicketCount);
+    }
+
+    private static async Task SetupAllFourSlaStatesAsync(OpsSphereSqliteFactory factory)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+        var now = DateTime.UtcNow;
+
+        var rows = await db.TicketSlaStates
+            .Include(s => s.Ticket)
+            .Where(s => s.Ticket.CampaignId == SeedIds.Campaigns.NovaBankCreditCard && !s.Ticket.IsDeleted)
+            .ToListAsync();
+
+        var openRow = rows.FirstOrDefault(s => s.Ticket.Status == TicketStatus.Open);
+        var assignedRow = rows.FirstOrDefault(s => s.Ticket.Status == TicketStatus.Assigned);
+        var inProgressRow = rows.FirstOrDefault(s => s.Ticket.Status == TicketStatus.InProgress);
+        var escalatedRow = rows.FirstOrDefault(s => s.Ticket.Status == TicketStatus.Escalated);
+
+        if (openRow is not null)
+        {
+            openRow.StartedAt = now.AddHours(-1);
+            openRow.DueAt = now.AddHours(23);
+            openRow.AtRiskThresholdPercent = 80;
+            openRow.State = SlaState.WithinSla.ToString();
+        }
+
+        if (assignedRow is not null)
+        {
+            assignedRow.StartedAt = now.AddHours(-2);
+            assignedRow.DueAt = now.AddHours(22);
+            assignedRow.AtRiskThresholdPercent = 80;
+            assignedRow.State = SlaState.WithinSla.ToString();
+        }
+
+        if (inProgressRow is not null)
+        {
+            inProgressRow.StartedAt = now.AddHours(-22);
+            inProgressRow.DueAt = now.AddHours(2);
+            inProgressRow.AtRiskThresholdPercent = 80;
+            inProgressRow.State = SlaState.WithinSla.ToString();
+        }
+
+        if (escalatedRow is not null)
+        {
+            escalatedRow.StartedAt = now.AddHours(-25);
+            escalatedRow.DueAt = now.AddHours(-1);
+            escalatedRow.AtRiskThresholdPercent = 80;
+            escalatedRow.State = SlaState.WithinSla.ToString();
+        }
+
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task AddOutOfScopeBreachedTicketAsync(OpsSphereSqliteFactory factory)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+        var campaign = await db.Campaigns
+            .AsNoTracking()
+            .Where(c => c.Id == SeedIds.Campaigns.StreamlyCreator)
+            .Select(c => new { c.CountryId, c.Country.RegionId })
+            .SingleAsync();
+
+        var now = DateTime.UtcNow;
+        var ticketId = Guid.NewGuid();
+        db.Tickets.Add(new Domain.Entities.Ticket
+        {
+            Id = ticketId,
+            TicketNumber = $"OPS-20990104-{System.Random.Shared.Next(1, 999999):D6}",
+            CustomerId = SeedIds.Customers.StreamlyCustomer1,
+            RegionId = campaign.RegionId,
+            CountryId = campaign.CountryId,
+            AccountId = SeedIds.Accounts.Streamly,
+            CampaignId = SeedIds.Campaigns.StreamlyCreator,
+            CreatedByUserId = SeedIds.Users.SupervisorNovabank,
+            Category = "Support",
+            Priority = TicketPriority.Normal,
+            Status = TicketStatus.Open,
+            Subject = "Out-of-scope SLA test ticket",
+            Description = "Should not appear in agent SLA summary",
+            SlaState = SlaState.WithinSla,
+            SlaDueAt = now.AddHours(-5),
+            IsEscalated = false,
+            IsDeleted = false,
+            CreatedAt = now
+        });
+        db.TicketSlaStates.Add(new Domain.Entities.TicketSlaState
+        {
+            Id = Guid.NewGuid(),
+            TicketId = ticketId,
+            StartedAt = now.AddHours(-10),
+            DueAt = now.AddHours(-5),
+            AtRiskThresholdPercent = 80,
+            State = SlaState.WithinSla.ToString()
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private sealed record SlaSummaryResponse(int WithinSlaCount, int AtRiskCount, int BreachedCount, int CompletedCount);
+    private sealed record OperationalDashboardResponse(
+        DateTime GeneratedAtUtc,
+        int TotalTicketCount,
+        int OpenTicketCount,
+        int AssignedTicketCount,
+        int EscalatedTicketCount,
+        int BreachedTicketCount,
+        int AtRiskTicketCount,
+        IReadOnlyList<DashboardGroupItemResponse> TicketsByStatus,
+        IReadOnlyList<DashboardGroupItemResponse> TicketsByPriority,
+        IReadOnlyList<DashboardGroupItemResponse> TicketsBySlaState,
+        IReadOnlyList<DashboardEntityGroupItemResponse> TicketsByAccount,
+        IReadOnlyList<DashboardEntityGroupItemResponse> TicketsByCampaign,
+        IReadOnlyList<DashboardUserGroupItemResponse> TicketsByAssignedAgent,
+        IReadOnlyList<DashboardUserGroupItemResponse> TicketsBySupervisor,
+        DashboardAppliedFiltersResponse AppliedFilters);
+    private sealed record DashboardGroupItemResponse(string Label, string Key, int Count, string? Status, string? Priority, string? SlaState, bool? IsEscalated, DateTime? DateFrom, DateTime? DateTo);
+    private sealed record DashboardEntityGroupItemResponse(string Label, Guid EntityId, int Count, Guid? AccountId, Guid? CampaignId, DateTime? DateFrom, DateTime? DateTo);
+    private sealed record DashboardUserGroupItemResponse(string Label, Guid? UserId, int Count, Guid? AssignedAgentUserId, Guid? SupervisorUserId, DateTime? DateFrom, DateTime? DateTo);
+    private sealed record DashboardAppliedFiltersResponse(Guid? RegionId, Guid? CountryId, Guid? AccountId, Guid? CampaignId, Guid? SupervisorUserId, Guid? AgentUserId, string? Status, string? Priority, string? SlaState, DateTime? DateFrom, DateTime? DateTo);
+}

--- a/tests/OpsSphere.IntegrationTests/Health/HealthCheckTests.cs
+++ b/tests/OpsSphere.IntegrationTests/Health/HealthCheckTests.cs
@@ -1,16 +1,10 @@
 using System.Net;
 using System.Text.Json;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpsSphere.Infrastructure.Persistence;
 using OpsSphere.Infrastructure.Persistence.SeedData;
+using OpsSphere.IntegrationTests.TestInfrastructure;
 
 namespace OpsSphere.IntegrationTests.Health;
 
@@ -22,7 +16,7 @@ public sealed class HealthCheckTests
     [Fact]
     public async Task Health_Returns200_WithSafeShape()
     {
-        await using var factory = await HealthApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
 
         var response = await factory.CreateClient().GetAsync("/health");
         var body = await response.Content.ReadAsStringAsync();
@@ -40,7 +34,7 @@ public sealed class HealthCheckTests
     [Fact]
     public async Task HealthDetails_Returns200_WithSafeShape()
     {
-        await using var factory = await HealthApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
 
         var response = await factory.CreateClient().GetAsync("/health/details");
         var body = await response.Content.ReadAsStringAsync();
@@ -58,7 +52,7 @@ public sealed class HealthCheckTests
     [Fact]
     public async Task HealthDetails_IncludesDatabaseCheck()
     {
-        await using var factory = await HealthApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
 
         var response = await factory.CreateClient().GetAsync("/health/details");
         var body = await response.Content.ReadAsStringAsync();
@@ -72,15 +66,15 @@ public sealed class HealthCheckTests
     [Fact]
     public async Task Health_DoesNotExposeSecrets()
     {
-        await using var factory = await HealthApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var client = factory.CreateClient();
 
         var healthBody = await (await client.GetAsync("/health")).Content.ReadAsStringAsync();
         var detailsBody = await (await client.GetAsync("/health/details")).Content.ReadAsStringAsync();
 
         // No secrets or sensitive data
-        Assert.DoesNotContain(HealthApiFactory.JwtSigningKey, healthBody, StringComparison.Ordinal);
-        Assert.DoesNotContain(HealthApiFactory.JwtSigningKey, detailsBody, StringComparison.Ordinal);
+        Assert.DoesNotContain(OpsSphereSqliteFactory.JwtSigningKey, healthBody, StringComparison.Ordinal);
+        Assert.DoesNotContain(OpsSphereSqliteFactory.JwtSigningKey, detailsBody, StringComparison.Ordinal);
         Assert.DoesNotContain("password", healthBody, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("password", detailsBody, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("Server=", detailsBody, StringComparison.OrdinalIgnoreCase);
@@ -90,7 +84,7 @@ public sealed class HealthCheckTests
     [Fact]
     public async Task Health_AlwaysReturnsCorrelationIdHeader()
     {
-        await using var factory = await HealthApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var client = factory.CreateClient();
 
         var healthResponse = await client.GetAsync("/health");
@@ -98,72 +92,5 @@ public sealed class HealthCheckTests
 
         Assert.True(healthResponse.Headers.Contains("X-Correlation-Id"));
         Assert.True(detailsResponse.Headers.Contains("X-Correlation-Id"));
-    }
-
-    internal sealed class HealthApiFactory : WebApplicationFactory<Program>
-    {
-        public const string JwtSigningKey = "integration-testing-only-fictional-jwt-signing-key";
-
-        private readonly SqliteConnection connection = new("Data Source=:memory:");
-
-        public static async Task<HealthApiFactory> CreateAsync()
-        {
-            ConfigureEnvironment();
-            var factory = new HealthApiFactory();
-            await factory.connection.OpenAsync();
-            await factory.InitializeDatabaseAsync();
-            return factory;
-        }
-
-        protected override void ConfigureWebHost(IWebHostBuilder builder)
-        {
-            builder.UseEnvironment("Testing");
-            builder.ConfigureAppConfiguration((_, config) =>
-            {
-                config.AddInMemoryCollection(new Dictionary<string, string?>
-                {
-                    ["ConnectionStrings:DefaultConnection"] = "Server=(local);Database=OpsSphereHealthTests;Trusted_Connection=True;TrustServerCertificate=True;",
-                    ["SeedData:Enabled"] = "false",
-                    ["Jwt:Issuer"] = "OpsSphere.Tests",
-                    ["Jwt:Audience"] = "OpsSphere.Tests.Angular",
-                    ["Jwt:ExpirationMinutes"] = "60",
-                    ["Jwt:SigningKey"] = JwtSigningKey
-                });
-            });
-            builder.ConfigureTestServices(services =>
-            {
-                services.RemoveAll<IDbContextOptionsConfiguration<OpsSphereDbContext>>();
-                services.RemoveAll<DbContextOptions<OpsSphereDbContext>>();
-                services.AddDbContext<OpsSphereDbContext>(options => options.UseSqlite(connection));
-            });
-        }
-
-        private static void ConfigureEnvironment()
-        {
-            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection",
-                "Server=(local);Database=OpsSphereHealthTests;Trusted_Connection=True;TrustServerCertificate=True;");
-            Environment.SetEnvironmentVariable("SeedData__Enabled", "false");
-            Environment.SetEnvironmentVariable("Jwt__Issuer", "OpsSphere.Tests");
-            Environment.SetEnvironmentVariable("Jwt__Audience", "OpsSphere.Tests.Angular");
-            Environment.SetEnvironmentVariable("Jwt__ExpirationMinutes", "60");
-            Environment.SetEnvironmentVariable("Jwt__SigningKey", JwtSigningKey);
-        }
-
-        public override async ValueTask DisposeAsync()
-        {
-            await connection.DisposeAsync();
-            await base.DisposeAsync();
-        }
-
-        private async Task InitializeDatabaseAsync()
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            await dbContext.Database.EnsureDeletedAsync();
-            await dbContext.Database.EnsureCreatedAsync();
-
-            var seeder = scope.ServiceProvider.GetRequiredService<OpsSphereDataSeeder>();
-            await seeder.SeedAsync();
-        }
     }
 }

--- a/tests/OpsSphere.IntegrationTests/Middleware/CorrelationIdTests.cs
+++ b/tests/OpsSphere.IntegrationTests/Middleware/CorrelationIdTests.cs
@@ -1,17 +1,11 @@
-using System.Net;
+﻿using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpsSphere.Infrastructure.Persistence;
 using OpsSphere.Infrastructure.Persistence.SeedData;
+using OpsSphere.IntegrationTests.TestInfrastructure;
 
 namespace OpsSphere.IntegrationTests.Middleware;
 
@@ -25,7 +19,7 @@ public sealed class CorrelationIdTests
     [Fact]
     public async Task Request_WithoutCorrelationId_GeneratesNewHeader()
     {
-        await using var factory = await CorrelationApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var client = factory.CreateClient();
 
         var response = await client.GetAsync("/health");
@@ -39,7 +33,7 @@ public sealed class CorrelationIdTests
     [Fact]
     public async Task Request_WithSafeCorrelationId_ReusesItInResponse()
     {
-        await using var factory = await CorrelationApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var client = factory.CreateClient();
         client.DefaultRequestHeaders.Add(CorrelationIdHeader, "test-correlation-123");
 
@@ -59,7 +53,7 @@ public sealed class CorrelationIdTests
     [InlineData("")]                                      // empty
     public async Task Request_WithUnsafeCorrelationId_GeneratesNewSafeHeader(string unsafeId)
     {
-        await using var factory = await CorrelationApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var client = factory.CreateClient();
 
         if (!string.IsNullOrEmpty(unsafeId))
@@ -83,7 +77,7 @@ public sealed class CorrelationIdTests
     [Fact]
     public async Task ErrorResponse_IncludesCorrelationId_FromHeader()
     {
-        await using var factory = await CorrelationApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var client = factory.CreateClient();
         client.DefaultRequestHeaders.Add(CorrelationIdHeader, "err-corr-id-abc");
 
@@ -104,7 +98,7 @@ public sealed class CorrelationIdTests
     [Fact]
     public async Task HealthResponse_IncludesCorrelationIdInBody()
     {
-        await using var factory = await CorrelationApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var client = factory.CreateClient();
         client.DefaultRequestHeaders.Add(CorrelationIdHeader, "health-corr-abc");
 
@@ -119,78 +113,11 @@ public sealed class CorrelationIdTests
     [Fact]
     public async Task Unauthenticated_Request_Returns401_WithCorrelationIdHeader()
     {
-        await using var factory = await CorrelationApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
 
         var response = await factory.CreateClient().GetAsync("/api/auth/me");
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         Assert.True(response.Headers.Contains(CorrelationIdHeader));
-    }
-
-    internal sealed class CorrelationApiFactory : WebApplicationFactory<Program>
-    {
-        public const string JwtSigningKey = "integration-testing-only-fictional-jwt-signing-key";
-
-        private readonly SqliteConnection connection = new("Data Source=:memory:");
-
-        public static async Task<CorrelationApiFactory> CreateAsync()
-        {
-            ConfigureEnvironment();
-            var factory = new CorrelationApiFactory();
-            await factory.connection.OpenAsync();
-            await factory.InitializeDatabaseAsync();
-            return factory;
-        }
-
-        protected override void ConfigureWebHost(IWebHostBuilder builder)
-        {
-            builder.UseEnvironment("Testing");
-            builder.ConfigureAppConfiguration((_, config) =>
-            {
-                config.AddInMemoryCollection(new Dictionary<string, string?>
-                {
-                    ["ConnectionStrings:DefaultConnection"] = "Server=(local);Database=OpsSphereCorrelationTests;Trusted_Connection=True;TrustServerCertificate=True;",
-                    ["SeedData:Enabled"] = "false",
-                    ["Jwt:Issuer"] = "OpsSphere.Tests",
-                    ["Jwt:Audience"] = "OpsSphere.Tests.Angular",
-                    ["Jwt:ExpirationMinutes"] = "60",
-                    ["Jwt:SigningKey"] = JwtSigningKey
-                });
-            });
-            builder.ConfigureTestServices(services =>
-            {
-                services.RemoveAll<IDbContextOptionsConfiguration<OpsSphereDbContext>>();
-                services.RemoveAll<DbContextOptions<OpsSphereDbContext>>();
-                services.AddDbContext<OpsSphereDbContext>(options => options.UseSqlite(connection));
-            });
-        }
-
-        private static void ConfigureEnvironment()
-        {
-            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection",
-                "Server=(local);Database=OpsSphereCorrelationTests;Trusted_Connection=True;TrustServerCertificate=True;");
-            Environment.SetEnvironmentVariable("SeedData__Enabled", "false");
-            Environment.SetEnvironmentVariable("Jwt__Issuer", "OpsSphere.Tests");
-            Environment.SetEnvironmentVariable("Jwt__Audience", "OpsSphere.Tests.Angular");
-            Environment.SetEnvironmentVariable("Jwt__ExpirationMinutes", "60");
-            Environment.SetEnvironmentVariable("Jwt__SigningKey", JwtSigningKey);
-        }
-
-        public override async ValueTask DisposeAsync()
-        {
-            await connection.DisposeAsync();
-            await base.DisposeAsync();
-        }
-
-        private async Task InitializeDatabaseAsync()
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            await dbContext.Database.EnsureDeletedAsync();
-            await dbContext.Database.EnsureCreatedAsync();
-
-            var seeder = scope.ServiceProvider.GetRequiredService<OpsSphereDataSeeder>();
-            await seeder.SeedAsync();
-        }
     }
 }

--- a/tests/OpsSphere.IntegrationTests/Middleware/ExceptionHandlingTests.cs
+++ b/tests/OpsSphere.IntegrationTests/Middleware/ExceptionHandlingTests.cs
@@ -1,19 +1,13 @@
 using System.Net;
 using System.Reflection;
 using System.Text.Json;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpsSphere.Application.Common.Exceptions;
 using OpsSphere.Infrastructure.Persistence;
 using OpsSphere.Infrastructure.Persistence.SeedData;
+using OpsSphere.IntegrationTests.TestInfrastructure;
 
 namespace OpsSphere.IntegrationTests.Middleware;
 
@@ -27,7 +21,7 @@ public sealed class ExceptionHandlingTests
     [Fact]
     public async Task ValidationException_Returns400_WithCanonicalEnvelope()
     {
-        await using var factory = await ExceptionApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
 
         var response = await factory.CreateClient().GetAsync("/api/test-diagnostics/throw-validation");
         var body = await response.Content.ReadAsStringAsync();
@@ -46,7 +40,7 @@ public sealed class ExceptionHandlingTests
     [Fact]
     public async Task BusinessRuleException_Returns400_WithCanonicalEnvelope()
     {
-        await using var factory = await ExceptionApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
 
         var response = await factory.CreateClient().GetAsync("/api/test-diagnostics/throw-business-rule");
         var body = await response.Content.ReadAsStringAsync();
@@ -63,7 +57,7 @@ public sealed class ExceptionHandlingTests
     [Fact]
     public async Task NotFoundException_Returns404_WithCanonicalEnvelope()
     {
-        await using var factory = await ExceptionApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
 
         var response = await factory.CreateClient().GetAsync("/api/test-diagnostics/throw-not-found");
         var body = await response.Content.ReadAsStringAsync();
@@ -80,7 +74,7 @@ public sealed class ExceptionHandlingTests
     [Fact]
     public async Task ConflictException_Returns409_WithCanonicalEnvelope()
     {
-        await using var factory = await ExceptionApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
 
         var response = await factory.CreateClient().GetAsync("/api/test-diagnostics/throw-conflict");
         var body = await response.Content.ReadAsStringAsync();
@@ -97,7 +91,7 @@ public sealed class ExceptionHandlingTests
     [Fact]
     public async Task UnhandledException_Returns500_WithSafeEnvelope()
     {
-        await using var factory = await ExceptionApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
 
         var response = await factory.CreateClient().GetAsync("/api/test-diagnostics/throw-unhandled");
         var body = await response.Content.ReadAsStringAsync();
@@ -114,7 +108,7 @@ public sealed class ExceptionHandlingTests
     [Fact]
     public async Task UnhandledException_Response_DoesNotIncludeStackTrace()
     {
-        await using var factory = await ExceptionApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
 
         var response = await factory.CreateClient().GetAsync("/api/test-diagnostics/throw-unhandled");
         var body = await response.Content.ReadAsStringAsync();
@@ -128,7 +122,7 @@ public sealed class ExceptionHandlingTests
     [Fact]
     public async Task ErrorResponse_DoesNotExposeSecrets()
     {
-        await using var factory = await ExceptionApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var client = factory.CreateClient();
 
         var unhandledBody = await (await client.GetAsync("/api/test-diagnostics/throw-unhandled")).Content.ReadAsStringAsync();
@@ -136,7 +130,7 @@ public sealed class ExceptionHandlingTests
 
         foreach (var body in new[] { unhandledBody, validationBody })
         {
-            Assert.DoesNotContain(ExceptionApiFactory.JwtSigningKey, body, StringComparison.Ordinal);
+            Assert.DoesNotContain(OpsSphereSqliteFactory.JwtSigningKey, body, StringComparison.Ordinal);
             Assert.DoesNotContain("passwordHash", body, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("password", body, StringComparison.OrdinalIgnoreCase);
         }
@@ -146,7 +140,7 @@ public sealed class ExceptionHandlingTests
     [Fact]
     public async Task ErrorResponse_AlwaysIncludesCorrelationIdHeader()
     {
-        await using var factory = await ExceptionApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         var client = factory.CreateClient();
 
         var endpoints = new[]
@@ -164,104 +158,4 @@ public sealed class ExceptionHandlingTests
                 $"Expected X-Correlation-Id header for {endpoint}");
         }
     }
-
-    internal sealed class ExceptionApiFactory : WebApplicationFactory<Program>
-    {
-        public const string JwtSigningKey = "integration-testing-only-fictional-jwt-signing-key";
-
-        private readonly SqliteConnection connection = new("Data Source=:memory:");
-
-        public static async Task<ExceptionApiFactory> CreateAsync()
-        {
-            ConfigureEnvironment();
-            var factory = new ExceptionApiFactory();
-            await factory.connection.OpenAsync();
-            await factory.InitializeDatabaseAsync();
-            return factory;
-        }
-
-        protected override void ConfigureWebHost(IWebHostBuilder builder)
-        {
-            builder.UseEnvironment("Testing");
-            builder.ConfigureAppConfiguration((_, config) =>
-            {
-                config.AddInMemoryCollection(new Dictionary<string, string?>
-                {
-                    ["ConnectionStrings:DefaultConnection"] = "Server=(local);Database=OpsSphereExceptionTests;Trusted_Connection=True;TrustServerCertificate=True;",
-                    ["SeedData:Enabled"] = "false",
-                    ["Jwt:Issuer"] = "OpsSphere.Tests",
-                    ["Jwt:Audience"] = "OpsSphere.Tests.Angular",
-                    ["Jwt:ExpirationMinutes"] = "60",
-                    ["Jwt:SigningKey"] = JwtSigningKey
-                });
-            });
-            builder.ConfigureTestServices(services =>
-            {
-                services.RemoveAll<IDbContextOptionsConfiguration<OpsSphereDbContext>>();
-                services.RemoveAll<DbContextOptions<OpsSphereDbContext>>();
-                services.AddDbContext<OpsSphereDbContext>(options => options.UseSqlite(connection));
-
-                // Register the test diagnostics controller from this assembly
-                services.AddControllers()
-                    .AddApplicationPart(Assembly.GetExecutingAssembly());
-            });
-        }
-
-        private static void ConfigureEnvironment()
-        {
-            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection",
-                "Server=(local);Database=OpsSphereExceptionTests;Trusted_Connection=True;TrustServerCertificate=True;");
-            Environment.SetEnvironmentVariable("SeedData__Enabled", "false");
-            Environment.SetEnvironmentVariable("Jwt__Issuer", "OpsSphere.Tests");
-            Environment.SetEnvironmentVariable("Jwt__Audience", "OpsSphere.Tests.Angular");
-            Environment.SetEnvironmentVariable("Jwt__ExpirationMinutes", "60");
-            Environment.SetEnvironmentVariable("Jwt__SigningKey", JwtSigningKey);
-        }
-
-        public override async ValueTask DisposeAsync()
-        {
-            await connection.DisposeAsync();
-            await base.DisposeAsync();
-        }
-
-        private async Task InitializeDatabaseAsync()
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            await dbContext.Database.EnsureDeletedAsync();
-            await dbContext.Database.EnsureCreatedAsync();
-
-            var seeder = scope.ServiceProvider.GetRequiredService<OpsSphereDataSeeder>();
-            await seeder.SeedAsync();
-        }
-    }
-}
-
-/// <summary>
-/// Test-only controller that throws specific exceptions to validate global exception handling.
-/// Registered only in the ExceptionApiFactory (Testing environment).
-/// </summary>
-[ApiController]
-[Route("api/test-diagnostics")]
-public sealed class TestDiagnosticsController : ControllerBase
-{
-    [HttpGet("throw-validation")]
-    public IActionResult ThrowValidation() =>
-        throw new ValidationException("email", "Email is required.");
-
-    [HttpGet("throw-business-rule")]
-    public IActionResult ThrowBusinessRule() =>
-        throw new BusinessRuleException("Ticket must be resolved before it can be closed.");
-
-    [HttpGet("throw-not-found")]
-    public IActionResult ThrowNotFound() =>
-        throw new NotFoundException("Ticket", Guid.NewGuid());
-
-    [HttpGet("throw-conflict")]
-    public IActionResult ThrowConflict() =>
-        throw new ConflictException("A user with this email already exists.");
-
-    [HttpGet("throw-unhandled")]
-    public IActionResult ThrowUnhandled() =>
-        throw new InvalidOperationException("Simulated unhandled exception for testing.");
 }

--- a/tests/OpsSphere.IntegrationTests/OpsSphere.IntegrationTests.csproj
+++ b/tests/OpsSphere.IntegrationTests/OpsSphere.IntegrationTests.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Testcontainers.MsSql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/OpsSphere.IntegrationTests/OrganizationManagement/OrganizationApiTests.cs
+++ b/tests/OpsSphere.IntegrationTests/OrganizationManagement/OrganizationApiTests.cs
@@ -1,19 +1,12 @@
 using System.Net;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpsSphere.Domain.Entities;
 using OpsSphere.Infrastructure.Persistence;
 using OpsSphere.Infrastructure.Persistence.SeedData;
+using OpsSphere.IntegrationTests.TestInfrastructure;
 
 namespace OpsSphere.IntegrationTests.OrganizationManagement;
 
@@ -30,15 +23,15 @@ public sealed class OrganizationApiTests
     [Fact]
     public async Task Admin_CanCreateUpdateAndDeactivateOrganizationHierarchy()
     {
-        await using var factory = await OrganizationApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var region = await CreateRegionAsync(client, "andr", "Andromeda Region");
         Assert.Equal("ANDR", region.Code);
         await factory.AssertAuditAsync("RegionCreated", "Region", region.Id);
 
         var updatedRegionResponse = await client.PutAsJsonAsync($"/api/regions/{region.Id}", new { code = "ANDR-OPS", name = "Andromeda Operations" });
-        var updatedRegion = await ReadDataAsync<RegionResponse>(updatedRegionResponse);
+        var updatedRegion = await OpsSphereSqliteFactory.ReadDataAsync<RegionResponse>(updatedRegionResponse);
         Assert.Equal(HttpStatusCode.OK, updatedRegionResponse.StatusCode);
         Assert.Equal("ANDR-OPS", updatedRegion.Code);
         await factory.AssertAuditAsync("RegionUpdated", "Region", region.Id);
@@ -47,7 +40,7 @@ public sealed class OrganizationApiTests
         await factory.AssertAuditAsync("CountryCreated", "Country", country.Id);
 
         var updatedCountryResponse = await client.PutAsJsonAsync($"/api/countries/{country.Id}", new { regionId = updatedRegion.Id, code = "LUN", name = "Lunara Prime" });
-        var updatedCountry = await ReadDataAsync<CountryResponse>(updatedCountryResponse);
+        var updatedCountry = await OpsSphereSqliteFactory.ReadDataAsync<CountryResponse>(updatedCountryResponse);
         Assert.Equal(HttpStatusCode.OK, updatedCountryResponse.StatusCode);
         Assert.Equal("LUN", updatedCountry.Code);
         await factory.AssertAuditAsync("CountryUpdated", "Country", country.Id);
@@ -56,7 +49,7 @@ public sealed class OrganizationApiTests
         await factory.AssertAuditAsync("AccountCreated", "Account", account.Id);
 
         var updatedAccountResponse = await client.PutAsJsonAsync($"/api/accounts/{account.Id}", new { countryId = updatedCountry.Id, code = "ORION", name = "Orion Support", description = "Updated fictional account." });
-        var updatedAccount = await ReadDataAsync<AccountResponse>(updatedAccountResponse);
+        var updatedAccount = await OpsSphereSqliteFactory.ReadDataAsync<AccountResponse>(updatedAccountResponse);
         Assert.Equal(HttpStatusCode.OK, updatedAccountResponse.StatusCode);
         Assert.Equal("ORION", updatedAccount.Code);
         await factory.AssertAuditAsync("AccountUpdated", "Account", account.Id);
@@ -65,7 +58,7 @@ public sealed class OrganizationApiTests
         await factory.AssertAuditAsync("CampaignCreated", "Campaign", campaign.Id);
 
         var updatedCampaignResponse = await client.PutAsJsonAsync($"/api/campaigns/{campaign.Id}", new { accountId = updatedAccount.Id, countryId = updatedCountry.Id, code = "ORION-VOICE", name = "Orion Voice", description = "Updated fictional campaign." });
-        var updatedCampaign = await ReadDataAsync<CampaignResponse>(updatedCampaignResponse);
+        var updatedCampaign = await OpsSphereSqliteFactory.ReadDataAsync<CampaignResponse>(updatedCampaignResponse);
         Assert.Equal(HttpStatusCode.OK, updatedCampaignResponse.StatusCode);
         Assert.Equal("ORION-VOICE", updatedCampaign.Code);
         await factory.AssertAuditAsync("CampaignUpdated", "Campaign", campaign.Id);
@@ -85,8 +78,8 @@ public sealed class OrganizationApiTests
     [Fact]
     public async Task NonAdmin_CannotCreateUpdateOrDeactivateOrganizationRecords()
     {
-        await using var factory = await OrganizationApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var createRegion = await client.PostAsJsonAsync("/api/regions", new { code = "DENY-R", name = "Denied Region" });
         var updateRegion = await client.PutAsJsonAsync($"/api/regions/{SeedIds.Regions.Latam}", new { code = "LATAM", name = "Denied Region Update" });
@@ -110,11 +103,11 @@ public sealed class OrganizationApiTests
     [Fact]
     public async Task OrganizationValidation_RejectsRequiredFieldAndDuplicateCodeFailures()
     {
-        await using var factory = await OrganizationApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var missing = await client.PostAsJsonAsync("/api/regions", new { code = "", name = "" });
-        var missingError = await ReadErrorAsync(missing);
+        var missingError = await OpsSphereSqliteFactory.ReadErrorAsync(missing);
         Assert.Equal(HttpStatusCode.BadRequest, missing.StatusCode);
         Assert.Equal("validation_error", missingError.Error.Code);
         Assert.Contains(missingError.Error.Details, detail => detail.Field == "code");
@@ -129,8 +122,8 @@ public sealed class OrganizationApiTests
     [Fact]
     public async Task OrganizationParentsAndDeactivationRules_AreEnforced()
     {
-        await using var factory = await OrganizationApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AdminEmail);
         var inactiveRegionId = await factory.AddInactiveRegionAsync("VOID-R", "Void Region");
         var inactiveCountryId = await factory.AddInactiveCountryAsync(inactiveRegionId, "VOID-C", "Void Country");
         var inactiveAccountId = await factory.AddInactiveAccountAsync(inactiveCountryId, "VOID-A", "Void Account");
@@ -160,15 +153,15 @@ public sealed class OrganizationApiTests
     [InlineData("viewer.latam@opssphere.local", "Campaign")]
     public async Task UserScopes_CanBeAssignedAccordingToRole(string email, string scopeType)
     {
-        await using var factory = await OrganizationApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AdminEmail);
         var userId = await factory.GetUserIdAsync(email);
 
         var response = await client.PutAsJsonAsync($"/api/users/{userId}/scopes", new
         {
             scopes = new[] { CreateScopeRequest(scopeType) }
         });
-        var assignment = await ReadDataAsync<UserScopeAssignmentResponse>(response);
+        var assignment = await OpsSphereSqliteFactory.ReadDataAsync<UserScopeAssignmentResponse>(response);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Contains(assignment.Scopes, scope => scope.ScopeType == scopeType && scope.IsActive);
@@ -178,8 +171,8 @@ public sealed class OrganizationApiTests
     [Fact]
     public async Task UserScopes_RejectInvalidRoleInvalidScopeInactiveUserAndInactiveTargets()
     {
-        await using var factory = await OrganizationApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AdminEmail);
         var inactiveRegionId = await factory.AddInactiveRegionAsync("SLEEP-R", "Sleeping Region");
         await factory.DeactivateUserAsync(SeedIds.Users.ViewerLatam);
 
@@ -192,8 +185,8 @@ public sealed class OrganizationApiTests
     [Fact]
     public async Task UserScopes_WriteAuditForAssignDeactivateAndReactivate()
     {
-        await using var factory = await OrganizationApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var assignAccount = await client.PutAsJsonAsync($"/api/users/{SeedIds.Users.AgentNovabank}/scopes", new { scopes = new[] { CreateScopeRequest("Account") } });
         Assert.Equal(HttpStatusCode.OK, assignAccount.StatusCode);
@@ -214,20 +207,20 @@ public sealed class OrganizationApiTests
     [Fact]
     public async Task ScopedReads_FilterOrganizationRecordsServerSide()
     {
-        await using var factory = await OrganizationApiFactory.CreateAsync();
-        var manager = await CreateAuthenticatedClientAsync(factory, ManagerEmail);
-        var viewer = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var manager = await factory.CreateAuthenticatedClientAsync(ManagerEmail);
+        var viewer = await factory.CreateAuthenticatedClientAsync(ViewerEmail);
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
-        var managerRegions = await ReadDataAsync<IReadOnlyList<RegionResponse>>(await manager.GetAsync("/api/regions"));
-        var viewerCountries = await ReadDataAsync<IReadOnlyList<CountryResponse>>(await viewer.GetAsync("/api/countries"));
-        var supervisorAccounts = await ReadDataAsync<IReadOnlyList<AccountResponse>>(await supervisor.GetAsync("/api/accounts"));
-        var supervisorCampaigns = await ReadDataAsync<IReadOnlyList<CampaignResponse>>(await supervisor.GetAsync("/api/campaigns"));
-        var agentRegions = await ReadDataAsync<IReadOnlyList<RegionResponse>>(await agent.GetAsync("/api/regions"));
-        var agentCountries = await ReadDataAsync<IReadOnlyList<CountryResponse>>(await agent.GetAsync("/api/countries"));
-        var agentAccounts = await ReadDataAsync<IReadOnlyList<AccountResponse>>(await agent.GetAsync("/api/accounts"));
-        var agentCampaigns = await ReadDataAsync<IReadOnlyList<CampaignResponse>>(await agent.GetAsync("/api/campaigns"));
+        var managerRegions = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<RegionResponse>>(await manager.GetAsync("/api/regions"));
+        var viewerCountries = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<CountryResponse>>(await viewer.GetAsync("/api/countries"));
+        var supervisorAccounts = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<AccountResponse>>(await supervisor.GetAsync("/api/accounts"));
+        var supervisorCampaigns = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<CampaignResponse>>(await supervisor.GetAsync("/api/campaigns"));
+        var agentRegions = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<RegionResponse>>(await agent.GetAsync("/api/regions"));
+        var agentCountries = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<CountryResponse>>(await agent.GetAsync("/api/countries"));
+        var agentAccounts = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<AccountResponse>>(await agent.GetAsync("/api/accounts"));
+        var agentCampaigns = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<CampaignResponse>>(await agent.GetAsync("/api/campaigns"));
 
         Assert.Single(managerRegions);
         Assert.Contains(managerRegions, region => region.Code == "LATAM");
@@ -248,8 +241,8 @@ public sealed class OrganizationApiTests
     [Fact]
     public async Task OrganizationResponses_UseEnvelopeAndDoNotExposeSecrets()
     {
-        await using var factory = await OrganizationApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var regionResponse = await client.GetAsync("/api/regions");
         var json = await regionResponse.Content.ReadAsStringAsync();
@@ -272,40 +265,40 @@ public sealed class OrganizationApiTests
     {
         var response = await client.PostAsJsonAsync("/api/regions", new { code, name });
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        return await ReadDataAsync<RegionResponse>(response);
+        return await OpsSphereSqliteFactory.ReadDataAsync<RegionResponse>(response);
     }
 
     private static async Task<CountryResponse> CreateCountryAsync(HttpClient client, Guid regionId, string code, string name)
     {
         var response = await client.PostAsJsonAsync("/api/countries", new { regionId, code, name });
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        return await ReadDataAsync<CountryResponse>(response);
+        return await OpsSphereSqliteFactory.ReadDataAsync<CountryResponse>(response);
     }
 
     private static async Task<AccountResponse> CreateAccountAsync(HttpClient client, Guid countryId, string code, string name, string description)
     {
         var response = await client.PostAsJsonAsync("/api/accounts", new { countryId, code, name, description });
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        return await ReadDataAsync<AccountResponse>(response);
+        return await OpsSphereSqliteFactory.ReadDataAsync<AccountResponse>(response);
     }
 
     private static async Task<CampaignResponse> CreateCampaignAsync(HttpClient client, Guid accountId, Guid countryId, string code, string name, string description)
     {
         var response = await client.PostAsJsonAsync("/api/campaigns", new { accountId, countryId, code, name, description });
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        return await ReadDataAsync<CampaignResponse>(response);
+        return await OpsSphereSqliteFactory.ReadDataAsync<CampaignResponse>(response);
     }
 
     private static async Task AssertConflictAsync(HttpResponseMessage response)
     {
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
         Assert.Equal("conflict", error.Error.Code);
     }
 
     private static async Task AssertValidationAsync(HttpResponseMessage response, string field)
     {
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         Assert.Equal("validation_error", error.Error.Code);
         Assert.Contains(error.Error.Details, detail => detail.Field == field);
@@ -313,204 +306,23 @@ public sealed class OrganizationApiTests
 
     private static async Task AssertBusinessRuleAsync(HttpResponseMessage response)
     {
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         Assert.Equal("business_rule_violation", error.Error.Code);
     }
 
-    private static async Task<HttpClient> CreateAuthenticatedClientAsync(OrganizationApiFactory factory, string email)
-    {
-        var client = factory.CreateClient();
-        var loginResponse = await client.PostAsJsonAsync("/api/auth/login", new
-        {
-            email,
-            password = OpsSphereSeedData.LocalDemoPassword
-        });
-        loginResponse.EnsureSuccessStatusCode();
-        var loginBody = await ReadResponseAsync<ApiResponse<LoginData>>(loginResponse);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", loginBody.Data.AccessToken);
-
-        return client;
-    }
-
-    private static async Task<T> ReadDataAsync<T>(HttpResponseMessage response)
-    {
-        var envelope = await ReadResponseAsync<ApiResponse<T>>(response);
-        return envelope.Data;
-    }
-
-    private static async Task<ApiErrorResponse> ReadErrorAsync(HttpResponseMessage response) =>
-        await ReadResponseAsync<ApiErrorResponse>(response);
-
-    private static async Task<T> ReadResponseAsync<T>(HttpResponseMessage response)
+private static async Task AssertResponseDoesNotExposeSensitiveDataAsync(HttpResponseMessage response)
     {
         var json = await response.Content.ReadAsStringAsync();
-        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
-
-        return value ?? throw new InvalidOperationException($"Could not deserialize {typeof(T).Name} from {(int)response.StatusCode}: {json}");
-    }
-
-    private static async Task AssertResponseDoesNotExposeSensitiveDataAsync(HttpResponseMessage response)
-    {
-        var json = await response.Content.ReadAsStringAsync();
-        foreach (var term in new[] { "passwordHash", "temporaryPassword", "accessToken", "refreshToken", "jwt", "secret", OrganizationApiFactory.JwtSigningKey })
+        foreach (var term in new[] { "passwordHash", "temporaryPassword", "accessToken", "refreshToken", "jwt", "secret", OpsSphereSqliteFactory.JwtSigningKey })
         {
             Assert.DoesNotContain(term, json, StringComparison.OrdinalIgnoreCase);
         }
     }
-
-    private sealed record ApiResponse<T>(T Data);
-    private sealed record ApiErrorResponse(ApiError Error);
-    private sealed record ApiError(string Code, string Message, IReadOnlyList<ApiErrorDetail> Details);
-    private sealed record ApiErrorDetail(string? Field, string Message);
-    private sealed record LoginData(string AccessToken);
     private sealed record RegionResponse(Guid Id, string Code, string Name, bool IsActive);
     private sealed record CountryResponse(Guid Id, Guid RegionId, string RegionCode, string Code, string Name, bool IsActive);
     private sealed record AccountResponse(Guid Id, Guid CountryId, string CountryCode, Guid RegionId, string RegionCode, string Code, string Name, string? Description, bool IsActive);
     private sealed record CampaignResponse(Guid Id, Guid AccountId, string AccountCode, Guid CountryId, string CountryCode, Guid RegionId, string RegionCode, string Code, string Name, string? Description, bool IsActive);
     private sealed record UserScopeAssignmentResponse(Guid UserId, string Email, bool IsActive, IReadOnlyList<string> Roles, IReadOnlyList<UserScopeResponse> Scopes);
     private sealed record UserScopeResponse(Guid Id, string ScopeType, Guid? RegionId, Guid? CountryId, Guid? AccountId, Guid? CampaignId, bool IsActive);
-
-    internal sealed class OrganizationApiFactory : WebApplicationFactory<Program>
-    {
-        public const string JwtSigningKey = "integration-testing-only-fictional-jwt-signing-key";
-
-        private readonly SqliteConnection connection = new("Data Source=:memory:");
-
-        public static async Task<OrganizationApiFactory> CreateAsync()
-        {
-            ConfigureEnvironment();
-            var factory = new OrganizationApiFactory();
-            await factory.connection.OpenAsync();
-            await factory.InitializeDatabaseAsync();
-
-            return factory;
-        }
-
-        public async Task<Guid> GetUserIdAsync(string email)
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-
-            return await dbContext.Users
-                .Where(user => user.Email == email)
-                .Select(user => user.Id)
-                .SingleAsync();
-        }
-
-        public async Task DeactivateUserAsync(Guid userId)
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            var user = await dbContext.Users.SingleAsync(u => u.Id == userId);
-            user.IsActive = false;
-            user.DeactivatedAt = DateTime.UtcNow;
-            await dbContext.SaveChangesAsync();
-        }
-
-        public async Task<Guid> AddInactiveRegionAsync(string code, string name)
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            var region = new Region { Id = Guid.NewGuid(), Code = code, Name = name, IsActive = false, CreatedAt = DateTime.UtcNow };
-            dbContext.Regions.Add(region);
-            await dbContext.SaveChangesAsync();
-
-            return region.Id;
-        }
-
-        public async Task<Guid> AddInactiveCountryAsync(Guid regionId, string code, string name)
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            var country = new Country { Id = Guid.NewGuid(), RegionId = regionId, Code = code, Name = name, IsActive = false, CreatedAt = DateTime.UtcNow };
-            dbContext.Countries.Add(country);
-            await dbContext.SaveChangesAsync();
-
-            return country.Id;
-        }
-
-        public async Task<Guid> AddInactiveAccountAsync(Guid countryId, string code, string name)
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            var account = new Account { Id = Guid.NewGuid(), CountryId = countryId, Code = code, Name = name, IsActive = false, CreatedAt = DateTime.UtcNow };
-            dbContext.Accounts.Add(account);
-            await dbContext.SaveChangesAsync();
-
-            return account.Id;
-        }
-
-        public async Task AssertAuditAsync(string action, string entityType, Guid entityId)
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-
-            var audit = await dbContext.AuditLogs
-                .AsNoTracking()
-                .Where(log => log.Action == action && log.EntityType == entityType && log.EntityId == entityId)
-                .OrderByDescending(log => log.CreatedAt)
-                .FirstOrDefaultAsync();
-
-            Assert.NotNull(audit);
-            Assert.Equal(SeedIds.Users.Admin, audit.ActorUserId);
-            Assert.False(string.IsNullOrWhiteSpace(audit.CorrelationId));
-            Assert.DoesNotContain("password", audit.PreviousValue ?? string.Empty, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain("password", audit.NewValue ?? string.Empty, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain(JwtSigningKey, audit.PreviousValue ?? string.Empty, StringComparison.Ordinal);
-            Assert.DoesNotContain(JwtSigningKey, audit.NewValue ?? string.Empty, StringComparison.Ordinal);
-        }
-
-        protected override void ConfigureWebHost(IWebHostBuilder builder)
-        {
-            builder.UseEnvironment("Testing");
-            builder.ConfigureAppConfiguration((_, config) =>
-            {
-                config.AddInMemoryCollection(new Dictionary<string, string?>
-                {
-                    ["ConnectionStrings:DefaultConnection"] = "Server=(local);Database=OpsSphereOrganizationTests;Trusted_Connection=True;TrustServerCertificate=True;",
-                    ["SeedData:Enabled"] = "false",
-                    ["Jwt:Issuer"] = "OpsSphere.Tests",
-                    ["Jwt:Audience"] = "OpsSphere.Tests.Angular",
-                    ["Jwt:ExpirationMinutes"] = "60",
-                    ["Jwt:SigningKey"] = JwtSigningKey
-                });
-            });
-            builder.ConfigureTestServices(services =>
-            {
-                services.RemoveAll<IDbContextOptionsConfiguration<OpsSphereDbContext>>();
-                services.RemoveAll<DbContextOptions<OpsSphereDbContext>>();
-                services.AddDbContext<OpsSphereDbContext>(options => options.UseSqlite(connection));
-            });
-        }
-
-        private static void ConfigureEnvironment()
-        {
-            Environment.SetEnvironmentVariable(
-                "ConnectionStrings__DefaultConnection",
-                "Server=(local);Database=OpsSphereOrganizationTests;Trusted_Connection=True;TrustServerCertificate=True;");
-            Environment.SetEnvironmentVariable("SeedData__Enabled", "false");
-            Environment.SetEnvironmentVariable("Jwt__Issuer", "OpsSphere.Tests");
-            Environment.SetEnvironmentVariable("Jwt__Audience", "OpsSphere.Tests.Angular");
-            Environment.SetEnvironmentVariable("Jwt__ExpirationMinutes", "60");
-            Environment.SetEnvironmentVariable("Jwt__SigningKey", JwtSigningKey);
-        }
-
-        public override async ValueTask DisposeAsync()
-        {
-            await connection.DisposeAsync();
-            await base.DisposeAsync();
-        }
-
-        private async Task InitializeDatabaseAsync()
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            await dbContext.Database.EnsureDeletedAsync();
-            await dbContext.Database.EnsureCreatedAsync();
-
-            var seeder = scope.ServiceProvider.GetRequiredService<OpsSphereDataSeeder>();
-            await seeder.SeedAsync();
-        }
-    }
 }

--- a/tests/OpsSphere.IntegrationTests/Persistence/MigrationTests.cs
+++ b/tests/OpsSphere.IntegrationTests/Persistence/MigrationTests.cs
@@ -1,0 +1,34 @@
+using DotNet.Testcontainers.Builders;
+using Microsoft.EntityFrameworkCore;
+using Testcontainers.MsSql;
+using OpsSphere.Infrastructure.Persistence;
+
+namespace OpsSphere.IntegrationTests.Persistence;
+
+[Trait("Category", "Heavy")]
+public sealed class MigrationTests
+{
+    [Fact]
+    public async Task AllMigrations_ApplyCleanly_ToSqlServer()
+    {
+        await using var container = new MsSqlBuilder()
+            .WithAutoRemove(true)
+            .WithCleanUp(true)
+            .Build();
+
+        await container.StartAsync();
+
+        var connectionString = container.GetConnectionString();
+
+        var options = new DbContextOptionsBuilder<OpsSphereDbContext>()
+            .UseSqlServer(connectionString)
+            .Options;
+
+        await using var dbContext = new OpsSphereDbContext(options);
+
+        await dbContext.Database.MigrateAsync();
+
+        var pendingMigrations = await dbContext.Database.GetPendingMigrationsAsync();
+        Assert.Empty(pendingMigrations);
+    }
+}

--- a/tests/OpsSphere.IntegrationTests/TestInfrastructure/OpsSphereSqliteFactory.cs
+++ b/tests/OpsSphere.IntegrationTests/TestInfrastructure/OpsSphereSqliteFactory.cs
@@ -1,0 +1,243 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using OpsSphere.Domain.Entities;
+using OpsSphere.Infrastructure.Persistence;
+using OpsSphere.Infrastructure.Persistence.SeedData;
+
+namespace OpsSphere.IntegrationTests.TestInfrastructure;
+
+public sealed class OpsSphereSqliteFactory : WebApplicationFactory<Program>, IAsyncDisposable
+{
+    public const string JwtSigningKey = "integration-testing-only-fictional-jwt-signing-key";
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly SqliteConnection connection = new("Data Source=:memory:");
+
+    public static async Task<OpsSphereSqliteFactory> CreateAsync()
+    {
+        ConfigureEnvironment();
+        var factory = new OpsSphereSqliteFactory();
+        await factory.connection.OpenAsync();
+        await factory.InitializeDatabaseAsync();
+        return factory;
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "Server=(local);Database=OpsSphereSqliteTests;Trusted_Connection=True;TrustServerCertificate=True;",
+                ["SeedData:Enabled"] = "false",
+                ["Jwt:Issuer"] = "OpsSphere.Tests",
+                ["Jwt:Audience"] = "OpsSphere.Tests.Angular",
+                ["Jwt:ExpirationMinutes"] = "60",
+                ["Jwt:SigningKey"] = JwtSigningKey
+            });
+        });
+        builder.ConfigureTestServices(services =>
+        {
+            services.RemoveAll<IDbContextOptionsConfiguration<OpsSphereDbContext>>();
+            services.RemoveAll<DbContextOptions<OpsSphereDbContext>>();
+            services.AddDbContext<OpsSphereDbContext>(options => options.UseSqlite(connection));
+            services.AddControllers()
+                .AddApplicationPart(Assembly.GetExecutingAssembly());
+        });
+    }
+
+    private static void ConfigureEnvironment()
+    {
+        Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", "Server=(local);Database=OpsSphereSqliteTests;Trusted_Connection=True;TrustServerCertificate=True;");
+        Environment.SetEnvironmentVariable("SeedData__Enabled", "false");
+        Environment.SetEnvironmentVariable("Jwt__Issuer", "OpsSphere.Tests");
+        Environment.SetEnvironmentVariable("Jwt__Audience", "OpsSphere.Tests.Angular");
+        Environment.SetEnvironmentVariable("Jwt__ExpirationMinutes", "60");
+        Environment.SetEnvironmentVariable("Jwt__SigningKey", JwtSigningKey);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        await connection.DisposeAsync();
+        await base.DisposeAsync();
+    }
+
+    private async Task InitializeDatabaseAsync()
+    {
+        using var scope = Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+        await dbContext.Database.EnsureDeletedAsync();
+        await dbContext.Database.EnsureCreatedAsync();
+
+        var seeder = scope.ServiceProvider.GetRequiredService<OpsSphereDataSeeder>();
+        await seeder.SeedAsync();
+    }
+
+    public async Task AssertAuditAsync(string action, string entityType, Guid entityId)
+    {
+        using var scope = Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+
+        var audit = await dbContext.AuditLogs
+            .AsNoTracking()
+            .Where(log => log.Action == action && log.EntityType == entityType && log.EntityId == entityId)
+            .OrderByDescending(log => log.CreatedAt)
+            .FirstOrDefaultAsync();
+
+        Assert.NotNull(audit);
+        Assert.False(string.IsNullOrWhiteSpace(audit.CorrelationId));
+        Assert.DoesNotContain("password", audit.PreviousValue ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("password", audit.NewValue ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(JwtSigningKey, audit.PreviousValue ?? string.Empty, StringComparison.Ordinal);
+        Assert.DoesNotContain(JwtSigningKey, audit.NewValue ?? string.Empty, StringComparison.Ordinal);
+    }
+
+    public async Task<HttpClient> CreateAuthenticatedClientAsync(string email)
+    {
+        var client = CreateClient();
+        var loginResponse = await client.PostAsJsonAsync("/api/auth/login", new
+        {
+            email,
+            password = OpsSphereSeedData.LocalDemoPassword
+        });
+        loginResponse.EnsureSuccessStatusCode();
+        var loginBody = await ReadResponseAsync<ApiResponse<LoginData>>(loginResponse);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", loginBody.Data.AccessToken);
+        return client;
+    }
+
+    public static async Task<T> ReadDataAsync<T>(HttpResponseMessage response)
+    {
+        var envelope = await ReadResponseAsync<ApiResponse<T>>(response);
+        return envelope.Data;
+    }
+
+    public static async Task<ApiErrorResponse> ReadErrorAsync(HttpResponseMessage response) =>
+        await ReadResponseAsync<ApiErrorResponse>(response);
+
+    public static async Task<T> ReadResponseAsync<T>(HttpResponseMessage response)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
+        return value ?? throw new InvalidOperationException($"Could not deserialize {typeof(T).Name} from {(int)response.StatusCode}: {json}");
+    }
+
+    public async Task AssertAuditAsync(string action, Guid entityId)
+    {
+        using var scope = Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+        var audit = await dbContext.AuditLogs
+            .AsNoTracking()
+            .Where(log => log.Action == action && log.EntityId == entityId)
+            .OrderByDescending(log => log.CreatedAt)
+            .FirstOrDefaultAsync();
+        Assert.NotNull(audit);
+        Assert.False(string.IsNullOrWhiteSpace(audit.CorrelationId));
+    }
+
+    public async Task AssertAuditDoesNotContainPiiAsync(Guid entityId)
+    {
+        using var scope = Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+        var auditLogs = await dbContext.AuditLogs
+            .AsNoTracking()
+            .Where(log => log.EntityId == entityId)
+            .ToListAsync();
+        foreach (var log in auditLogs)
+        {
+            Assert.DoesNotContain("@", log.NewValue ?? string.Empty, StringComparison.Ordinal);
+            Assert.DoesNotContain("phone", log.NewValue ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("@", log.PreviousValue ?? string.Empty, StringComparison.Ordinal);
+            Assert.DoesNotContain("phone", log.PreviousValue ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    public async Task<Guid> AddInactiveRegionAsync(string code, string name)
+    {
+        using var scope = Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+        var region = new Region { Id = Guid.NewGuid(), Code = code.ToUpperInvariant(), Name = name, IsActive = false, CreatedAt = DateTime.UtcNow };
+        dbContext.Regions.Add(region);
+        await dbContext.SaveChangesAsync();
+        return region.Id;
+    }
+
+    public async Task<Guid> AddInactiveCountryAsync(Guid regionId, string code, string name)
+    {
+        using var scope = Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+        var country = new Country { Id = Guid.NewGuid(), RegionId = regionId, Code = code.ToUpperInvariant(), Name = name, IsActive = false, CreatedAt = DateTime.UtcNow };
+        dbContext.Countries.Add(country);
+        await dbContext.SaveChangesAsync();
+        return country.Id;
+    }
+
+    public async Task<Guid> AddInactiveAccountAsync(Guid countryId, string code, string name)
+    {
+        using var scope = Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+        var account = new Account { Id = Guid.NewGuid(), CountryId = countryId, Code = code.ToUpperInvariant(), Name = name, IsActive = false, CreatedAt = DateTime.UtcNow };
+        dbContext.Accounts.Add(account);
+        await dbContext.SaveChangesAsync();
+        return account.Id;
+    }
+
+    public async Task<Guid> AddInactiveAccountAsync(string code, string name)
+    {
+        return await AddInactiveAccountAsync(SeedIds.Countries.Mexico, code, name);
+    }
+
+    public async Task<Guid> GetUserIdAsync(string email)
+    {
+        using var scope = Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+        var user = await dbContext.Users.AsNoTracking().SingleAsync(u => u.Email == email);
+        return user.Id;
+    }
+
+    public async Task DeactivateUserAsync(Guid userId)
+    {
+        using var scope = Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+        var user = await dbContext.Users.SingleAsync(u => u.Id == userId);
+        user.IsActive = false;
+        user.DeactivatedAt = DateTime.UtcNow;
+        await dbContext.SaveChangesAsync();
+    }
+
+    public async Task DeactivateUserAsync(string email)
+    {
+        using var scope = Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+        var user = await dbContext.Users.SingleAsync(u => u.Email == email);
+        user.IsActive = false;
+        user.DeactivatedAt = DateTime.UtcNow;
+        await dbContext.SaveChangesAsync();
+    }
+
+    public async Task<IReadOnlyList<string>> GetPasswordHashesAsync()
+    {
+        using var scope = Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
+        return await dbContext.Users.AsNoTracking().Select(u => u.PasswordHash).ToListAsync();
+    }
+
+    public sealed record ApiResponse<T>(T Data);
+    public sealed record ApiErrorResponse(ApiError Error);
+    public sealed record ApiError(string Code, string Message, IReadOnlyList<ApiErrorDetail>? Details, string? CorrelationId);
+    public sealed record ApiErrorDetail(string? Field, string Message);
+    public sealed record LoginData(string AccessToken);
+}

--- a/tests/OpsSphere.IntegrationTests/TestInfrastructure/TestDiagnosticsController.cs
+++ b/tests/OpsSphere.IntegrationTests/TestInfrastructure/TestDiagnosticsController.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using OpsSphere.Application.Common.Exceptions;
+
+namespace OpsSphere.IntegrationTests.TestInfrastructure;
+
+[ApiController]
+[Route("api/test-diagnostics")]
+public sealed class TestDiagnosticsController : ControllerBase
+{
+    [HttpGet("throw-validation")]
+    public IActionResult ThrowValidation() =>
+        throw new ValidationException("email", "Email is required.");
+
+    [HttpGet("throw-business-rule")]
+    public IActionResult ThrowBusinessRule() =>
+        throw new BusinessRuleException("Ticket must be resolved before it can be closed.");
+
+    [HttpGet("throw-not-found")]
+    public IActionResult ThrowNotFound() =>
+        throw new NotFoundException("Ticket", Guid.NewGuid());
+
+    [HttpGet("throw-conflict")]
+    public IActionResult ThrowConflict() =>
+        throw new ConflictException("A user with this email already exists.");
+
+    [HttpGet("throw-unhandled")]
+    public IActionResult ThrowUnhandled() =>
+        throw new InvalidOperationException("Simulated unhandled exception for testing.");
+}

--- a/tests/OpsSphere.IntegrationTests/TicketManagement/TicketAssignmentApiTests.cs
+++ b/tests/OpsSphere.IntegrationTests/TicketManagement/TicketAssignmentApiTests.cs
@@ -1,21 +1,14 @@
-using System.Net;
-using System.Net.Http.Headers;
+﻿using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpsSphere.Domain.Authorization;
 using OpsSphere.Domain.Entities;
 using OpsSphere.Domain.Enums;
 using OpsSphere.Infrastructure.Persistence;
 using OpsSphere.Infrastructure.Persistence.SeedData;
+using OpsSphere.IntegrationTests.TestInfrastructure;
 
 namespace OpsSphere.IntegrationTests.TicketManagement;
 
@@ -31,14 +24,14 @@ public sealed class TicketAssignmentApiTests
     [Fact]
     public async Task Supervisor_CanAssignTicket_WithinScope_Returns200()
     {
-        await using var factory = await TicketAssignmentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Assignment happy path");
 
         var response = await AssignTicketAsync(supervisor, ticket.Id, SeedIds.Users.AgentNovabank);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<AssignTicketResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<AssignTicketResponse>(response);
         Assert.Equal(ticket.Id, result.TicketId);
         Assert.Equal(ticket.TicketNumber, result.TicketNumber);
         Assert.Equal(SeedIds.Users.AgentNovabank, result.AssignedAgentUserId);
@@ -50,8 +43,8 @@ public sealed class TicketAssignmentApiTests
     [Fact]
     public async Task Supervisor_CanReassignTicket_Returns200()
     {
-        await using var factory = await TicketAssignmentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Reassignment happy path");
         await AssignTicketAsync(supervisor, ticket.Id, SeedIds.Users.AgentNovabank);
         var secondAgentId = await AddAgentAsync(factory, "Reassign Target", isActive: true, scopeType: ScopeTypes.Account, accountId: SeedIds.Accounts.NovaBank);
@@ -59,7 +52,7 @@ public sealed class TicketAssignmentApiTests
         var response = await AssignTicketAsync(supervisor, ticket.Id, secondAgentId, "Routing to backup agent");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<AssignTicketResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<AssignTicketResponse>(response);
         Assert.Equal(secondAgentId, result.AssignedAgentUserId);
         Assert.Equal(SeedIds.Users.AgentNovabank, result.PreviousAgentUserId);
         Assert.Equal("Assigned", result.Status);
@@ -68,9 +61,9 @@ public sealed class TicketAssignmentApiTests
     [Fact]
     public async Task Agent_CannotAssignTicket_Returns403()
     {
-        await using var factory = await TicketAssignmentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Agent forbidden assignment");
 
         var response = await AssignTicketAsync(agent, ticket.Id, SeedIds.Users.AgentNovabank);
@@ -81,9 +74,9 @@ public sealed class TicketAssignmentApiTests
     [Fact]
     public async Task Viewer_CannotAssignTicket_Returns403()
     {
-        await using var factory = await TicketAssignmentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var viewer = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var viewer = await factory.CreateAuthenticatedClientAsync(ViewerEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Viewer forbidden assignment");
 
         var response = await AssignTicketAsync(viewer, ticket.Id, SeedIds.Users.AgentNovabank);
@@ -94,9 +87,9 @@ public sealed class TicketAssignmentApiTests
     [Fact]
     public async Task Admin_CannotAssignTicket_Returns403()
     {
-        await using var factory = await TicketAssignmentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var admin = await factory.CreateAuthenticatedClientAsync(AdminEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Admin forbidden assignment");
 
         var response = await AssignTicketAsync(admin, ticket.Id, SeedIds.Users.AgentNovabank);
@@ -107,8 +100,8 @@ public sealed class TicketAssignmentApiTests
     [Fact]
     public async Task Supervisor_CannotAssign_OutOfScopeTicket_Returns404()
     {
-        await using var factory = await TicketAssignmentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var outOfScopeTicketId = await AddTicketDirectlyAsync(
             factory,
             SeedIds.Accounts.Streamly,
@@ -125,15 +118,15 @@ public sealed class TicketAssignmentApiTests
     [Fact]
     public async Task Supervisor_CannotAssign_ClosedTicket_Returns400()
     {
-        await using var factory = await TicketAssignmentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Closed assignment rejection");
         await SetTicketStatusAsync(factory, ticket.Id, TicketStatus.Closed);
 
         var response = await AssignTicketAsync(supervisor, ticket.Id, SeedIds.Users.AgentNovabank);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
         Assert.Contains("closed", error.Error.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -141,15 +134,15 @@ public sealed class TicketAssignmentApiTests
     [Fact]
     public async Task Supervisor_CannotAssign_InactiveAgent_Returns400()
     {
-        await using var factory = await TicketAssignmentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Inactive agent rejection");
         var inactiveAgentId = await AddAgentAsync(factory, "Inactive Test Agent", isActive: false, scopeType: ScopeTypes.Campaign, campaignId: SeedIds.Campaigns.NovaBankCreditCard);
 
         var response = await AssignTicketAsync(supervisor, ticket.Id, inactiveAgentId);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("validation_error", error.Error.Code);
         Assert.Contains(error.Error.Details, d => d.Field == "targetAgentUserId");
     }
@@ -157,15 +150,15 @@ public sealed class TicketAssignmentApiTests
     [Fact]
     public async Task Supervisor_CannotAssign_OutOfScopeAgent_Returns400()
     {
-        await using var factory = await TicketAssignmentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Out-of-scope agent rejection");
         var outOfScopeAgentId = await AddAgentAsync(factory, "Streamly Test Agent", isActive: true, scopeType: ScopeTypes.Campaign, campaignId: SeedIds.Campaigns.StreamlyCreator);
 
         var response = await AssignTicketAsync(supervisor, ticket.Id, outOfScopeAgentId);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("validation_error", error.Error.Code);
         Assert.Contains(error.Error.Details, d => d.Field == "targetAgentUserId");
     }
@@ -173,15 +166,15 @@ public sealed class TicketAssignmentApiTests
     [Fact]
     public async Task Supervisor_CannotAssign_SameAgent_Returns400()
     {
-        await using var factory = await TicketAssignmentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Same-agent assignment rejection");
         await AssignTicketAsync(supervisor, ticket.Id, SeedIds.Users.AgentNovabank);
 
         var response = await AssignTicketAsync(supervisor, ticket.Id, SeedIds.Users.AgentNovabank);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
         Assert.Contains("already assigned", error.Error.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -189,8 +182,8 @@ public sealed class TicketAssignmentApiTests
     [Fact]
     public async Task Assign_UpdatesStatus_OpenToAssigned()
     {
-        await using var factory = await TicketAssignmentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Open to assigned status");
 
         await AssignTicketAsync(supervisor, ticket.Id, SeedIds.Users.AgentNovabank);
@@ -205,8 +198,8 @@ public sealed class TicketAssignmentApiTests
     [Fact]
     public async Task Assign_DoesNotChangeStatus_IfAlreadyAssigned()
     {
-        await using var factory = await TicketAssignmentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Assigned status remains assigned");
         var secondAgentId = await AddAgentAsync(factory, "Second Assigned Agent", isActive: true, scopeType: ScopeTypes.Account, accountId: SeedIds.Accounts.NovaBank);
         await AssignTicketAsync(supervisor, ticket.Id, SeedIds.Users.AgentNovabank);
@@ -223,8 +216,8 @@ public sealed class TicketAssignmentApiTests
     [Fact]
     public async Task Assign_CreatesAssignmentHistory()
     {
-        await using var factory = await TicketAssignmentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Assignment history persistence");
 
         await AssignTicketAsync(supervisor, ticket.Id, SeedIds.Users.AgentNovabank, "  Trimmed reason  ");
@@ -241,8 +234,8 @@ public sealed class TicketAssignmentApiTests
     [Fact]
     public async Task Assign_CreatesStatusHistory_WhenOpenToAssigned()
     {
-        await using var factory = await TicketAssignmentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Assignment status history");
 
         await AssignTicketAsync(supervisor, ticket.Id, SeedIds.Users.AgentNovabank);
@@ -262,8 +255,8 @@ public sealed class TicketAssignmentApiTests
     [Fact]
     public async Task Assign_DoesNotCreateStatusHistory_WhenStatusUnchanged()
     {
-        await using var factory = await TicketAssignmentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "No status history on reassignment");
         var secondAgentId = await AddAgentAsync(factory, "No Status History Agent", isActive: true, scopeType: ScopeTypes.Account, accountId: SeedIds.Accounts.NovaBank);
         await AssignTicketAsync(supervisor, ticket.Id, SeedIds.Users.AgentNovabank);
@@ -278,8 +271,8 @@ public sealed class TicketAssignmentApiTests
     [Fact]
     public async Task Assign_CreatesAuditLog_WithTicketAssignedAction()
     {
-        await using var factory = await TicketAssignmentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Assignment audit action");
 
         await AssignTicketAsync(supervisor, ticket.Id, SeedIds.Users.AgentNovabank);
@@ -297,8 +290,8 @@ public sealed class TicketAssignmentApiTests
     [Fact]
     public async Task AuditLog_DoesNotContainPII_OnAssignment()
     {
-        await using var factory = await TicketAssignmentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         const string sensitiveSubject = "AssignmentSensitiveSubject-ABC123";
         const string sensitiveDescription = "AssignmentSensitiveDescription-XYZ987";
         var ticket = await CreateTicketAsync(
@@ -333,22 +326,22 @@ public sealed class TicketAssignmentApiTests
     [Fact]
     public async Task GetEligibleAgents_ReturnsActiveAgentsInScope_Returns200()
     {
-        await using var factory = await TicketAssignmentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Eligible agents lookup");
 
         var response = await supervisor.GetAsync($"/api/tickets/{ticket.Id}/eligible-agents");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var agents = await ReadDataAsync<IReadOnlyList<EligibleAgentDto>>(response);
+        var agents = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<EligibleAgentDto>>(response);
         Assert.Contains(agents, a => a.UserId == SeedIds.Users.AgentNovabank && a.DisplayName == "Diego Santos");
     }
 
     [Fact]
     public async Task GetEligibleAgents_Returns404_ForOutOfScopeTicket()
     {
-        await using var factory = await TicketAssignmentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var outOfScopeTicketId = await AddTicketDirectlyAsync(
             factory,
             SeedIds.Accounts.Streamly,
@@ -365,8 +358,8 @@ public sealed class TicketAssignmentApiTests
     [Fact]
     public async Task GetEligibleAgents_DoesNotReturnInactiveOrOutOfScopeAgents()
     {
-        await using var factory = await TicketAssignmentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Eligible agents filtering");
         var inactiveAgentId = await AddAgentAsync(factory, "Inactive Lookup Agent", isActive: false, scopeType: ScopeTypes.Campaign, campaignId: SeedIds.Campaigns.NovaBankCreditCard);
         var outOfScopeAgentId = await AddAgentAsync(factory, "Out Of Scope Lookup Agent", isActive: true, scopeType: ScopeTypes.Campaign, campaignId: SeedIds.Campaigns.StreamlyCreator);
@@ -375,7 +368,7 @@ public sealed class TicketAssignmentApiTests
         var response = await supervisor.GetAsync($"/api/tickets/{ticket.Id}/eligible-agents");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var agents = await ReadDataAsync<IReadOnlyList<EligibleAgentDto>>(response);
+        var agents = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<EligibleAgentDto>>(response);
         Assert.Contains(agents, a => a.UserId == SeedIds.Users.AgentNovabank);
         Assert.DoesNotContain(agents, a => a.UserId == inactiveAgentId);
         Assert.DoesNotContain(agents, a => a.UserId == outOfScopeAgentId);
@@ -421,11 +414,11 @@ public sealed class TicketAssignmentApiTests
             description
         });
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        return await ReadDataAsync<CreateTicketResult>(response);
+        return await OpsSphereSqliteFactory.ReadDataAsync<CreateTicketResult>(response);
     }
 
     private static async Task<Guid> AddAgentAsync(
-        TicketAssignmentApiFactory factory,
+        OpsSphereSqliteFactory factory,
         string displayName,
         bool isActive,
         string scopeType,
@@ -470,7 +463,7 @@ public sealed class TicketAssignmentApiTests
     }
 
     private static async Task<Guid> AddTicketDirectlyAsync(
-        TicketAssignmentApiFactory factory,
+        OpsSphereSqliteFactory factory,
         Guid accountId,
         Guid campaignId,
         Guid customerId,
@@ -530,7 +523,7 @@ public sealed class TicketAssignmentApiTests
         return ticketId;
     }
 
-    private static async Task SetTicketStatusAsync(TicketAssignmentApiFactory factory, Guid ticketId, TicketStatus status)
+    private static async Task SetTicketStatusAsync(OpsSphereSqliteFactory factory, Guid ticketId, TicketStatus status)
     {
         using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
@@ -539,48 +532,12 @@ public sealed class TicketAssignmentApiTests
         await db.SaveChangesAsync();
     }
 
-    private static async Task<int> CountStatusHistoryAsync(TicketAssignmentApiFactory factory, Guid ticketId)
+    private static async Task<int> CountStatusHistoryAsync(OpsSphereSqliteFactory factory, Guid ticketId)
     {
         using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
         return await db.TicketStatusHistory.AsNoTracking().CountAsync(h => h.TicketId == ticketId);
     }
-
-    private static async Task<HttpClient> CreateAuthenticatedClientAsync(TicketAssignmentApiFactory factory, string email)
-    {
-        var client = factory.CreateClient();
-        var loginResponse = await client.PostAsJsonAsync("/api/auth/login", new
-        {
-            email,
-            password = OpsSphereSeedData.LocalDemoPassword
-        });
-        loginResponse.EnsureSuccessStatusCode();
-        var loginBody = await ReadResponseAsync<ApiResponse<LoginData>>(loginResponse);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", loginBody.Data.AccessToken);
-        return client;
-    }
-
-    private static async Task<T> ReadDataAsync<T>(HttpResponseMessage response)
-    {
-        var envelope = await ReadResponseAsync<ApiResponse<T>>(response);
-        return envelope.Data;
-    }
-
-    private static async Task<ApiErrorResponse> ReadErrorAsync(HttpResponseMessage response) =>
-        await ReadResponseAsync<ApiErrorResponse>(response);
-
-    private static async Task<T> ReadResponseAsync<T>(HttpResponseMessage response)
-    {
-        var json = await response.Content.ReadAsStringAsync();
-        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
-        return value ?? throw new InvalidOperationException($"Could not deserialize {typeof(T).Name} from {(int)response.StatusCode}: {json}");
-    }
-
-    private sealed record ApiResponse<T>(T Data);
-    private sealed record ApiErrorResponse(ApiError Error);
-    private sealed record ApiError(string Code, string Message, IReadOnlyList<ApiErrorDetail> Details);
-    private sealed record ApiErrorDetail(string? Field, string Message);
-    private sealed record LoginData(string AccessToken);
 
     private sealed record CreateTicketResult(
         Guid Id,
@@ -603,70 +560,4 @@ public sealed class TicketAssignmentApiTests
         string DisplayName,
         string? ScopeType,
         string? ScopeReference);
-
-    internal sealed class TicketAssignmentApiFactory : WebApplicationFactory<Program>
-    {
-        public const string JwtSigningKey = "integration-testing-only-fictional-jwt-signing-key";
-
-        private readonly SqliteConnection connection = new("Data Source=:memory:");
-
-        public static async Task<TicketAssignmentApiFactory> CreateAsync()
-        {
-            ConfigureEnvironment();
-            var factory = new TicketAssignmentApiFactory();
-            await factory.connection.OpenAsync();
-            await factory.InitializeDatabaseAsync();
-            return factory;
-        }
-
-        protected override void ConfigureWebHost(IWebHostBuilder builder)
-        {
-            builder.UseEnvironment("Testing");
-            builder.ConfigureAppConfiguration((_, config) =>
-            {
-                config.AddInMemoryCollection(new Dictionary<string, string?>
-                {
-                    ["ConnectionStrings:DefaultConnection"] = "Server=(local);Database=OpsSphereTicketAssignmentTests;Trusted_Connection=True;TrustServerCertificate=True;",
-                    ["SeedData:Enabled"] = "false",
-                    ["Jwt:Issuer"] = "OpsSphere.Tests",
-                    ["Jwt:Audience"] = "OpsSphere.Tests.Angular",
-                    ["Jwt:ExpirationMinutes"] = "60",
-                    ["Jwt:SigningKey"] = JwtSigningKey
-                });
-            });
-            builder.ConfigureTestServices(services =>
-            {
-                services.RemoveAll<IDbContextOptionsConfiguration<OpsSphereDbContext>>();
-                services.RemoveAll<DbContextOptions<OpsSphereDbContext>>();
-                services.AddDbContext<OpsSphereDbContext>(options => options.UseSqlite(connection));
-            });
-        }
-
-        private static void ConfigureEnvironment()
-        {
-            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", "Server=(local);Database=OpsSphereTicketAssignmentTests;Trusted_Connection=True;TrustServerCertificate=True;");
-            Environment.SetEnvironmentVariable("SeedData__Enabled", "false");
-            Environment.SetEnvironmentVariable("Jwt__Issuer", "OpsSphere.Tests");
-            Environment.SetEnvironmentVariable("Jwt__Audience", "OpsSphere.Tests.Angular");
-            Environment.SetEnvironmentVariable("Jwt__ExpirationMinutes", "60");
-            Environment.SetEnvironmentVariable("Jwt__SigningKey", JwtSigningKey);
-        }
-
-        public override async ValueTask DisposeAsync()
-        {
-            await connection.DisposeAsync();
-            await base.DisposeAsync();
-        }
-
-        private async Task InitializeDatabaseAsync()
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            await dbContext.Database.EnsureDeletedAsync();
-            await dbContext.Database.EnsureCreatedAsync();
-
-            var seeder = scope.ServiceProvider.GetRequiredService<OpsSphereDataSeeder>();
-            await seeder.SeedAsync();
-        }
-    }
 }

--- a/tests/OpsSphere.IntegrationTests/TicketManagement/TicketCommentApiTests.cs
+++ b/tests/OpsSphere.IntegrationTests/TicketManagement/TicketCommentApiTests.cs
@@ -1,20 +1,13 @@
-using System.Net;
-using System.Net.Http.Headers;
+﻿using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpsSphere.Domain.Entities;
 using OpsSphere.Domain.Enums;
 using OpsSphere.Infrastructure.Persistence;
 using OpsSphere.Infrastructure.Persistence.SeedData;
+using OpsSphere.IntegrationTests.TestInfrastructure;
 
 namespace OpsSphere.IntegrationTests.TicketManagement;
 
@@ -31,14 +24,14 @@ public sealed class TicketCommentApiTests
     [Fact]
     public async Task Agent_CanAddComment_WithinScope_Returns200()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Agent comment");
 
         var response = await AddCommentAsync(agent, ticket.Id, "Agent internal note");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<AddInternalCommentResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<AddInternalCommentResponse>(response);
         Assert.Equal(ticket.Id, result.TicketId);
         Assert.Equal(ticket.TicketNumber, result.TicketNumber);
         Assert.Equal(SeedIds.Users.AgentNovabank, result.AuthorUserId);
@@ -50,14 +43,14 @@ public sealed class TicketCommentApiTests
     [Fact]
     public async Task Supervisor_CanAddComment_WithinScope_Returns200()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Supervisor comment");
 
         var response = await AddCommentAsync(supervisor, ticket.Id, "Supervisor note");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<AddInternalCommentResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<AddInternalCommentResponse>(response);
         Assert.Equal(SeedIds.Users.SupervisorNovabank, result.AuthorUserId);
         Assert.Equal("Lina Calderon", result.AuthorDisplayName);
     }
@@ -65,15 +58,15 @@ public sealed class TicketCommentApiTests
     [Fact]
     public async Task OperationsManager_CanAddComment_WithinScope_Returns200()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var manager = await CreateAuthenticatedClientAsync(factory, ManagerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var manager = await factory.CreateAuthenticatedClientAsync(ManagerEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Manager scoped comment");
 
         var response = await AddCommentAsync(manager, ticket.Id, "Manager note");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<AddInternalCommentResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<AddInternalCommentResponse>(response);
         Assert.Equal(SeedIds.Users.ManagerLatam, result.AuthorUserId);
         Assert.Equal("Mateo Rios", result.AuthorDisplayName);
     }
@@ -81,9 +74,9 @@ public sealed class TicketCommentApiTests
     [Fact]
     public async Task Admin_CannotAddComment_Returns403()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var admin = await factory.CreateAuthenticatedClientAsync(AdminEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Admin comment forbidden");
 
         var response = await AddCommentAsync(admin, ticket.Id, "Admin note");
@@ -94,9 +87,9 @@ public sealed class TicketCommentApiTests
     [Fact]
     public async Task Viewer_CannotAddComment_Returns403()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var viewer = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var viewer = await factory.CreateAuthenticatedClientAsync(ViewerEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Viewer comment forbidden");
 
         var response = await AddCommentAsync(viewer, ticket.Id, "Viewer note");
@@ -107,8 +100,8 @@ public sealed class TicketCommentApiTests
     [Fact]
     public async Task Unauthenticated_CannotAddComment_Returns401()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Unauthenticated comment forbidden");
         var anonymous = factory.CreateClient();
 
@@ -120,14 +113,14 @@ public sealed class TicketCommentApiTests
     [Fact]
     public async Task AddComment_EmptyBody_Returns400_WithValidationError()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Empty comment body");
 
         var response = await AddCommentAsync(agent, ticket.Id, string.Empty);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("validation_error", error.Error.Code);
         Assert.Contains(error.Error.Details ?? [], d => d.Field == "body");
     }
@@ -135,14 +128,14 @@ public sealed class TicketCommentApiTests
     [Fact]
     public async Task AddComment_WhitespaceBody_Returns400_WithValidationError()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Whitespace comment body");
 
         var response = await AddCommentAsync(agent, ticket.Id, "   ");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("validation_error", error.Error.Code);
         Assert.Contains(error.Error.Details ?? [], d => d.Field == "body");
     }
@@ -150,14 +143,14 @@ public sealed class TicketCommentApiTests
     [Fact]
     public async Task AddComment_TooLongBody_Returns400_WithValidationError()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Long comment body");
 
         var response = await AddCommentAsync(agent, ticket.Id, new string('a', 5001));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("validation_error", error.Error.Code);
         Assert.Contains(error.Error.Details ?? [], d => d.Field == "body");
     }
@@ -165,8 +158,8 @@ public sealed class TicketCommentApiTests
     [Fact]
     public async Task AddComment_CrossScope_Returns404()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var outOfScopeTicketId = await AddTicketDirectlyAsync(
             factory,
             SeedIds.Accounts.Streamly,
@@ -183,15 +176,15 @@ public sealed class TicketCommentApiTests
     [Fact]
     public async Task AddComment_ClosedTicket_Returns400_WithBusinessRuleViolation()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Closed comment rejection");
         await SetTicketStatusAsync(factory, ticket.Id, TicketStatus.Closed);
 
         var response = await AddCommentAsync(agent, ticket.Id, "Closed ticket note");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
         Assert.Contains("closed", error.Error.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -199,15 +192,15 @@ public sealed class TicketCommentApiTests
     [Fact]
     public async Task AddComment_PersistsAuthorAndTimestamp()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Comment persistence");
         var before = DateTime.UtcNow;
 
         var response = await AddCommentAsync(agent, ticket.Id, "Persisted note");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<AddInternalCommentResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<AddInternalCommentResponse>(response);
         using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
         var comment = await db.TicketComments.AsNoTracking().SingleAsync(c => c.Id == result.CommentId);
@@ -219,14 +212,14 @@ public sealed class TicketCommentApiTests
     [Fact]
     public async Task AddComment_TrimsBodyBeforePersistence()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Trimmed comment");
 
         var response = await AddCommentAsync(agent, ticket.Id, "  Trimmed body  ");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<AddInternalCommentResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<AddInternalCommentResponse>(response);
         Assert.Equal("Trimmed body", result.Body);
         using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
@@ -237,8 +230,8 @@ public sealed class TicketCommentApiTests
     [Fact]
     public async Task AddComment_CreatesAuditLog_InternalCommentAdded()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Comment audit action");
 
         var response = await AddCommentAsync(agent, ticket.Id, "Audited note");
@@ -258,8 +251,8 @@ public sealed class TicketCommentApiTests
     [Fact]
     public async Task AddComment_AuditLogDoesNotContainCommentBodyOrPii()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         const string sensitiveSubject = "CommentSensitiveSubject-ABC123";
         const string sensitiveDescription = "CommentSensitiveDescription-XYZ987";
         const string sensitiveBody = "SensitiveCommentBody-SECRET456";
@@ -268,7 +261,7 @@ public sealed class TicketCommentApiTests
         var response = await AddCommentAsync(agent, ticket.Id, sensitiveBody);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<AddInternalCommentResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<AddInternalCommentResponse>(response);
         using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
         var audit = await db.AuditLogs
@@ -295,15 +288,15 @@ public sealed class TicketCommentApiTests
     [Fact]
     public async Task GetComments_WithinScope_ReturnsComments()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Comment list");
         await AddCommentAsync(agent, ticket.Id, "First listed note");
 
         var response = await agent.GetAsync($"/api/tickets/{ticket.Id}/comments");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var comments = await ReadDataAsync<IReadOnlyList<TicketCommentDto>>(response);
+        var comments = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<TicketCommentDto>>(response);
         var comment = Assert.Single(comments);
         Assert.Equal("First listed note", comment.Body);
         Assert.Equal("Diego Santos", comment.AuthorDisplayName);
@@ -312,22 +305,22 @@ public sealed class TicketCommentApiTests
     [Fact]
     public async Task GetComments_WhenNoneExist_ReturnsEmptyList()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "No comments");
 
         var response = await agent.GetAsync($"/api/tickets/{ticket.Id}/comments");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var comments = await ReadDataAsync<IReadOnlyList<TicketCommentDto>>(response);
+        var comments = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<TicketCommentDto>>(response);
         Assert.Empty(comments);
     }
 
     [Fact]
     public async Task GetComments_ReturnsChronologicalAscending()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Chronological comments");
         await AddCommentDirectlyAsync(factory, ticket.Id, SeedIds.Users.AgentNovabank, "Third", DateTime.UtcNow.AddMinutes(3));
         await AddCommentDirectlyAsync(factory, ticket.Id, SeedIds.Users.AgentNovabank, "First", DateTime.UtcNow.AddMinutes(1));
@@ -336,31 +329,31 @@ public sealed class TicketCommentApiTests
         var response = await agent.GetAsync($"/api/tickets/{ticket.Id}/comments");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var comments = await ReadDataAsync<IReadOnlyList<TicketCommentDto>>(response);
+        var comments = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<TicketCommentDto>>(response);
         Assert.Equal(["First", "Second", "Third"], comments.Select(c => c.Body).ToArray());
     }
 
     [Fact]
     public async Task Viewer_CanListComments_WithinScope()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var viewer = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var viewer = await factory.CreateAuthenticatedClientAsync(ViewerEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Viewer comment list");
         await AddCommentAsync(supervisor, ticket.Id, "Viewer visible note");
 
         var response = await viewer.GetAsync($"/api/tickets/{ticket.Id}/comments");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var comments = await ReadDataAsync<IReadOnlyList<TicketCommentDto>>(response);
+        var comments = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<TicketCommentDto>>(response);
         Assert.Contains(comments, c => c.Body == "Viewer visible note");
     }
 
     [Fact]
     public async Task GetComments_CrossScope_Returns404()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var outOfScopeTicketId = await AddTicketDirectlyAsync(
             factory,
             SeedIds.Accounts.Streamly,
@@ -377,8 +370,8 @@ public sealed class TicketCommentApiTests
     [Fact]
     public async Task GetComments_DoesNotReturnSoftDeletedComments()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Soft deleted comments");
         await AddCommentDirectlyAsync(factory, ticket.Id, SeedIds.Users.AgentNovabank, "Visible note", DateTime.UtcNow, isDeleted: false);
         await AddCommentDirectlyAsync(factory, ticket.Id, SeedIds.Users.AgentNovabank, "Deleted note", DateTime.UtcNow.AddMinutes(1), isDeleted: true);
@@ -386,7 +379,7 @@ public sealed class TicketCommentApiTests
         var response = await agent.GetAsync($"/api/tickets/{ticket.Id}/comments");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var comments = await ReadDataAsync<IReadOnlyList<TicketCommentDto>>(response);
+        var comments = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<TicketCommentDto>>(response);
         Assert.Contains(comments, c => c.Body == "Visible note");
         Assert.DoesNotContain(comments, c => c.Body == "Deleted note");
     }
@@ -394,8 +387,8 @@ public sealed class TicketCommentApiTests
     [Fact]
     public async Task GetComments_ClosedTicket_StillAllowedWithinScope()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Closed comment list");
         await AddCommentDirectlyAsync(factory, ticket.Id, SeedIds.Users.AgentNovabank, "Closed ticket visible note", DateTime.UtcNow);
         await SetTicketStatusAsync(factory, ticket.Id, TicketStatus.Closed);
@@ -403,22 +396,22 @@ public sealed class TicketCommentApiTests
         var response = await agent.GetAsync($"/api/tickets/{ticket.Id}/comments");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var comments = await ReadDataAsync<IReadOnlyList<TicketCommentDto>>(response);
+        var comments = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<TicketCommentDto>>(response);
         Assert.Contains(comments, c => c.Body == "Closed ticket visible note");
     }
 
     [Fact]
     public async Task AddComment_ClosedTicket_Rejected()
     {
-        await using var factory = await TicketCommentApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Closed duplicate rejection");
         await SetTicketStatusAsync(factory, ticket.Id, TicketStatus.Closed);
 
         var response = await AddCommentAsync(supervisor, ticket.Id, "Rejected closed note");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
     }
 
@@ -465,11 +458,11 @@ public sealed class TicketCommentApiTests
             description
         });
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        return await ReadDataAsync<CreateTicketResult>(response);
+        return await OpsSphereSqliteFactory.ReadDataAsync<CreateTicketResult>(response);
     }
 
     private static async Task<Guid> AddTicketDirectlyAsync(
-        TicketCommentApiFactory factory,
+        OpsSphereSqliteFactory factory,
         Guid accountId,
         Guid campaignId,
         Guid customerId,
@@ -531,7 +524,7 @@ public sealed class TicketCommentApiTests
     }
 
     private static async Task AddCommentDirectlyAsync(
-        TicketCommentApiFactory factory,
+        OpsSphereSqliteFactory factory,
         Guid ticketId,
         Guid authorUserId,
         string body,
@@ -557,7 +550,7 @@ public sealed class TicketCommentApiTests
         await db.SaveChangesAsync();
     }
 
-    private static async Task SetTicketStatusAsync(TicketCommentApiFactory factory, Guid ticketId, TicketStatus status)
+    private static async Task SetTicketStatusAsync(OpsSphereSqliteFactory factory, Guid ticketId, TicketStatus status)
     {
         using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
@@ -565,42 +558,6 @@ public sealed class TicketCommentApiTests
         ticket.Status = status;
         await db.SaveChangesAsync();
     }
-
-    private static async Task<HttpClient> CreateAuthenticatedClientAsync(TicketCommentApiFactory factory, string email)
-    {
-        var client = factory.CreateClient();
-        var loginResponse = await client.PostAsJsonAsync("/api/auth/login", new
-        {
-            email,
-            password = OpsSphereSeedData.LocalDemoPassword
-        });
-        loginResponse.EnsureSuccessStatusCode();
-        var loginBody = await ReadResponseAsync<ApiResponse<LoginData>>(loginResponse);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", loginBody.Data.AccessToken);
-        return client;
-    }
-
-    private static async Task<T> ReadDataAsync<T>(HttpResponseMessage response)
-    {
-        var envelope = await ReadResponseAsync<ApiResponse<T>>(response);
-        return envelope.Data;
-    }
-
-    private static async Task<ApiErrorResponse> ReadErrorAsync(HttpResponseMessage response) =>
-        await ReadResponseAsync<ApiErrorResponse>(response);
-
-    private static async Task<T> ReadResponseAsync<T>(HttpResponseMessage response)
-    {
-        var json = await response.Content.ReadAsStringAsync();
-        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
-        return value ?? throw new InvalidOperationException($"Could not deserialize {typeof(T).Name} from {(int)response.StatusCode}: {json}");
-    }
-
-    private sealed record ApiResponse<T>(T Data);
-    private sealed record ApiErrorResponse(ApiError Error);
-    private sealed record ApiError(string Code, string Message, IReadOnlyList<ApiErrorDetail>? Details, string? CorrelationId);
-    private sealed record ApiErrorDetail(string? Field, string Message);
-    private sealed record LoginData(string AccessToken);
 
     private sealed record CreateTicketResult(
         Guid Id,
@@ -627,70 +584,4 @@ public sealed class TicketCommentApiTests
         string AuthorDisplayName,
         string Body,
         DateTime CreatedAt);
-
-    internal sealed class TicketCommentApiFactory : WebApplicationFactory<Program>
-    {
-        public const string JwtSigningKey = "integration-testing-only-fictional-jwt-signing-key";
-
-        private readonly SqliteConnection connection = new("Data Source=:memory:");
-
-        public static async Task<TicketCommentApiFactory> CreateAsync()
-        {
-            ConfigureEnvironment();
-            var factory = new TicketCommentApiFactory();
-            await factory.connection.OpenAsync();
-            await factory.InitializeDatabaseAsync();
-            return factory;
-        }
-
-        protected override void ConfigureWebHost(IWebHostBuilder builder)
-        {
-            builder.UseEnvironment("Testing");
-            builder.ConfigureAppConfiguration((_, config) =>
-            {
-                config.AddInMemoryCollection(new Dictionary<string, string?>
-                {
-                    ["ConnectionStrings:DefaultConnection"] = "Server=(local);Database=OpsSphereTicketCommentTests;Trusted_Connection=True;TrustServerCertificate=True;",
-                    ["SeedData:Enabled"] = "false",
-                    ["Jwt:Issuer"] = "OpsSphere.Tests",
-                    ["Jwt:Audience"] = "OpsSphere.Tests.Angular",
-                    ["Jwt:ExpirationMinutes"] = "60",
-                    ["Jwt:SigningKey"] = JwtSigningKey
-                });
-            });
-            builder.ConfigureTestServices(services =>
-            {
-                services.RemoveAll<IDbContextOptionsConfiguration<OpsSphereDbContext>>();
-                services.RemoveAll<DbContextOptions<OpsSphereDbContext>>();
-                services.AddDbContext<OpsSphereDbContext>(options => options.UseSqlite(connection));
-            });
-        }
-
-        private static void ConfigureEnvironment()
-        {
-            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", "Server=(local);Database=OpsSphereTicketCommentTests;Trusted_Connection=True;TrustServerCertificate=True;");
-            Environment.SetEnvironmentVariable("SeedData__Enabled", "false");
-            Environment.SetEnvironmentVariable("Jwt__Issuer", "OpsSphere.Tests");
-            Environment.SetEnvironmentVariable("Jwt__Audience", "OpsSphere.Tests.Angular");
-            Environment.SetEnvironmentVariable("Jwt__ExpirationMinutes", "60");
-            Environment.SetEnvironmentVariable("Jwt__SigningKey", JwtSigningKey);
-        }
-
-        public override async ValueTask DisposeAsync()
-        {
-            await connection.DisposeAsync();
-            await base.DisposeAsync();
-        }
-
-        private async Task InitializeDatabaseAsync()
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            await dbContext.Database.EnsureDeletedAsync();
-            await dbContext.Database.EnsureCreatedAsync();
-
-            var seeder = scope.ServiceProvider.GetRequiredService<OpsSphereDataSeeder>();
-            await seeder.SeedAsync();
-        }
-    }
 }

--- a/tests/OpsSphere.IntegrationTests/TicketManagement/TicketEscalationApiTests.cs
+++ b/tests/OpsSphere.IntegrationTests/TicketManagement/TicketEscalationApiTests.cs
@@ -1,20 +1,13 @@
-using System.Net;
-using System.Net.Http.Headers;
+﻿using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpsSphere.Domain.Entities;
 using OpsSphere.Domain.Enums;
 using OpsSphere.Infrastructure.Persistence;
 using OpsSphere.Infrastructure.Persistence.SeedData;
+using OpsSphere.IntegrationTests.TestInfrastructure;
 
 namespace OpsSphere.IntegrationTests.TicketManagement;
 
@@ -31,14 +24,14 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task Supervisor_CanEscalate_OpenTicket_Returns200()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Supervisor escalates open");
 
         var response = await EscalateAsync(supervisor, ticket.Id, "Customer impact requires supervisor attention");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<EscalateTicketResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<EscalateTicketResponse>(response);
         Assert.Equal(ticket.Id, result.TicketId);
         Assert.Equal(ticket.TicketNumber, result.TicketNumber);
         Assert.Equal("Open", result.PreviousStatus);
@@ -50,15 +43,15 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task Supervisor_CanEscalate_AssignedTicket_Returns200()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Supervisor escalates assigned");
         await SetTicketStatusAsync(factory, ticket.Id, TicketStatus.Assigned);
 
         var response = await EscalateAsync(supervisor, ticket.Id, "Assigned ticket needs escalation");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<EscalateTicketResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<EscalateTicketResponse>(response);
         Assert.Equal("Assigned", result.PreviousStatus);
         Assert.Equal("Escalated", result.NewStatus);
     }
@@ -66,52 +59,52 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task Supervisor_CanEscalate_InProgressTicket_Returns200()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Supervisor escalates in progress");
         await SetTicketStatusAsync(factory, ticket.Id, TicketStatus.InProgress);
 
         var response = await EscalateAsync(supervisor, ticket.Id, "Investigation needs leadership visibility");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<EscalateTicketResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<EscalateTicketResponse>(response);
         Assert.Equal("InProgress", result.PreviousStatus);
     }
 
     [Fact]
     public async Task Supervisor_CanEscalate_WaitingForCustomerTicket_Returns200()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Supervisor escalates waiting");
         await SetTicketStatusAsync(factory, ticket.Id, TicketStatus.WaitingForCustomer);
 
         var response = await EscalateAsync(supervisor, ticket.Id, "Customer-facing delay needs escalation");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<EscalateTicketResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<EscalateTicketResponse>(response);
         Assert.Equal("WaitingForCustomer", result.PreviousStatus);
     }
 
     [Fact]
     public async Task Agent_CanEscalate_WithinCampaignScope_Returns200()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Agent escalates scoped ticket");
 
         var response = await EscalateAsync(agent, ticket.Id, "Agent needs supervisor support");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<EscalateTicketResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<EscalateTicketResponse>(response);
         Assert.Equal(ticket.Id, result.TicketId);
     }
 
     [Fact]
     public async Task Unauthenticated_CannotEscalate_Returns401()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Anonymous escalation forbidden");
         var anonymous = factory.CreateClient();
 
@@ -123,9 +116,9 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task Admin_CannotEscalate_Returns403()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var admin = await factory.CreateAuthenticatedClientAsync(AdminEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Admin escalation forbidden");
 
         var response = await EscalateAsync(admin, ticket.Id, "Admin reason");
@@ -136,9 +129,9 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task OperationsManager_CannotEscalate_Returns403()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var manager = await CreateAuthenticatedClientAsync(factory, ManagerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var manager = await factory.CreateAuthenticatedClientAsync(ManagerEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Manager escalation forbidden");
 
         var response = await EscalateAsync(manager, ticket.Id, "Manager reason");
@@ -149,9 +142,9 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task Viewer_CannotEscalate_Returns403()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var viewer = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var viewer = await factory.CreateAuthenticatedClientAsync(ViewerEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Viewer escalation forbidden");
 
         var response = await EscalateAsync(viewer, ticket.Id, "Viewer reason");
@@ -162,14 +155,14 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task Escalate_EmptyReason_Returns400_WithValidationError()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Empty reason");
 
         var response = await EscalateAsync(supervisor, ticket.Id, string.Empty);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("validation_error", error.Error.Code);
         Assert.Contains(error.Error.Details ?? [], d => d.Field == "escalationReason");
     }
@@ -177,14 +170,14 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task Escalate_WhitespaceReason_Returns400_WithValidationError()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Whitespace reason");
 
         var response = await EscalateAsync(supervisor, ticket.Id, "   ");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("validation_error", error.Error.Code);
         Assert.Contains(error.Error.Details ?? [], d => d.Field == "escalationReason");
     }
@@ -192,14 +185,14 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task Escalate_TooLongReason_Returns400_WithValidationError()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Long reason");
 
         var response = await EscalateAsync(supervisor, ticket.Id, new string('a', 1001));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("validation_error", error.Error.Code);
         Assert.Contains(error.Error.Details ?? [], d => d.Field == "escalationReason");
     }
@@ -207,8 +200,8 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task Escalate_CrossScopeTicket_Returns404()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var outOfScopeTicketId = await AddTicketDirectlyAsync(
             factory,
             SeedIds.Accounts.Streamly,
@@ -225,15 +218,15 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task Escalate_AlreadyEscalatedTicket_Returns400()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Already escalated");
         await AddEscalationDirectlyAsync(factory, ticket.Id, SeedIds.Users.SupervisorNovabank, "Existing escalation");
 
         var response = await EscalateAsync(supervisor, ticket.Id, "Duplicate escalation");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
         Assert.Contains("already", error.Error.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -241,15 +234,15 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task Escalate_ClosedTicket_Returns400()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Closed escalation");
         await SetTicketStatusAsync(factory, ticket.Id, TicketStatus.Closed);
 
         var response = await EscalateAsync(supervisor, ticket.Id, "Closed ticket reason");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
         Assert.Contains("closed", error.Error.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -257,15 +250,15 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task Escalate_ResolvedTicket_Returns400()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Resolved escalation");
         await SetTicketStatusAsync(factory, ticket.Id, TicketStatus.Resolved);
 
         var response = await EscalateAsync(supervisor, ticket.Id, "Resolved ticket reason");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
         Assert.Contains("resolved", error.Error.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -273,8 +266,8 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task Escalate_UpdatesStatusToEscalated()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Status persistence");
 
         await EscalateAsync(supervisor, ticket.Id, "Persist escalated status");
@@ -286,8 +279,8 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task Escalate_SetsIsEscalatedTrue()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Escalated flag");
 
         await EscalateAsync(supervisor, ticket.Id, "Persist escalated flag");
@@ -299,14 +292,14 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task Escalate_CreatesTicketEscalationRecord()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Escalation record");
 
         var response = await EscalateAsync(supervisor, ticket.Id, "Create escalation record");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<EscalateTicketResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<EscalateTicketResponse>(response);
         using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
         var escalation = await db.TicketEscalations.AsNoTracking().SingleAsync(e => e.Id == result.EscalationId);
@@ -321,14 +314,14 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task Escalate_StoresTrimmedEscalationReason()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Trim escalation reason");
 
         var response = await EscalateAsync(supervisor, ticket.Id, "  Trimmed escalation reason  ");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<EscalateTicketResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<EscalateTicketResponse>(response);
         using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
         var escalation = await db.TicketEscalations.AsNoTracking().SingleAsync(e => e.Id == result.EscalationId);
@@ -338,8 +331,8 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task Escalate_CreatesStatusHistoryRecord()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Escalation status history");
 
         await EscalateAsync(supervisor, ticket.Id, "History reason");
@@ -357,8 +350,8 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task Escalate_CreatesAuditLog_TicketEscalated()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Escalation audit");
 
         await EscalateAsync(supervisor, ticket.Id, "Audit reason");
@@ -377,8 +370,8 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task Escalate_AuditLogDoesNotContainReasonOrPii()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         const string sensitiveSubject = "EscalationSensitiveSubject-ABC123";
         const string sensitiveDescription = "EscalationSensitiveDescription-XYZ987";
         const string sensitiveReason = "EscalationSensitiveReason-SECRET456";
@@ -402,8 +395,8 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task Escalate_AuditLogPropertyShape_IsExpected()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Escalation audit shape");
 
         await EscalateAsync(supervisor, ticket.Id, "Audit shape reason");
@@ -426,8 +419,8 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task EscalationQueue_Supervisor_ReturnsScopedEscalations()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var inScopeTicketId = await AddTicketDirectlyAsync(factory, SeedIds.Accounts.NovaBank, SeedIds.Campaigns.NovaBankCreditCard, SeedIds.Customers.NovaBankCustomer1, TicketStatus.Open, "Supervisor queue scoped");
         var outOfScopeTicketId = await AddTicketDirectlyAsync(factory, SeedIds.Accounts.Shopora, SeedIds.Campaigns.ShoporaAccess, SeedIds.Customers.ShoporaCustomer1, TicketStatus.Open, "Supervisor queue out of scope");
         await AddEscalationDirectlyAsync(factory, inScopeTicketId, SeedIds.Users.SupervisorNovabank, "In-scope supervisor reason");
@@ -436,7 +429,7 @@ public sealed class TicketEscalationApiTests
         var response = await supervisor.GetAsync("/api/tickets/escalations");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var queue = await ReadDataAsync<IReadOnlyList<EscalationQueueItemDto>>(response);
+        var queue = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<EscalationQueueItemDto>>(response);
         Assert.Contains(queue, item => item.TicketId == inScopeTicketId);
         Assert.DoesNotContain(queue, item => item.TicketId == outOfScopeTicketId);
     }
@@ -444,67 +437,67 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task EscalationQueue_OperationsManager_CanViewScopedEscalations()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var manager = await CreateAuthenticatedClientAsync(factory, ManagerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var manager = await factory.CreateAuthenticatedClientAsync(ManagerEmail);
         var ticketId = await AddTicketDirectlyAsync(factory, SeedIds.Accounts.NovaBank, SeedIds.Campaigns.NovaBankCreditCard, SeedIds.Customers.NovaBankCustomer1, TicketStatus.Open, "Manager queue scoped");
         await AddEscalationDirectlyAsync(factory, ticketId, SeedIds.Users.SupervisorNovabank, "Manager visible reason");
 
         var response = await manager.GetAsync("/api/tickets/escalations");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var queue = await ReadDataAsync<IReadOnlyList<EscalationQueueItemDto>>(response);
+        var queue = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<EscalationQueueItemDto>>(response);
         Assert.Contains(queue, item => item.TicketId == ticketId);
     }
 
     [Fact]
     public async Task EscalationQueue_Viewer_CanViewScopedEscalations()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var viewer = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var viewer = await factory.CreateAuthenticatedClientAsync(ViewerEmail);
         var ticketId = await AddTicketDirectlyAsync(factory, SeedIds.Accounts.NovaBank, SeedIds.Campaigns.NovaBankCreditCard, SeedIds.Customers.NovaBankCustomer1, TicketStatus.Open, "Viewer queue scoped");
         await AddEscalationDirectlyAsync(factory, ticketId, SeedIds.Users.SupervisorNovabank, "Viewer visible reason");
 
         var response = await viewer.GetAsync("/api/tickets/escalations");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var queue = await ReadDataAsync<IReadOnlyList<EscalationQueueItemDto>>(response);
+        var queue = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<EscalationQueueItemDto>>(response);
         Assert.Contains(queue, item => item.TicketId == ticketId);
     }
 
     [Fact]
     public async Task EscalationQueue_ExcludesNonEscalatedTickets()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticketId = await AddTicketDirectlyAsync(factory, SeedIds.Accounts.NovaBank, SeedIds.Campaigns.NovaBankCreditCard, SeedIds.Customers.NovaBankCustomer1, TicketStatus.Open, "Queue non-escalated excluded");
 
         var response = await supervisor.GetAsync("/api/tickets/escalations");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var queue = await ReadDataAsync<IReadOnlyList<EscalationQueueItemDto>>(response);
+        var queue = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<EscalationQueueItemDto>>(response);
         Assert.DoesNotContain(queue, item => item.TicketId == ticketId);
     }
 
     [Fact]
     public async Task EscalationQueue_ExcludesOutOfScopeEscalations()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var outOfScopeTicketId = await AddTicketDirectlyAsync(factory, SeedIds.Accounts.Streamly, SeedIds.Campaigns.StreamlyCreator, SeedIds.Customers.StreamlyCustomer1, TicketStatus.Open, "Queue out-of-scope excluded");
         await AddEscalationDirectlyAsync(factory, outOfScopeTicketId, SeedIds.Users.SupervisorNovabank, "Out-of-scope reason");
 
         var response = await supervisor.GetAsync("/api/tickets/escalations");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var queue = await ReadDataAsync<IReadOnlyList<EscalationQueueItemDto>>(response);
+        var queue = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<EscalationQueueItemDto>>(response);
         Assert.DoesNotContain(queue, item => item.TicketId == outOfScopeTicketId);
     }
 
     [Fact]
     public async Task EscalationQueue_ReturnsActiveEscalationsOnly()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var activeTicketId = await AddTicketDirectlyAsync(factory, SeedIds.Accounts.NovaBank, SeedIds.Campaigns.NovaBankCreditCard, SeedIds.Customers.NovaBankCustomer1, TicketStatus.Open, "Active escalation");
         var inactiveTicketId = await AddTicketDirectlyAsync(factory, SeedIds.Accounts.NovaBank, SeedIds.Campaigns.NovaBankCreditCard, SeedIds.Customers.NovaBankCustomer1, TicketStatus.Open, "Inactive escalation");
         await AddEscalationDirectlyAsync(factory, activeTicketId, SeedIds.Users.SupervisorNovabank, "Active reason", isActive: true);
@@ -513,7 +506,7 @@ public sealed class TicketEscalationApiTests
         var response = await supervisor.GetAsync("/api/tickets/escalations");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var queue = await ReadDataAsync<IReadOnlyList<EscalationQueueItemDto>>(response);
+        var queue = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<EscalationQueueItemDto>>(response);
         Assert.Contains(queue, item => item.TicketId == activeTicketId);
         Assert.DoesNotContain(queue, item => item.TicketId == inactiveTicketId);
     }
@@ -521,8 +514,8 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task EscalationQueue_SortedNewestFirst()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var olderTicketId = await AddTicketDirectlyAsync(factory, SeedIds.Accounts.NovaBank, SeedIds.Campaigns.NovaBankCreditCard, SeedIds.Customers.NovaBankCustomer1, TicketStatus.Open, "Older escalation");
         var newerTicketId = await AddTicketDirectlyAsync(factory, SeedIds.Accounts.NovaBank, SeedIds.Campaigns.NovaBankCreditCard, SeedIds.Customers.NovaBankCustomer1, TicketStatus.Open, "Newer escalation");
         await AddEscalationDirectlyAsync(factory, olderTicketId, SeedIds.Users.SupervisorNovabank, "Older reason", DateTime.UtcNow.AddMinutes(-10));
@@ -531,7 +524,7 @@ public sealed class TicketEscalationApiTests
         var response = await supervisor.GetAsync("/api/tickets/escalations");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var queue = await ReadDataAsync<IReadOnlyList<EscalationQueueItemDto>>(response);
+        var queue = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<EscalationQueueItemDto>>(response);
         Assert.True(queue.Count >= 2);
         Assert.Equal(newerTicketId, queue[0].TicketId);
         Assert.Equal(olderTicketId, queue[1].TicketId);
@@ -540,8 +533,8 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task EscalationQueue_IncludesEscalationReason()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         const string reason = "Queue should show operational escalation reason";
         var ticketId = await AddTicketDirectlyAsync(factory, SeedIds.Accounts.NovaBank, SeedIds.Campaigns.NovaBankCreditCard, SeedIds.Customers.NovaBankCustomer1, TicketStatus.Open, "Queue reason included");
         await AddEscalationDirectlyAsync(factory, ticketId, SeedIds.Users.SupervisorNovabank, reason);
@@ -549,7 +542,7 @@ public sealed class TicketEscalationApiTests
         var response = await supervisor.GetAsync("/api/tickets/escalations");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var queue = await ReadDataAsync<IReadOnlyList<EscalationQueueItemDto>>(response);
+        var queue = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<EscalationQueueItemDto>>(response);
         var item = Assert.Single(queue, i => i.TicketId == ticketId);
         Assert.Equal(reason, item.EscalationReason);
         Assert.Equal("Lina Calderon", item.EscalatedByName);
@@ -560,15 +553,15 @@ public sealed class TicketEscalationApiTests
     [Fact]
     public async Task Escalate_BusinessRuleError_UsesCanonicalEnvelope()
     {
-        await using var factory = await TicketEscalationApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Escalation canonical envelope");
         await AddEscalationDirectlyAsync(factory, ticket.Id, SeedIds.Users.SupervisorNovabank, "Existing escalation");
 
         var response = await EscalateAsync(supervisor, ticket.Id, "Duplicate reason");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
         Assert.False(string.IsNullOrWhiteSpace(error.Error.Message));
         Assert.False(string.IsNullOrWhiteSpace(error.Error.CorrelationId));
@@ -620,11 +613,11 @@ public sealed class TicketEscalationApiTests
             description
         });
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        return await ReadDataAsync<CreateTicketResult>(response);
+        return await OpsSphereSqliteFactory.ReadDataAsync<CreateTicketResult>(response);
     }
 
     private static async Task<Guid> AddTicketDirectlyAsync(
-        TicketEscalationApiFactory factory,
+        OpsSphereSqliteFactory factory,
         Guid accountId,
         Guid campaignId,
         Guid customerId,
@@ -686,7 +679,7 @@ public sealed class TicketEscalationApiTests
     }
 
     private static async Task<Guid> AddEscalationDirectlyAsync(
-        TicketEscalationApiFactory factory,
+        OpsSphereSqliteFactory factory,
         Guid ticketId,
         Guid escalatedByUserId,
         string escalationReason,
@@ -718,7 +711,7 @@ public sealed class TicketEscalationApiTests
         return escalationId;
     }
 
-    private static async Task SetTicketStatusAsync(TicketEscalationApiFactory factory, Guid ticketId, TicketStatus status)
+    private static async Task SetTicketStatusAsync(OpsSphereSqliteFactory factory, Guid ticketId, TicketStatus status)
     {
         using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
@@ -728,14 +721,14 @@ public sealed class TicketEscalationApiTests
         await db.SaveChangesAsync();
     }
 
-    private static async Task<Ticket> GetTicketAsync(TicketEscalationApiFactory factory, Guid ticketId)
+    private static async Task<Ticket> GetTicketAsync(OpsSphereSqliteFactory factory, Guid ticketId)
     {
         using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
         return await db.Tickets.AsNoTracking().SingleAsync(t => t.Id == ticketId);
     }
 
-    private static async Task<string> GetAuditPayloadAsync(TicketEscalationApiFactory factory, Guid ticketId)
+    private static async Task<string> GetAuditPayloadAsync(OpsSphereSqliteFactory factory, Guid ticketId)
     {
         using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
@@ -745,42 +738,6 @@ public sealed class TicketEscalationApiTests
 
         return $"{audit.PreviousValue}{audit.NewValue}";
     }
-
-    private static async Task<HttpClient> CreateAuthenticatedClientAsync(TicketEscalationApiFactory factory, string email)
-    {
-        var client = factory.CreateClient();
-        var loginResponse = await client.PostAsJsonAsync("/api/auth/login", new
-        {
-            email,
-            password = OpsSphereSeedData.LocalDemoPassword
-        });
-        loginResponse.EnsureSuccessStatusCode();
-        var loginBody = await ReadResponseAsync<ApiResponse<LoginData>>(loginResponse);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", loginBody.Data.AccessToken);
-        return client;
-    }
-
-    private static async Task<T> ReadDataAsync<T>(HttpResponseMessage response)
-    {
-        var envelope = await ReadResponseAsync<ApiResponse<T>>(response);
-        return envelope.Data;
-    }
-
-    private static async Task<ApiErrorResponse> ReadErrorAsync(HttpResponseMessage response) =>
-        await ReadResponseAsync<ApiErrorResponse>(response);
-
-    private static async Task<T> ReadResponseAsync<T>(HttpResponseMessage response)
-    {
-        var json = await response.Content.ReadAsStringAsync();
-        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
-        return value ?? throw new InvalidOperationException($"Could not deserialize {typeof(T).Name} from {(int)response.StatusCode}: {json}");
-    }
-
-    private sealed record ApiResponse<T>(T Data);
-    private sealed record ApiErrorResponse(ApiError Error);
-    private sealed record ApiError(string Code, string Message, IReadOnlyList<ApiErrorDetail>? Details, string? CorrelationId);
-    private sealed record ApiErrorDetail(string? Field, string Message);
-    private sealed record LoginData(string AccessToken);
 
     private sealed record CreateTicketResult(
         Guid Id,
@@ -812,70 +769,4 @@ public sealed class TicketEscalationApiTests
         Guid EscalatedByUserId,
         string EscalatedByName,
         string EscalationReason);
-
-    internal sealed class TicketEscalationApiFactory : WebApplicationFactory<Program>
-    {
-        public const string JwtSigningKey = "integration-testing-only-fictional-jwt-signing-key";
-
-        private readonly SqliteConnection connection = new("Data Source=:memory:");
-
-        public static async Task<TicketEscalationApiFactory> CreateAsync()
-        {
-            ConfigureEnvironment();
-            var factory = new TicketEscalationApiFactory();
-            await factory.connection.OpenAsync();
-            await factory.InitializeDatabaseAsync();
-            return factory;
-        }
-
-        protected override void ConfigureWebHost(IWebHostBuilder builder)
-        {
-            builder.UseEnvironment("Testing");
-            builder.ConfigureAppConfiguration((_, config) =>
-            {
-                config.AddInMemoryCollection(new Dictionary<string, string?>
-                {
-                    ["ConnectionStrings:DefaultConnection"] = "Server=(local);Database=OpsSphereTicketEscalationTests;Trusted_Connection=True;TrustServerCertificate=True;",
-                    ["SeedData:Enabled"] = "false",
-                    ["Jwt:Issuer"] = "OpsSphere.Tests",
-                    ["Jwt:Audience"] = "OpsSphere.Tests.Angular",
-                    ["Jwt:ExpirationMinutes"] = "60",
-                    ["Jwt:SigningKey"] = JwtSigningKey
-                });
-            });
-            builder.ConfigureTestServices(services =>
-            {
-                services.RemoveAll<IDbContextOptionsConfiguration<OpsSphereDbContext>>();
-                services.RemoveAll<DbContextOptions<OpsSphereDbContext>>();
-                services.AddDbContext<OpsSphereDbContext>(options => options.UseSqlite(connection));
-            });
-        }
-
-        private static void ConfigureEnvironment()
-        {
-            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", "Server=(local);Database=OpsSphereTicketEscalationTests;Trusted_Connection=True;TrustServerCertificate=True;");
-            Environment.SetEnvironmentVariable("SeedData__Enabled", "false");
-            Environment.SetEnvironmentVariable("Jwt__Issuer", "OpsSphere.Tests");
-            Environment.SetEnvironmentVariable("Jwt__Audience", "OpsSphere.Tests.Angular");
-            Environment.SetEnvironmentVariable("Jwt__ExpirationMinutes", "60");
-            Environment.SetEnvironmentVariable("Jwt__SigningKey", JwtSigningKey);
-        }
-
-        public override async ValueTask DisposeAsync()
-        {
-            await connection.DisposeAsync();
-            await base.DisposeAsync();
-        }
-
-        private async Task InitializeDatabaseAsync()
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            await dbContext.Database.EnsureDeletedAsync();
-            await dbContext.Database.EnsureCreatedAsync();
-
-            var seeder = scope.ServiceProvider.GetRequiredService<OpsSphereDataSeeder>();
-            await seeder.SeedAsync();
-        }
-    }
 }

--- a/tests/OpsSphere.IntegrationTests/TicketManagement/TicketLifecycleGapsApiTests.cs
+++ b/tests/OpsSphere.IntegrationTests/TicketManagement/TicketLifecycleGapsApiTests.cs
@@ -1,0 +1,236 @@
+using System.Net;
+using System.Net.Http.Json;
+using OpsSphere.Infrastructure.Persistence.SeedData;
+using OpsSphere.IntegrationTests.TestInfrastructure;
+
+namespace OpsSphere.IntegrationTests.TicketManagement;
+
+public sealed class TicketLifecycleGapsApiTests
+{
+    private const string AgentEmail = "agent.novabank@opssphere.local";
+    private const string SupervisorEmail = "supervisor.novabank@opssphere.local";
+    private const string ViewerEmail = "viewer.latam@opssphere.local";
+
+    [Fact]
+    public async Task UpdatePriority_Supervisor_CanChangePriority_Returns200()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+
+        var created = await CreateTicketAsync(supervisor);
+        var response = await supervisor.PutAsJsonAsync($"/api/tickets/{created.Id}/priority", new
+        {
+            priority = "High",
+            changeReason = "Escalating priority for test"
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<UpdateTicketPriorityResponse>(response);
+        Assert.Equal("Normal", result.PreviousPriority);
+        Assert.Equal("High", result.NewPriority);
+    }
+
+    [Fact]
+    public async Task UpdatePriority_Agent_CanChangePriority_Returns200()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
+
+        var created = await CreateTicketAsync(agent);
+        var response = await agent.PutAsJsonAsync($"/api/tickets/{created.Id}/priority", new
+        {
+            priority = "Critical",
+            changeReason = "Critical escalation for test"
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<UpdateTicketPriorityResponse>(response);
+        Assert.Equal("Critical", result.NewPriority);
+    }
+
+    [Fact]
+    public async Task UpdatePriority_Viewer_Returns403()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
+        var viewer = await factory.CreateAuthenticatedClientAsync(ViewerEmail);
+
+        var created = await CreateTicketAsync(agent);
+        var response = await viewer.PutAsJsonAsync($"/api/tickets/{created.Id}/priority", new
+        {
+            priority = "High",
+            changeReason = "Viewer attempt"
+        });
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdatePriority_WithInvalidPriority_Returns400()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
+
+        var created = await CreateTicketAsync(agent);
+        var response = await agent.PutAsJsonAsync($"/api/tickets/{created.Id}/priority", new
+        {
+            priority = "Urgent",
+            changeReason = "Invalid priority test"
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
+        Assert.Equal("validation_error", error.Error.Code);
+    }
+
+    [Fact]
+    public async Task GetEscalationQueue_WithoutAuth_Returns401()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+
+        var response = await factory.CreateClient().GetAsync("/api/tickets/escalations");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetEscalationQueue_Supervisor_ReturnsSeededEscalation()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+
+        var response = await supervisor.GetAsync("/api/tickets/escalations");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var items = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<EscalationQueueItemDto>>(response);
+        Assert.NotEmpty(items);
+        Assert.Contains(items, item => item.TicketId == SeedIds.Tickets.NovaBankEscalated);
+    }
+
+    [Fact]
+    public async Task GetEscalationQueue_Agent_ReturnsOnly_CampaignScopedEscalations()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
+
+        var response = await agent.GetAsync("/api/tickets/escalations");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var items = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<EscalationQueueItemDto>>(response);
+        Assert.All(items, item => Assert.Equal("Credit Card Support", item.CampaignName));
+    }
+
+    [Fact]
+    public async Task GetTicketHistory_WithoutAuth_Returns401()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+
+        var response = await factory.CreateClient().GetAsync($"/api/tickets/{SeedIds.Tickets.NovaBankOpen}/history");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetTicketHistory_ReturnsSeededHistoryForOpenTicket()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
+
+        var response = await agent.GetAsync($"/api/tickets/{SeedIds.Tickets.NovaBankOpen}/history");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var history = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<TicketStatusHistoryItemDto>>(response);
+        Assert.NotEmpty(history);
+        Assert.Contains(history, h => h.NewStatus == "Open");
+    }
+
+    [Fact]
+    public async Task GetTicketHistory_AfterStatusUpdate_IncludesNewEntry()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+
+        var created = await CreateTicketAsync(supervisor);
+        var assignResponse = await supervisor.PostAsJsonAsync($"/api/tickets/{created.Id}/assign", new
+        {
+            targetAgentUserId = SeedIds.Users.AgentNovabank,
+            reassignmentReason = (string?)null
+        });
+        assignResponse.EnsureSuccessStatusCode();
+
+        var historyResponse = await supervisor.GetAsync($"/api/tickets/{created.Id}/history");
+        Assert.Equal(HttpStatusCode.OK, historyResponse.StatusCode);
+        var history = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<TicketStatusHistoryItemDto>>(historyResponse);
+
+        Assert.True(history.Count >= 2);
+        Assert.Contains(history, h => h.NewStatus == "Open");
+        Assert.Contains(history, h => h.NewStatus == "Assigned");
+    }
+
+    [Fact]
+    public async Task GetTicketComments_WithoutAuth_Returns401()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+
+        var response = await factory.CreateClient().GetAsync($"/api/tickets/{SeedIds.Tickets.NovaBankInProgress}/comments");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetTicketComments_ReturnsSeededCommentForInProgressTicket()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+
+        var response = await supervisor.GetAsync($"/api/tickets/{SeedIds.Tickets.NovaBankInProgress}/comments");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var comments = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<TicketCommentDto>>(response);
+        Assert.NotEmpty(comments);
+        Assert.All(comments, c => Assert.Equal(SeedIds.Tickets.NovaBankInProgress, c.TicketId));
+    }
+
+    [Fact]
+    public async Task GetTicketComments_AfterAddComment_IncludesNewComment()
+    {
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+
+        var created = await CreateTicketAsync(supervisor);
+        var addResponse = await supervisor.PostAsJsonAsync($"/api/tickets/{created.Id}/comments", new
+        {
+            body = "Lifecycle gap test comment body"
+        });
+        addResponse.EnsureSuccessStatusCode();
+
+        var getResponse = await supervisor.GetAsync($"/api/tickets/{created.Id}/comments");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        var comments = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<TicketCommentDto>>(getResponse);
+
+        Assert.Single(comments);
+        Assert.Equal("Lifecycle gap test comment body", comments[0].Body);
+    }
+
+    private static async Task<CreateTicketResult> CreateTicketAsync(HttpClient client)
+    {
+        var response = await client.PostAsJsonAsync("/api/tickets", new
+        {
+            customerId = SeedIds.Customers.NovaBankCustomer1,
+            accountId = SeedIds.Accounts.NovaBank,
+            campaignId = SeedIds.Campaigns.NovaBankCreditCard,
+            category = "Support",
+            priority = "Normal",
+            subject = "Lifecycle gap test ticket",
+            description = "Testing lifecycle gaps in integration coverage"
+        });
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        return await OpsSphereSqliteFactory.ReadDataAsync<CreateTicketResult>(response);
+    }
+
+    private sealed record CreateTicketResult(Guid Id, string TicketNumber, string Status, string Priority);
+    private sealed record UpdateTicketPriorityResponse(Guid TicketId, string TicketNumber, string PreviousPriority, string NewPriority, string Message);
+    private sealed record EscalationQueueItemDto(Guid EscalationId, Guid TicketId, string TicketNumber, string CustomerName, string AccountName, string CampaignName, string Priority, string Status, string SlaState, DateTime EscalatedAt, Guid EscalatedByUserId, string EscalatedByName, string EscalationReason);
+    private sealed record TicketStatusHistoryItemDto(Guid Id, Guid TicketId, string? PreviousStatus, string NewStatus, Guid ChangedByUserId, string? ChangeReason, DateTime CreatedAt);
+    private sealed record TicketCommentDto(Guid Id, Guid TicketId, Guid AuthorUserId, string AuthorDisplayName, string Body, DateTime CreatedAt);
+}

--- a/tests/OpsSphere.IntegrationTests/TicketManagement/TicketManagementApiTests.cs
+++ b/tests/OpsSphere.IntegrationTests/TicketManagement/TicketManagementApiTests.cs
@@ -1,18 +1,11 @@
-using System.Net;
-using System.Net.Http.Headers;
+﻿using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpsSphere.Infrastructure.Persistence;
 using OpsSphere.Infrastructure.Persistence.SeedData;
+using OpsSphere.IntegrationTests.TestInfrastructure;
 
 namespace OpsSphere.IntegrationTests.TicketManagement;
 
@@ -30,8 +23,8 @@ public sealed class TicketManagementApiTests
     [Fact]
     public async Task Agent_CanCreateTicket_Returns201_WithTicketNumber()
     {
-        await using var factory = await TicketApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var response = await PostTicketAsync(agent,
             customerId: SeedIds.Customers.NovaBankCustomer1,
@@ -44,7 +37,7 @@ public sealed class TicketManagementApiTests
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
-        var result = await ReadDataAsync<CreateTicketResult>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<CreateTicketResult>(response);
         Assert.Equal("Open", result.Status);
         Assert.Matches(@"^OPS-\d{8}-\d{6}$", result.TicketNumber);
     }
@@ -52,8 +45,8 @@ public sealed class TicketManagementApiTests
     [Fact]
     public async Task Supervisor_CanCreateTicket_WithinAccountScope_Returns201()
     {
-        await using var factory = await TicketApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
 
         // Supervisor has NOVABANK account scope — NovaBankFraud is within scope
         var response = await PostTicketAsync(supervisor,
@@ -67,15 +60,15 @@ public sealed class TicketManagementApiTests
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
-        var result = await ReadDataAsync<CreateTicketResult>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<CreateTicketResult>(response);
         Assert.Equal("Open", result.Status);
     }
 
     [Fact]
     public async Task Admin_CannotCreateTicket_Returns403()
     {
-        await using var factory = await TicketApiFactory.CreateAsync();
-        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var admin = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var response = await PostTicketAsync(admin,
             customerId: SeedIds.Customers.NovaBankCustomer1,
@@ -92,8 +85,8 @@ public sealed class TicketManagementApiTests
     [Fact]
     public async Task Viewer_CannotCreateTicket_Returns403()
     {
-        await using var factory = await TicketApiFactory.CreateAsync();
-        var viewer = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var viewer = await factory.CreateAuthenticatedClientAsync(ViewerEmail);
 
         var response = await PostTicketAsync(viewer,
             customerId: SeedIds.Customers.NovaBankCustomer1,
@@ -112,8 +105,8 @@ public sealed class TicketManagementApiTests
     [Fact]
     public async Task CreateTicket_MissingRequiredFields_Returns400_WithFieldErrors()
     {
-        await using var factory = await TicketApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var response = await agent.PostAsJsonAsync("/api/tickets", new
         {
@@ -127,7 +120,7 @@ public sealed class TicketManagementApiTests
         });
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("validation_error", error.Error.Code);
         Assert.Contains(error.Error.Details, d => d.Field == "category");
         Assert.Contains(error.Error.Details, d => d.Field == "subject");
@@ -138,8 +131,8 @@ public sealed class TicketManagementApiTests
     [Fact]
     public async Task CreateTicket_InvalidPriority_Returns400()
     {
-        await using var factory = await TicketApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var response = await agent.PostAsJsonAsync("/api/tickets", new
         {
@@ -153,7 +146,7 @@ public sealed class TicketManagementApiTests
         });
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("validation_error", error.Error.Code);
         Assert.Contains(error.Error.Details, d => d.Field == "priority");
     }
@@ -161,8 +154,8 @@ public sealed class TicketManagementApiTests
     [Fact]
     public async Task CreateTicket_EmptyCampaignId_Returns400()
     {
-        await using var factory = await TicketApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var response = await agent.PostAsJsonAsync("/api/tickets", new
         {
@@ -176,7 +169,7 @@ public sealed class TicketManagementApiTests
         });
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("validation_error", error.Error.Code);
         Assert.Contains(error.Error.Details, d => d.Field == "campaignId");
     }
@@ -186,8 +179,8 @@ public sealed class TicketManagementApiTests
     [Fact]
     public async Task CreateTicket_CrossAccountCustomer_Returns400()
     {
-        await using var factory = await TicketApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         // StreamlyCustomer1 belongs to STREAMLY, but NovaBankCreditCard is under NOVABANK
         var response = await PostTicketAsync(agent,
@@ -200,7 +193,7 @@ public sealed class TicketManagementApiTests
             description: "StreamlyCustomer1 does not belong to the NovaBank campaign account");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("validation_error", error.Error.Code);
         Assert.Contains(error.Error.Details, d => d.Field == "customerId");
     }
@@ -208,10 +201,10 @@ public sealed class TicketManagementApiTests
     [Fact]
     public async Task CreateTicket_OutOfScopeCampaign_Returns404()
     {
-        await using var factory = await TicketApiFactory.CreateAsync();
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
         // Agent has campaign scope NOVABANK-CC only; NovaBankFraud is a different campaign in the same account
         // but the agent's scope is campaign-level, not account-level, so NovaBankFraud is out of scope
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var response = await PostTicketAsync(agent,
             customerId: SeedIds.Customers.NovaBankCustomer1,
@@ -231,8 +224,8 @@ public sealed class TicketManagementApiTests
     [Fact]
     public async Task CreatedTicket_HasStatus_Open()
     {
-        await using var factory = await TicketApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var created = await CreateTicketAsync(agent,
             customerId: SeedIds.Customers.NovaBankCustomer1,
@@ -246,15 +239,15 @@ public sealed class TicketManagementApiTests
         var getResponse = await agent.GetAsync($"/api/tickets/{created.Id}");
         Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
 
-        var detail = await ReadDataAsync<TicketDetailDto>(getResponse);
+        var detail = await OpsSphereSqliteFactory.ReadDataAsync<TicketDetailDto>(getResponse);
         Assert.Equal("Open", detail.Status);
     }
 
     [Fact]
     public async Task CreatedTicket_HasSlaState_WithinSla_AndSlaDueAt_Set()
     {
-        await using var factory = await TicketApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var created = await CreateTicketAsync(agent,
             customerId: SeedIds.Customers.NovaBankCustomer1,
@@ -271,7 +264,7 @@ public sealed class TicketManagementApiTests
 
         // Also verify via GET detail endpoint
         var getResponse = await agent.GetAsync($"/api/tickets/{created.Id}");
-        var detail = await ReadDataAsync<TicketDetailDto>(getResponse);
+        var detail = await OpsSphereSqliteFactory.ReadDataAsync<TicketDetailDto>(getResponse);
         Assert.Equal("WithinSla", detail.SlaState);
         Assert.NotNull(detail.SlaDueAt);
     }
@@ -279,8 +272,8 @@ public sealed class TicketManagementApiTests
     [Fact]
     public async Task CreatedTicket_HasInitialStatusHistoryRow()
     {
-        await using var factory = await TicketApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var created = await CreateTicketAsync(agent,
             customerId: SeedIds.Customers.NovaBankCustomer1,
@@ -306,8 +299,8 @@ public sealed class TicketManagementApiTests
     [Fact]
     public async Task CreatedTicket_HasTicketSlaStateRow()
     {
-        await using var factory = await TicketApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var created = await CreateTicketAsync(agent,
             customerId: SeedIds.Customers.NovaBankCustomer1,
@@ -334,8 +327,8 @@ public sealed class TicketManagementApiTests
     [Fact]
     public async Task GetTickets_SlaStateFilter_UsesRequestTimeEvaluation()
     {
-        await using var factory = await TicketApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var created = await CreateTicketAsync(agent,
             customerId: SeedIds.Customers.NovaBankCustomer1,
@@ -361,7 +354,7 @@ public sealed class TicketManagementApiTests
         var listResponse = await agent.GetAsync("/api/tickets?slaState=AtRisk");
         Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
 
-        var tickets = await ReadDataAsync<IReadOnlyList<TicketListItemDto>>(listResponse);
+        var tickets = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<TicketListItemDto>>(listResponse);
         var ticket = Assert.Single(tickets, t => t.Id == created.Id);
         Assert.Equal("AtRisk", ticket.SlaState);
     }
@@ -369,8 +362,8 @@ public sealed class TicketManagementApiTests
     [Fact]
     public async Task GetSlaSummary_ReturnsScopedEvaluatedCounts()
     {
-        await using var factory = await TicketApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var created = await CreateTicketAsync(agent,
             customerId: SeedIds.Customers.NovaBankCustomer1,
@@ -394,15 +387,15 @@ public sealed class TicketManagementApiTests
         var response = await agent.GetAsync("/api/sla/summary");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        var summary = await ReadDataAsync<SlaSummaryDto>(response);
+        var summary = await OpsSphereSqliteFactory.ReadDataAsync<SlaSummaryDto>(response);
         Assert.Equal(3, summary.BreachedCount);
     }
 
     [Fact]
     public async Task CreatedTicket_HasAuditLog_WithAction_TicketCreated()
     {
-        await using var factory = await TicketApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var created = await CreateTicketAsync(agent,
             customerId: SeedIds.Customers.NovaBankCustomer1,
@@ -419,8 +412,8 @@ public sealed class TicketManagementApiTests
     [Fact]
     public async Task AuditLog_DoesNotContain_TicketDescription_OrPii()
     {
-        await using var factory = await TicketApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         const string sensitiveDescription = "SensitiveDescription-PiiTestValue-XYZ987";
         const string sensitiveSubject = "SensitiveSubject-PiiTestValue-ABC123";
@@ -459,8 +452,8 @@ public sealed class TicketManagementApiTests
     [Fact]
     public async Task GetTickets_ScopedAgent_ReturnsOnly_CampaignTickets()
     {
-        await using var factory = await TicketApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         // Create a ticket in the agent's campaign scope
         var created = await CreateTicketAsync(agent,
@@ -475,7 +468,7 @@ public sealed class TicketManagementApiTests
         var listResponse = await agent.GetAsync("/api/tickets");
         Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
 
-        var tickets = await ReadDataAsync<IReadOnlyList<TicketListItemDto>>(listResponse);
+        var tickets = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<TicketListItemDto>>(listResponse);
         Assert.NotEmpty(tickets);
         Assert.Contains(tickets, t => t.Id == created.Id);
 
@@ -486,9 +479,9 @@ public sealed class TicketManagementApiTests
     [Fact]
     public async Task GetTicket_CrossScope_Returns404()
     {
-        await using var factory = await TicketApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
 
         // Supervisor creates a ticket in NovaBankFraud (not visible to agent with NOVABANK-CC scope)
         var created = await CreateTicketAsync(supervisor,
@@ -508,8 +501,8 @@ public sealed class TicketManagementApiTests
     [Fact]
     public async Task GetTickets_ReturnsEnvelopePattern()
     {
-        await using var factory = await TicketApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var response = await agent.GetAsync("/api/tickets");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -524,8 +517,8 @@ public sealed class TicketManagementApiTests
     [Fact]
     public async Task TwoTickets_HaveDifferentTicketNumbers()
     {
-        await using var factory = await TicketApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var first = await CreateTicketAsync(agent,
             customerId: SeedIds.Customers.NovaBankCustomer1,
@@ -574,46 +567,10 @@ public sealed class TicketManagementApiTests
     {
         var response = await PostTicketAsync(client, customerId, accountId, campaignId, category, priority, subject, description);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        return await ReadDataAsync<CreateTicketResult>(response);
+        return await OpsSphereSqliteFactory.ReadDataAsync<CreateTicketResult>(response);
     }
 
-    private static async Task<HttpClient> CreateAuthenticatedClientAsync(TicketApiFactory factory, string email)
-    {
-        var client = factory.CreateClient();
-        var loginResponse = await client.PostAsJsonAsync("/api/auth/login", new
-        {
-            email,
-            password = OpsSphereSeedData.LocalDemoPassword
-        });
-        loginResponse.EnsureSuccessStatusCode();
-        var loginBody = await ReadResponseAsync<ApiResponse<LoginData>>(loginResponse);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", loginBody.Data.AccessToken);
-        return client;
-    }
-
-    private static async Task<T> ReadDataAsync<T>(HttpResponseMessage response)
-    {
-        var envelope = await ReadResponseAsync<ApiResponse<T>>(response);
-        return envelope.Data;
-    }
-
-    private static async Task<ApiErrorResponse> ReadErrorAsync(HttpResponseMessage response) =>
-        await ReadResponseAsync<ApiErrorResponse>(response);
-
-    private static async Task<T> ReadResponseAsync<T>(HttpResponseMessage response)
-    {
-        var json = await response.Content.ReadAsStringAsync();
-        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
-        return value ?? throw new InvalidOperationException($"Could not deserialize {typeof(T).Name} from {(int)response.StatusCode}: {json}");
-    }
-
-    // ─── Response records ─────────────────────────────────────────────────────
-
-    private sealed record ApiResponse<T>(T Data);
-    private sealed record ApiErrorResponse(ApiError Error);
-    private sealed record ApiError(string Code, string Message, IReadOnlyList<ApiErrorDetail> Details);
-    private sealed record ApiErrorDetail(string? Field, string Message);
-    private sealed record LoginData(string AccessToken);
+// ─── Response records ─────────────────────────────────────────────────────
 
     private sealed record CreateTicketResult(
         Guid Id,
@@ -663,89 +620,4 @@ public sealed class TicketManagementApiTests
         int CompletedCount);
 
     // ─── Factory ──────────────────────────────────────────────────────────────
-
-    internal sealed class TicketApiFactory : WebApplicationFactory<Program>
-    {
-        public const string JwtSigningKey = "integration-testing-only-fictional-jwt-signing-key";
-
-        private readonly SqliteConnection connection = new("Data Source=:memory:");
-
-        public static async Task<TicketApiFactory> CreateAsync()
-        {
-            ConfigureEnvironment();
-            var factory = new TicketApiFactory();
-            await factory.connection.OpenAsync();
-            await factory.InitializeDatabaseAsync();
-            return factory;
-        }
-
-        public async Task AssertAuditAsync(string action, string entityType, Guid entityId)
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-
-            var audit = await dbContext.AuditLogs
-                .AsNoTracking()
-                .Where(log => log.Action == action && log.EntityType == entityType && log.EntityId == entityId)
-                .OrderByDescending(log => log.CreatedAt)
-                .FirstOrDefaultAsync();
-
-            Assert.NotNull(audit);
-            Assert.False(string.IsNullOrWhiteSpace(audit.CorrelationId));
-            Assert.DoesNotContain("password", audit.PreviousValue ?? string.Empty, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain("password", audit.NewValue ?? string.Empty, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain(JwtSigningKey, audit.PreviousValue ?? string.Empty, StringComparison.Ordinal);
-            Assert.DoesNotContain(JwtSigningKey, audit.NewValue ?? string.Empty, StringComparison.Ordinal);
-        }
-
-        protected override void ConfigureWebHost(IWebHostBuilder builder)
-        {
-            builder.UseEnvironment("Testing");
-            builder.ConfigureAppConfiguration((_, config) =>
-            {
-                config.AddInMemoryCollection(new Dictionary<string, string?>
-                {
-                    ["ConnectionStrings:DefaultConnection"] = "Server=(local);Database=OpsSphereTicketTests;Trusted_Connection=True;TrustServerCertificate=True;",
-                    ["SeedData:Enabled"] = "false",
-                    ["Jwt:Issuer"] = "OpsSphere.Tests",
-                    ["Jwt:Audience"] = "OpsSphere.Tests.Angular",
-                    ["Jwt:ExpirationMinutes"] = "60",
-                    ["Jwt:SigningKey"] = JwtSigningKey
-                });
-            });
-            builder.ConfigureTestServices(services =>
-            {
-                services.RemoveAll<IDbContextOptionsConfiguration<OpsSphereDbContext>>();
-                services.RemoveAll<DbContextOptions<OpsSphereDbContext>>();
-                services.AddDbContext<OpsSphereDbContext>(options => options.UseSqlite(connection));
-            });
-        }
-
-        private static void ConfigureEnvironment()
-        {
-            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", "Server=(local);Database=OpsSphereTicketTests;Trusted_Connection=True;TrustServerCertificate=True;");
-            Environment.SetEnvironmentVariable("SeedData__Enabled", "false");
-            Environment.SetEnvironmentVariable("Jwt__Issuer", "OpsSphere.Tests");
-            Environment.SetEnvironmentVariable("Jwt__Audience", "OpsSphere.Tests.Angular");
-            Environment.SetEnvironmentVariable("Jwt__ExpirationMinutes", "60");
-            Environment.SetEnvironmentVariable("Jwt__SigningKey", JwtSigningKey);
-        }
-
-        public override async ValueTask DisposeAsync()
-        {
-            await connection.DisposeAsync();
-            await base.DisposeAsync();
-        }
-
-        private async Task InitializeDatabaseAsync()
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            await dbContext.Database.EnsureDeletedAsync();
-            await dbContext.Database.EnsureCreatedAsync();
-
-            var seeder = scope.ServiceProvider.GetRequiredService<OpsSphereDataSeeder>();
-            await seeder.SeedAsync();
-        }
-    }
 }

--- a/tests/OpsSphere.IntegrationTests/TicketManagement/TicketResolveCloseApiTests.cs
+++ b/tests/OpsSphere.IntegrationTests/TicketManagement/TicketResolveCloseApiTests.cs
@@ -1,20 +1,13 @@
-using System.Net;
-using System.Net.Http.Headers;
+﻿using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpsSphere.Domain.Entities;
 using OpsSphere.Domain.Enums;
 using OpsSphere.Infrastructure.Persistence;
 using OpsSphere.Infrastructure.Persistence.SeedData;
+using OpsSphere.IntegrationTests.TestInfrastructure;
 
 namespace OpsSphere.IntegrationTests.TicketManagement;
 
@@ -35,14 +28,14 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Supervisor_CanResolve_OpenTicket_Returns200()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Supervisor resolves open");
 
         var response = await ResolveAsync(supervisor, ticket.Id, "Issue confirmed and resolved.", null);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<ResolveTicketResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<ResolveTicketResponse>(response);
         Assert.Equal(ticket.Id, result.TicketId);
         Assert.Equal(ticket.TicketNumber, result.TicketNumber);
         Assert.Equal("Open", result.PreviousStatus);
@@ -55,23 +48,23 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Agent_CanResolve_WithinScope_Returns200()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Agent resolves ticket");
 
         var response = await ResolveAsync(agent, ticket.Id, "Agent resolution summary.", null);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<ResolveTicketResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<ResolveTicketResponse>(response);
         Assert.Equal("Resolved", result.NewStatus);
     }
 
     [Fact]
     public async Task OperationsManager_CannotResolve_Returns403()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var manager = await CreateAuthenticatedClientAsync(factory, ManagerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var manager = await factory.CreateAuthenticatedClientAsync(ManagerEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Manager resolves ticket");
 
         var response = await ResolveAsync(manager, ticket.Id, "Manager resolution summary.", null);
@@ -82,9 +75,9 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Admin_CannotResolve_Returns403()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var admin = await factory.CreateAuthenticatedClientAsync(AdminEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Admin resolve forbidden");
 
         var response = await ResolveAsync(admin, ticket.Id, "Admin resolution.", null);
@@ -95,9 +88,9 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Viewer_CannotResolve_Returns403()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var viewer = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var viewer = await factory.CreateAuthenticatedClientAsync(ViewerEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Viewer resolve forbidden");
 
         var response = await ResolveAsync(viewer, ticket.Id, "Viewer resolution.", null);
@@ -108,8 +101,8 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Unauthenticated_CannotResolve_Returns401()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Unauthenticated resolve forbidden");
         var anonymous = factory.CreateClient();
 
@@ -125,14 +118,14 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Resolve_EmptySummary_Returns400_ValidationError()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Empty resolution summary");
 
         var response = await ResolveAsync(agent, ticket.Id, string.Empty, null);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("validation_error", error.Error.Code);
         Assert.Contains(error.Error.Details ?? [], d => d.Field == "resolutionSummary");
     }
@@ -140,14 +133,14 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Resolve_NullSummary_Returns400_ValidationError()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Null resolution summary");
 
         var response = await ResolveAsync(agent, ticket.Id, null, null);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("validation_error", error.Error.Code);
         Assert.Contains(error.Error.Details ?? [], d => d.Field == "resolutionSummary");
     }
@@ -155,14 +148,14 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Resolve_TooLongSummary_Returns400_ValidationError()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Too long resolution summary");
 
         var response = await ResolveAsync(agent, ticket.Id, new string('a', 2001), null);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("validation_error", error.Error.Code);
         Assert.Contains(error.Error.Details ?? [], d => d.Field == "resolutionSummary");
     }
@@ -170,14 +163,14 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Resolve_TooLongResolutionCode_Returns400_ValidationError()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Too long resolution code");
 
         var response = await ResolveAsync(agent, ticket.Id, "Valid summary.", new string('x', 101));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("validation_error", error.Error.Code);
         Assert.Contains(error.Error.Details ?? [], d => d.Field == "resolutionCode");
     }
@@ -185,8 +178,8 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Resolve_CrossScope_Returns404()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var outOfScopeTicketId = await AddTicketDirectlyAsync(factory, SeedIds.Accounts.Streamly, SeedIds.Campaigns.StreamlyCreator, SeedIds.Customers.StreamlyCustomer1, TicketStatus.Open, "Cross-scope resolve");
 
         var response = await ResolveAsync(supervisor, outOfScopeTicketId, "Cross scope summary.", null);
@@ -201,15 +194,15 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Resolve_AlreadyResolved_Returns400_BusinessRuleViolation()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Already resolved rejection");
         await AddResolutionDirectlyAsync(factory, ticket.Id, SeedIds.Users.AgentNovabank, "First resolution", "WithinSla");
 
         var response = await ResolveAsync(agent, ticket.Id, "Second resolution attempt.", null);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
         Assert.Contains("already resolved", error.Error.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -217,23 +210,23 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Resolve_ClosedTicket_Returns400_BusinessRuleViolation()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Closed ticket resolve rejection");
         await SetTicketStatusAsync(factory, ticket.Id, TicketStatus.Closed);
 
         var response = await ResolveAsync(agent, ticket.Id, "Closed ticket summary.", null);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
     }
 
     [Fact]
     public async Task Resolve_EscalatedTicket_DeactivatesEscalation_And_ClearsIsEscalated()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Escalated then resolved");
         await AddEscalationDirectlyAsync(factory, ticket.Id, SeedIds.Users.SupervisorNovabank, "Needs resolution");
 
@@ -257,14 +250,14 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Resolve_PersistsResolutionRecord()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Resolution persistence check");
 
         var response = await ResolveAsync(agent, ticket.Id, "Customer issue confirmed resolved.", "RC-001");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<ResolveTicketResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<ResolveTicketResponse>(response);
 
         using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
@@ -279,8 +272,8 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Resolve_SetsTicketStatusToResolved_And_ResolvedAt()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Ticket status resolved persistence");
         var before = DateTime.UtcNow;
 
@@ -298,8 +291,8 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Resolve_SetsSlaStateToCompleted()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "SLA state Completed on resolve");
 
         var response = await ResolveAsync(agent, ticket.Id, "SLA state check.", null);
@@ -320,15 +313,15 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Resolve_PreservesOriginalSlaStateAsFinalState()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "FinalSlaState preservation");
         await SetTicketSlaStateAsync(factory, ticket.Id, SlaState.Breached);
 
         var response = await ResolveAsync(agent, ticket.Id, "Breached SLA, still resolved.", null);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<ResolveTicketResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<ResolveTicketResponse>(response);
         Assert.Equal("Breached", result.FinalSlaState);
 
         using var scope = factory.Services.CreateScope();
@@ -345,8 +338,8 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Resolve_CreatesStatusHistoryEntry()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Resolve status history");
 
         var response = await ResolveAsync(agent, ticket.Id, "Status history resolve check.", null);
@@ -364,8 +357,8 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Resolve_CreatesAuditLog_TicketResolved()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Resolve audit action");
 
         var response = await ResolveAsync(agent, ticket.Id, "Audit resolve check.", null);
@@ -382,8 +375,8 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Resolve_AuditLog_DoesNotContainResolutionSummaryOrPii()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         const string sensitiveSubject = "ResolveSensitiveSubject-ABC123";
         const string sensitiveDescription = "ResolveSensitiveDescription-XYZ987";
         const string sensitiveSummary = "ResolveSensitiveSummary-SECRET456";
@@ -411,8 +404,8 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Resolve_AuditLog_PropertyShape_IsExpected()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Resolve audit shape");
 
         var response = await ResolveAsync(agent, ticket.Id, "Audit shape check.", "SHAPE-01");
@@ -438,8 +431,8 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Resolve_WithOptionalCode_PersistsCode()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Resolve with optional code");
 
         var response = await ResolveAsync(agent, ticket.Id, "Resolution with code.", "RESOLVED-001");
@@ -455,8 +448,8 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Resolve_WithoutCode_PersistsNullCode()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Resolve without code");
 
         var response = await ResolveAsync(agent, ticket.Id, "Resolution without code.", null);
@@ -476,15 +469,15 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Supervisor_CanClose_ResolvedTicket_Returns200()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Supervisor closes resolved");
         await AddResolutionDirectlyAsync(factory, ticket.Id, SeedIds.Users.SupervisorNovabank, "Pre-resolved for close", "WithinSla");
 
         var response = await CloseAsync(supervisor, ticket.Id);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<CloseTicketResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<CloseTicketResponse>(response);
         Assert.Equal(ticket.Id, result.TicketId);
         Assert.Equal("Resolved", result.PreviousStatus);
         Assert.Equal("Closed", result.NewStatus);
@@ -494,8 +487,8 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Agent_CanClose_ResolvedTicket_Returns200()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Agent closes resolved");
         await AddResolutionDirectlyAsync(factory, ticket.Id, SeedIds.Users.AgentNovabank, "Agent pre-resolved", "WithinSla");
 
@@ -507,9 +500,9 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Admin_CannotClose_Returns403()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var admin = await factory.CreateAuthenticatedClientAsync(AdminEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Admin close forbidden");
         await AddResolutionDirectlyAsync(factory, ticket.Id, SeedIds.Users.SupervisorNovabank, "Admin close forbidden resolution", "WithinSla");
 
@@ -521,9 +514,9 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Viewer_CannotClose_Returns403()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var viewer = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var viewer = await factory.CreateAuthenticatedClientAsync(ViewerEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Viewer close forbidden");
         await AddResolutionDirectlyAsync(factory, ticket.Id, SeedIds.Users.SupervisorNovabank, "Viewer close forbidden resolution", "WithinSla");
 
@@ -535,8 +528,8 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Unauthenticated_CannotClose_Returns401()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Unauthenticated close forbidden");
         await AddResolutionDirectlyAsync(factory, ticket.Id, SeedIds.Users.SupervisorNovabank, "Unauthenticated resolution", "WithinSla");
         var anonymous = factory.CreateClient();
@@ -553,14 +546,14 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Close_OpenTicket_Returns400_BusinessRuleViolation()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Close open ticket rejection");
 
         var response = await CloseAsync(agent, ticket.Id);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
         Assert.Contains("resolved", error.Error.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -568,38 +561,38 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Close_InProgressTicket_Returns400_BusinessRuleViolation()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Close in-progress rejection");
         await SetTicketStatusAsync(factory, ticket.Id, TicketStatus.InProgress);
 
         var response = await CloseAsync(agent, ticket.Id);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
     }
 
     [Fact]
     public async Task Close_EscalatedTicket_Returns400_BusinessRuleViolation()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Close escalated rejection");
         await AddEscalationDirectlyAsync(factory, ticket.Id, SeedIds.Users.SupervisorNovabank, "Escalated ticket close rejection");
 
         var response = await CloseAsync(supervisor, ticket.Id);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
     }
 
     [Fact]
     public async Task Close_CrossScope_Returns404()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var outOfScopeTicketId = await AddTicketDirectlyAsync(factory, SeedIds.Accounts.Streamly, SeedIds.Campaigns.StreamlyCreator, SeedIds.Customers.StreamlyCustomer1, TicketStatus.Resolved, "Cross-scope close");
 
         var response = await CloseAsync(supervisor, outOfScopeTicketId);
@@ -614,8 +607,8 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Close_SetsTicketStatusToClosed_And_ClosedAt()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Closed persistence check");
         await AddResolutionDirectlyAsync(factory, ticket.Id, SeedIds.Users.AgentNovabank, "Pre-resolved", "WithinSla");
         var before = DateTime.UtcNow;
@@ -634,8 +627,8 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Close_CreatesStatusHistoryEntry()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Close status history");
         await AddResolutionDirectlyAsync(factory, ticket.Id, SeedIds.Users.AgentNovabank, "Pre-resolved for history", "WithinSla");
 
@@ -654,8 +647,8 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Close_CreatesAuditLog_TicketClosed()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Close audit action");
         await AddResolutionDirectlyAsync(factory, ticket.Id, SeedIds.Users.AgentNovabank, "Pre-resolved for audit", "WithinSla");
 
@@ -673,8 +666,8 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Close_AuditLog_PropertyShape_IsExpected()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Close audit shape");
         await AddResolutionDirectlyAsync(factory, ticket.Id, SeedIds.Users.AgentNovabank, "Pre-resolved for shape", "WithinSla");
 
@@ -702,8 +695,8 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Close_DoesNotModifyResolutionRecord()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Close does not modify resolution");
         await AddResolutionDirectlyAsync(factory, ticket.Id, SeedIds.Users.AgentNovabank, "Resolution before close", "WithinSla");
 
@@ -730,22 +723,22 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task GetHistory_Agent_WithinScope_Returns200_WithEntries()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "History entries check");
 
         var response = await GetHistoryAsync(agent, ticket.Id);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var history = await ReadDataAsync<IReadOnlyList<TicketStatusHistoryItemDto>>(response);
+        var history = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<TicketStatusHistoryItemDto>>(response);
         Assert.NotEmpty(history);
     }
 
     [Fact]
     public async Task GetHistory_CrossScope_Returns404()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var outOfScopeTicketId = await AddTicketDirectlyAsync(factory, SeedIds.Accounts.Streamly, SeedIds.Campaigns.StreamlyCreator, SeedIds.Customers.StreamlyCustomer1, TicketStatus.Open, "Cross-scope history");
 
         var response = await GetHistoryAsync(supervisor, outOfScopeTicketId);
@@ -756,9 +749,9 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task GetHistory_Admin_Returns200()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var admin = await factory.CreateAuthenticatedClientAsync(AdminEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Admin history forbidden");
 
         var response = await GetHistoryAsync(admin, ticket.Id);
@@ -769,8 +762,8 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task GetHistory_ReturnsEntriesInChronologicalOrder()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "History chronological order");
 
         await ResolveAsync(agent, ticket.Id, "Resolved for history order.", null);
@@ -778,7 +771,7 @@ public sealed class TicketResolveCloseApiTests
         var response = await GetHistoryAsync(agent, ticket.Id);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var history = await ReadDataAsync<IReadOnlyList<TicketStatusHistoryItemDto>>(response);
+        var history = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<TicketStatusHistoryItemDto>>(response);
         Assert.True(history.Count >= 2);
         for (var i = 1; i < history.Count; i++)
         {
@@ -791,8 +784,8 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task GetHistory_ReflectsResolveAndClose()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "History full lifecycle");
 
         await ResolveAsync(agent, ticket.Id, "Full lifecycle resolved.", null);
@@ -801,7 +794,7 @@ public sealed class TicketResolveCloseApiTests
         var response = await GetHistoryAsync(agent, ticket.Id);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var history = await ReadDataAsync<IReadOnlyList<TicketStatusHistoryItemDto>>(response);
+        var history = await OpsSphereSqliteFactory.ReadDataAsync<IReadOnlyList<TicketStatusHistoryItemDto>>(response);
         Assert.Contains(history, h => h.NewStatus == "Resolved");
         Assert.Contains(history, h => h.NewStatus == "Closed");
     }
@@ -809,8 +802,8 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task Unauthenticated_CannotGetHistory_Returns401()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Unauthenticated history");
         var anonymous = factory.CreateClient();
 
@@ -826,18 +819,18 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task FullLifecycle_OpenToResolvedToClosed_PersistsAll()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Full lifecycle open to closed");
 
         var resolveResponse = await ResolveAsync(agent, ticket.Id, "Customer issue resolved.", "RC-FULL");
         Assert.Equal(HttpStatusCode.OK, resolveResponse.StatusCode);
-        var resolveResult = await ReadDataAsync<ResolveTicketResponse>(resolveResponse);
+        var resolveResult = await OpsSphereSqliteFactory.ReadDataAsync<ResolveTicketResponse>(resolveResponse);
         Assert.Equal("Resolved", resolveResult.NewStatus);
 
         var closeResponse = await CloseAsync(agent, ticket.Id);
         Assert.Equal(HttpStatusCode.OK, closeResponse.StatusCode);
-        var closeResult = await ReadDataAsync<CloseTicketResponse>(closeResponse);
+        var closeResult = await OpsSphereSqliteFactory.ReadDataAsync<CloseTicketResponse>(closeResponse);
         Assert.Equal("Closed", closeResult.NewStatus);
 
         using var scope = factory.Services.CreateScope();
@@ -856,8 +849,8 @@ public sealed class TicketResolveCloseApiTests
     [Fact]
     public async Task ClosedTicket_CannotBeResolved_Returns400()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Closed cannot be re-resolved");
         await AddResolutionDirectlyAsync(factory, ticket.Id, SeedIds.Users.AgentNovabank, "Already resolved", "WithinSla");
         await CloseAsync(agent, ticket.Id);
@@ -865,15 +858,15 @@ public sealed class TicketResolveCloseApiTests
         var response = await ResolveAsync(agent, ticket.Id, "Try resolve closed.", null);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
     }
 
     [Fact]
     public async Task ClosedTicket_CannotBeClosed_Returns400()
     {
-        await using var factory = await TicketResolveCloseApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Closed cannot be re-closed");
         await AddResolutionDirectlyAsync(factory, ticket.Id, SeedIds.Users.AgentNovabank, "Already resolved", "WithinSla");
         await CloseAsync(agent, ticket.Id);
@@ -881,7 +874,7 @@ public sealed class TicketResolveCloseApiTests
         var response = await CloseAsync(agent, ticket.Id);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
     }
 
@@ -935,11 +928,11 @@ public sealed class TicketResolveCloseApiTests
             customerId, accountId, campaignId, category, priority, subject, description
         });
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        return await ReadDataAsync<CreateTicketResult>(response);
+        return await OpsSphereSqliteFactory.ReadDataAsync<CreateTicketResult>(response);
     }
 
     private static async Task<Guid> AddTicketDirectlyAsync(
-        TicketResolveCloseApiFactory factory,
+        OpsSphereSqliteFactory factory,
         Guid accountId,
         Guid campaignId,
         Guid customerId,
@@ -1001,7 +994,7 @@ public sealed class TicketResolveCloseApiTests
     }
 
     private static async Task AddResolutionDirectlyAsync(
-        TicketResolveCloseApiFactory factory,
+        OpsSphereSqliteFactory factory,
         Guid ticketId,
         Guid resolvedByUserId,
         string summary,
@@ -1039,7 +1032,7 @@ public sealed class TicketResolveCloseApiTests
         await db.SaveChangesAsync();
     }
 
-    private static async Task SetTicketStatusAsync(TicketResolveCloseApiFactory factory, Guid ticketId, TicketStatus status)
+    private static async Task SetTicketStatusAsync(OpsSphereSqliteFactory factory, Guid ticketId, TicketStatus status)
     {
         using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
@@ -1049,7 +1042,7 @@ public sealed class TicketResolveCloseApiTests
         await db.SaveChangesAsync();
     }
 
-    private static async Task SetTicketSlaStateAsync(TicketResolveCloseApiFactory factory, Guid ticketId, SlaState slaState, DateTime? dueAt = null)
+    private static async Task SetTicketSlaStateAsync(OpsSphereSqliteFactory factory, Guid ticketId, SlaState slaState, DateTime? dueAt = null)
     {
         using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
@@ -1067,7 +1060,7 @@ public sealed class TicketResolveCloseApiTests
     }
 
     private static async Task AddEscalationDirectlyAsync(
-        TicketResolveCloseApiFactory factory,
+        OpsSphereSqliteFactory factory,
         Guid ticketId,
         Guid escalatedByUserId,
         string reason)
@@ -1099,45 +1092,9 @@ public sealed class TicketResolveCloseApiTests
     // Read helpers
     // -------------------------------------------------------------------------
 
-    private static async Task<T> ReadDataAsync<T>(HttpResponseMessage response)
-    {
-        var envelope = await ReadResponseAsync<ApiResponse<T>>(response);
-        return envelope.Data;
-    }
-
-    private static async Task<ApiErrorResponse> ReadErrorAsync(HttpResponseMessage response) =>
-        await ReadResponseAsync<ApiErrorResponse>(response);
-
-    private static async Task<T> ReadResponseAsync<T>(HttpResponseMessage response)
-    {
-        var json = await response.Content.ReadAsStringAsync();
-        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
-        return value ?? throw new InvalidOperationException($"Could not deserialize {typeof(T).Name} from {(int)response.StatusCode}: {json}");
-    }
-
-    private static async Task<HttpClient> CreateAuthenticatedClientAsync(TicketResolveCloseApiFactory factory, string email)
-    {
-        var client = factory.CreateClient();
-        var loginResponse = await client.PostAsJsonAsync("/api/auth/login", new
-        {
-            email,
-            password = OpsSphereSeedData.LocalDemoPassword
-        });
-        loginResponse.EnsureSuccessStatusCode();
-        var loginBody = await ReadResponseAsync<ApiResponse<LoginData>>(loginResponse);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", loginBody.Data.AccessToken);
-        return client;
-    }
-
     // -------------------------------------------------------------------------
     // Response DTOs (test-local)
     // -------------------------------------------------------------------------
-
-    private sealed record ApiResponse<T>(T Data);
-    private sealed record ApiErrorResponse(ApiError Error);
-    private sealed record ApiError(string Code, string Message, IReadOnlyList<ApiErrorDetail>? Details, string? CorrelationId);
-    private sealed record ApiErrorDetail(string? Field, string Message);
-    private sealed record LoginData(string AccessToken);
 
     private sealed record CreateTicketResult(
         Guid Id,
@@ -1177,70 +1134,4 @@ public sealed class TicketResolveCloseApiTests
     // -------------------------------------------------------------------------
     // Factory
     // -------------------------------------------------------------------------
-
-    internal sealed class TicketResolveCloseApiFactory : WebApplicationFactory<Program>
-    {
-        public const string JwtSigningKey = "integration-testing-only-fictional-jwt-signing-key";
-
-        private readonly SqliteConnection connection = new("Data Source=:memory:");
-
-        public static async Task<TicketResolveCloseApiFactory> CreateAsync()
-        {
-            ConfigureEnvironment();
-            var factory = new TicketResolveCloseApiFactory();
-            await factory.connection.OpenAsync();
-            await factory.InitializeDatabaseAsync();
-            return factory;
-        }
-
-        protected override void ConfigureWebHost(IWebHostBuilder builder)
-        {
-            builder.UseEnvironment("Testing");
-            builder.ConfigureAppConfiguration((_, config) =>
-            {
-                config.AddInMemoryCollection(new Dictionary<string, string?>
-                {
-                    ["ConnectionStrings:DefaultConnection"] = "Server=(local);Database=OpsSphereResolveCloseTests;Trusted_Connection=True;TrustServerCertificate=True;",
-                    ["SeedData:Enabled"] = "false",
-                    ["Jwt:Issuer"] = "OpsSphere.Tests",
-                    ["Jwt:Audience"] = "OpsSphere.Tests.Angular",
-                    ["Jwt:ExpirationMinutes"] = "60",
-                    ["Jwt:SigningKey"] = JwtSigningKey
-                });
-            });
-            builder.ConfigureTestServices(services =>
-            {
-                services.RemoveAll<IDbContextOptionsConfiguration<OpsSphereDbContext>>();
-                services.RemoveAll<DbContextOptions<OpsSphereDbContext>>();
-                services.AddDbContext<OpsSphereDbContext>(options => options.UseSqlite(connection));
-            });
-        }
-
-        private static void ConfigureEnvironment()
-        {
-            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", "Server=(local);Database=OpsSphereResolveCloseTests;Trusted_Connection=True;TrustServerCertificate=True;");
-            Environment.SetEnvironmentVariable("SeedData__Enabled", "false");
-            Environment.SetEnvironmentVariable("Jwt__Issuer", "OpsSphere.Tests");
-            Environment.SetEnvironmentVariable("Jwt__Audience", "OpsSphere.Tests.Angular");
-            Environment.SetEnvironmentVariable("Jwt__ExpirationMinutes", "60");
-            Environment.SetEnvironmentVariable("Jwt__SigningKey", JwtSigningKey);
-        }
-
-        public override async ValueTask DisposeAsync()
-        {
-            await connection.DisposeAsync();
-            await base.DisposeAsync();
-        }
-
-        private async Task InitializeDatabaseAsync()
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            await dbContext.Database.EnsureDeletedAsync();
-            await dbContext.Database.EnsureCreatedAsync();
-
-            var seeder = scope.ServiceProvider.GetRequiredService<OpsSphereDataSeeder>();
-            await seeder.SeedAsync();
-        }
-    }
 }

--- a/tests/OpsSphere.IntegrationTests/TicketManagement/TicketStatusWorkflowApiTests.cs
+++ b/tests/OpsSphere.IntegrationTests/TicketManagement/TicketStatusWorkflowApiTests.cs
@@ -1,20 +1,13 @@
-using System.Net;
-using System.Net.Http.Headers;
+﻿using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpsSphere.Domain.Entities;
 using OpsSphere.Domain.Enums;
 using OpsSphere.Infrastructure.Persistence;
 using OpsSphere.Infrastructure.Persistence.SeedData;
+using OpsSphere.IntegrationTests.TestInfrastructure;
 
 namespace OpsSphere.IntegrationTests.TicketManagement;
 
@@ -31,14 +24,14 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task Agent_CanUpdateStatus_OpenToInProgress_Returns200()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Agent status update");
 
         var response = await UpdateStatusAsync(agent, ticket.Id, "InProgress", "Starting work");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<UpdateTicketStatusResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<UpdateTicketStatusResponse>(response);
         Assert.Equal(ticket.Id, result.TicketId);
         Assert.Equal(ticket.TicketNumber, result.TicketNumber);
         Assert.Equal("Open", result.PreviousStatus);
@@ -49,15 +42,15 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task Supervisor_CanUpdateStatus_AssignedToInProgress_Returns200()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Supervisor status update");
         await AssignTicketAsync(supervisor, ticket.Id, SeedIds.Users.AgentNovabank);
 
         var response = await UpdateStatusAsync(supervisor, ticket.Id, "InProgress");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<UpdateTicketStatusResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<UpdateTicketStatusResponse>(response);
         Assert.Equal("Assigned", result.PreviousStatus);
         Assert.Equal("InProgress", result.NewStatus);
     }
@@ -65,15 +58,15 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task Agent_CanUpdateStatus_InProgressToWaitingForCustomer_Returns200()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Agent waiting status update");
         await UpdateStatusAsync(agent, ticket.Id, "InProgress");
 
         var response = await UpdateStatusAsync(agent, ticket.Id, "WaitingForCustomer", "Need customer response");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<UpdateTicketStatusResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<UpdateTicketStatusResponse>(response);
         Assert.Equal("InProgress", result.PreviousStatus);
         Assert.Equal("WaitingForCustomer", result.NewStatus);
     }
@@ -81,9 +74,9 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task Admin_CannotUpdateStatus_Returns403()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var admin = await factory.CreateAuthenticatedClientAsync(AdminEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Admin status forbidden");
 
         var response = await UpdateStatusAsync(admin, ticket.Id, "InProgress");
@@ -94,9 +87,9 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task Viewer_CannotUpdateStatus_Returns403()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var viewer = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var viewer = await factory.CreateAuthenticatedClientAsync(ViewerEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Viewer status forbidden");
 
         var response = await UpdateStatusAsync(viewer, ticket.Id, "InProgress");
@@ -107,9 +100,9 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task Manager_CannotUpdateStatus_Returns403()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var manager = await CreateAuthenticatedClientAsync(factory, ManagerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var manager = await factory.CreateAuthenticatedClientAsync(ManagerEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Manager status forbidden");
 
         var response = await UpdateStatusAsync(manager, ticket.Id, "InProgress");
@@ -120,8 +113,8 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task UpdateStatus_CrossScope_Returns404()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var outOfScopeTicketId = await AddTicketDirectlyAsync(
             factory,
             SeedIds.Accounts.Streamly,
@@ -138,15 +131,15 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task UpdateStatus_ClosedTicket_Returns400()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Closed status update");
         await SetTicketStatusAsync(factory, ticket.Id, TicketStatus.Closed);
 
         var response = await UpdateStatusAsync(agent, ticket.Id, "InProgress");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
         Assert.Contains("closed", error.Error.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -154,14 +147,14 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task UpdateStatus_SameStatus_Returns400()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Same status update");
 
         var response = await UpdateStatusAsync(agent, ticket.Id, "Open");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
         Assert.Contains("already", error.Error.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -169,14 +162,14 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task UpdateStatus_InvalidTransition_Returns400()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Invalid status transition");
 
         var response = await UpdateStatusAsync(agent, ticket.Id, "WaitingForCustomer");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
         Assert.Contains("Cannot transition", error.Error.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -196,14 +189,14 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task UpdateStatus_AssignedWithoutAgent_Returns400()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Assigned without agent");
 
         var response = await UpdateStatusAsync(agent, ticket.Id, "Assigned");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
         Assert.Contains("no agent", error.Error.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -211,14 +204,14 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task UpdateStatus_InvalidStatusString_Returns400()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Invalid status string");
 
         var response = await UpdateStatusAsync(agent, ticket.Id, "TotallyInvalid");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("validation_error", error.Error.Code);
         Assert.Contains(error.Error.Details ?? [], d => d.Field == "status");
     }
@@ -226,8 +219,8 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task UpdateStatus_CreatesStatusHistoryRecord()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Status history update");
 
         await UpdateStatusAsync(agent, ticket.Id, "InProgress", "Investigating account details");
@@ -247,8 +240,8 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task UpdateStatus_CreatesAuditLogRecord()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Status audit update");
 
         await UpdateStatusAsync(agent, ticket.Id, "InProgress");
@@ -268,29 +261,29 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task UpdateStatus_GetTicket_ReflectsNewStatus()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Status detail reflection");
 
         await UpdateStatusAsync(agent, ticket.Id, "InProgress");
         var getResponse = await agent.GetAsync($"/api/tickets/{ticket.Id}");
 
         Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
-        var detail = await ReadDataAsync<TicketDetailDto>(getResponse);
+        var detail = await OpsSphereSqliteFactory.ReadDataAsync<TicketDetailDto>(getResponse);
         Assert.Equal("InProgress", detail.Status);
     }
 
     [Fact]
     public async Task UpdateStatus_BusinessRuleError_UsesCanonicalEnvelope()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Status canonical envelope");
 
         var response = await UpdateStatusAsync(agent, ticket.Id, "WaitingForCustomer");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
         Assert.False(string.IsNullOrWhiteSpace(error.Error.Message));
         Assert.False(string.IsNullOrWhiteSpace(error.Error.CorrelationId));
@@ -299,14 +292,14 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task Agent_CanUpdatePriority_NormalToHigh_Returns200()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Agent priority update");
 
         var response = await UpdatePriorityAsync(agent, ticket.Id, "High", "Raising urgency");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<UpdateTicketPriorityResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<UpdateTicketPriorityResponse>(response);
         Assert.Equal(ticket.Id, result.TicketId);
         Assert.Equal(ticket.TicketNumber, result.TicketNumber);
         Assert.Equal("Normal", result.PreviousPriority);
@@ -317,14 +310,14 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task Supervisor_CanUpdatePriority_Returns200()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Supervisor priority update");
 
         var response = await UpdatePriorityAsync(supervisor, ticket.Id, "Critical");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await ReadDataAsync<UpdateTicketPriorityResponse>(response);
+        var result = await OpsSphereSqliteFactory.ReadDataAsync<UpdateTicketPriorityResponse>(response);
         Assert.Equal("Normal", result.PreviousPriority);
         Assert.Equal("Critical", result.NewPriority);
     }
@@ -332,9 +325,9 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task Admin_CannotUpdatePriority_Returns403()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var admin = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var admin = await factory.CreateAuthenticatedClientAsync(AdminEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Admin priority forbidden");
 
         var response = await UpdatePriorityAsync(admin, ticket.Id, "High");
@@ -345,9 +338,9 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task Viewer_CannotUpdatePriority_Returns403()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var viewer = await CreateAuthenticatedClientAsync(factory, ViewerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var viewer = await factory.CreateAuthenticatedClientAsync(ViewerEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Viewer priority forbidden");
 
         var response = await UpdatePriorityAsync(viewer, ticket.Id, "High");
@@ -358,9 +351,9 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task Manager_CannotUpdatePriority_Returns403()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
-        var manager = await CreateAuthenticatedClientAsync(factory, ManagerEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
+        var manager = await factory.CreateAuthenticatedClientAsync(ManagerEmail);
         var ticket = await CreateNovaBankTicketAsync(supervisor, "Manager priority forbidden");
 
         var response = await UpdatePriorityAsync(manager, ticket.Id, "High");
@@ -371,8 +364,8 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task UpdatePriority_CrossScope_Returns404()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var supervisor = await CreateAuthenticatedClientAsync(factory, SupervisorEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var supervisor = await factory.CreateAuthenticatedClientAsync(SupervisorEmail);
         var outOfScopeTicketId = await AddTicketDirectlyAsync(
             factory,
             SeedIds.Accounts.Streamly,
@@ -389,15 +382,15 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task UpdatePriority_ClosedTicket_Returns400()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Closed priority update");
         await SetTicketStatusAsync(factory, ticket.Id, TicketStatus.Closed);
 
         var response = await UpdatePriorityAsync(agent, ticket.Id, "High");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
         Assert.Contains("closed", error.Error.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -405,14 +398,14 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task UpdatePriority_SamePriority_Returns400()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Same priority update");
 
         var response = await UpdatePriorityAsync(agent, ticket.Id, "Normal");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
         Assert.Contains("already", error.Error.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -420,14 +413,14 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task UpdatePriority_InvalidPriorityString_Returns400()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Invalid priority string");
 
         var response = await UpdatePriorityAsync(agent, ticket.Id, "TotallyInvalid");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("validation_error", error.Error.Code);
         Assert.Contains(error.Error.Details ?? [], d => d.Field == "priority");
     }
@@ -435,8 +428,8 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task UpdatePriority_CreatesAuditLogRecord()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Priority audit update");
 
         await UpdatePriorityAsync(agent, ticket.Id, "High");
@@ -456,8 +449,8 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task UpdatePriority_DoesNotRecalculateSla()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Priority SLA unchanged");
         var before = await GetSlaSnapshotAsync(factory, ticket.Id);
 
@@ -473,29 +466,29 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task UpdatePriority_GetTicket_ReflectsNewPriority()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Priority detail reflection");
 
         await UpdatePriorityAsync(agent, ticket.Id, "High");
         var getResponse = await agent.GetAsync($"/api/tickets/{ticket.Id}");
 
         Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
-        var detail = await ReadDataAsync<TicketDetailDto>(getResponse);
+        var detail = await OpsSphereSqliteFactory.ReadDataAsync<TicketDetailDto>(getResponse);
         Assert.Equal("High", detail.Priority);
     }
 
     [Fact]
     public async Task UpdatePriority_BusinessRuleError_UsesCanonicalEnvelope()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, "Priority canonical envelope");
 
         var response = await UpdatePriorityAsync(agent, ticket.Id, "Normal");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
         Assert.False(string.IsNullOrWhiteSpace(error.Error.Message));
         Assert.False(string.IsNullOrWhiteSpace(error.Error.CorrelationId));
@@ -504,8 +497,8 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task StatusAuditPayload_DoesNotContainSubjectDescriptionChangeReasonCustomerDataOrPii()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         const string sensitiveSubject = "StatusSensitiveSubject-ABC123";
         const string sensitiveDescription = "StatusSensitiveDescription-XYZ987";
         const string sensitiveReason = "StatusSensitiveChangeReason-SECRET456";
@@ -520,8 +513,8 @@ public sealed class TicketStatusWorkflowApiTests
     [Fact]
     public async Task PriorityAuditPayload_DoesNotContainSubjectDescriptionChangeReasonCustomerDataOrPii()
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         const string sensitiveSubject = "PrioritySensitiveSubject-ABC123";
         const string sensitiveDescription = "PrioritySensitiveDescription-XYZ987";
         const string sensitiveReason = "PrioritySensitiveChangeReason-SECRET456";
@@ -535,14 +528,14 @@ public sealed class TicketStatusWorkflowApiTests
 
     private static async Task AssertBlockedDestinationAsync(string status)
     {
-        await using var factory = await TicketStatusWorkflowApiFactory.CreateAsync();
-        var agent = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var agent = await factory.CreateAuthenticatedClientAsync(AgentEmail);
         var ticket = await CreateNovaBankTicketAsync(agent, $"Blocked destination {status}");
 
         var response = await UpdateStatusAsync(agent, ticket.Id, status);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var error = await ReadErrorAsync(response);
+        var error = await OpsSphereSqliteFactory.ReadErrorAsync(response);
         Assert.Equal("business_rule_violation", error.Error.Code);
         Assert.Contains("Only Assigned, InProgress, and WaitingForCustomer", error.Error.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -620,11 +613,11 @@ public sealed class TicketStatusWorkflowApiTests
             description
         });
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        return await ReadDataAsync<CreateTicketResult>(response);
+        return await OpsSphereSqliteFactory.ReadDataAsync<CreateTicketResult>(response);
     }
 
     private static async Task<Guid> AddTicketDirectlyAsync(
-        TicketStatusWorkflowApiFactory factory,
+        OpsSphereSqliteFactory factory,
         Guid accountId,
         Guid campaignId,
         Guid customerId,
@@ -685,7 +678,7 @@ public sealed class TicketStatusWorkflowApiTests
         return ticketId;
     }
 
-    private static async Task SetTicketStatusAsync(TicketStatusWorkflowApiFactory factory, Guid ticketId, TicketStatus status)
+    private static async Task SetTicketStatusAsync(OpsSphereSqliteFactory factory, Guid ticketId, TicketStatus status)
     {
         using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
@@ -694,7 +687,7 @@ public sealed class TicketStatusWorkflowApiTests
         await db.SaveChangesAsync();
     }
 
-    private static async Task<SlaSnapshot> GetSlaSnapshotAsync(TicketStatusWorkflowApiFactory factory, Guid ticketId)
+    private static async Task<SlaSnapshot> GetSlaSnapshotAsync(OpsSphereSqliteFactory factory, Guid ticketId)
     {
         using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
@@ -703,7 +696,7 @@ public sealed class TicketStatusWorkflowApiTests
         return new SlaSnapshot(ticket.SlaDueAt, slaState.DueAt, slaState.State, slaState.LastEvaluatedAt);
     }
 
-    private static async Task<string> GetAuditPayloadAsync(TicketStatusWorkflowApiFactory factory, string action, Guid ticketId)
+    private static async Task<string> GetAuditPayloadAsync(OpsSphereSqliteFactory factory, string action, Guid ticketId)
     {
         using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
@@ -727,42 +720,6 @@ public sealed class TicketStatusWorkflowApiTests
         Assert.DoesNotContain("Santos", combined, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain(AgentEmail, combined, StringComparison.OrdinalIgnoreCase);
     }
-
-    private static async Task<HttpClient> CreateAuthenticatedClientAsync(TicketStatusWorkflowApiFactory factory, string email)
-    {
-        var client = factory.CreateClient();
-        var loginResponse = await client.PostAsJsonAsync("/api/auth/login", new
-        {
-            email,
-            password = OpsSphereSeedData.LocalDemoPassword
-        });
-        loginResponse.EnsureSuccessStatusCode();
-        var loginBody = await ReadResponseAsync<ApiResponse<LoginData>>(loginResponse);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", loginBody.Data.AccessToken);
-        return client;
-    }
-
-    private static async Task<T> ReadDataAsync<T>(HttpResponseMessage response)
-    {
-        var envelope = await ReadResponseAsync<ApiResponse<T>>(response);
-        return envelope.Data;
-    }
-
-    private static async Task<ApiErrorResponse> ReadErrorAsync(HttpResponseMessage response) =>
-        await ReadResponseAsync<ApiErrorResponse>(response);
-
-    private static async Task<T> ReadResponseAsync<T>(HttpResponseMessage response)
-    {
-        var json = await response.Content.ReadAsStringAsync();
-        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
-        return value ?? throw new InvalidOperationException($"Could not deserialize {typeof(T).Name} from {(int)response.StatusCode}: {json}");
-    }
-
-    private sealed record ApiResponse<T>(T Data);
-    private sealed record ApiErrorResponse(ApiError Error);
-    private sealed record ApiError(string Code, string Message, IReadOnlyList<ApiErrorDetail>? Details, string? CorrelationId);
-    private sealed record ApiErrorDetail(string? Field, string Message);
-    private sealed record LoginData(string AccessToken);
 
     private sealed record CreateTicketResult(
         Guid Id,
@@ -814,70 +771,4 @@ public sealed class TicketStatusWorkflowApiTests
         DateTime SlaStateDueAt,
         string SlaState,
         DateTime? LastEvaluatedAt);
-
-    internal sealed class TicketStatusWorkflowApiFactory : WebApplicationFactory<Program>
-    {
-        public const string JwtSigningKey = "integration-testing-only-fictional-jwt-signing-key";
-
-        private readonly SqliteConnection connection = new("Data Source=:memory:");
-
-        public static async Task<TicketStatusWorkflowApiFactory> CreateAsync()
-        {
-            ConfigureEnvironment();
-            var factory = new TicketStatusWorkflowApiFactory();
-            await factory.connection.OpenAsync();
-            await factory.InitializeDatabaseAsync();
-            return factory;
-        }
-
-        protected override void ConfigureWebHost(IWebHostBuilder builder)
-        {
-            builder.UseEnvironment("Testing");
-            builder.ConfigureAppConfiguration((_, config) =>
-            {
-                config.AddInMemoryCollection(new Dictionary<string, string?>
-                {
-                    ["ConnectionStrings:DefaultConnection"] = "Server=(local);Database=OpsSphereTicketStatusWorkflowTests;Trusted_Connection=True;TrustServerCertificate=True;",
-                    ["SeedData:Enabled"] = "false",
-                    ["Jwt:Issuer"] = "OpsSphere.Tests",
-                    ["Jwt:Audience"] = "OpsSphere.Tests.Angular",
-                    ["Jwt:ExpirationMinutes"] = "60",
-                    ["Jwt:SigningKey"] = JwtSigningKey
-                });
-            });
-            builder.ConfigureTestServices(services =>
-            {
-                services.RemoveAll<IDbContextOptionsConfiguration<OpsSphereDbContext>>();
-                services.RemoveAll<DbContextOptions<OpsSphereDbContext>>();
-                services.AddDbContext<OpsSphereDbContext>(options => options.UseSqlite(connection));
-            });
-        }
-
-        private static void ConfigureEnvironment()
-        {
-            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", "Server=(local);Database=OpsSphereTicketStatusWorkflowTests;Trusted_Connection=True;TrustServerCertificate=True;");
-            Environment.SetEnvironmentVariable("SeedData__Enabled", "false");
-            Environment.SetEnvironmentVariable("Jwt__Issuer", "OpsSphere.Tests");
-            Environment.SetEnvironmentVariable("Jwt__Audience", "OpsSphere.Tests.Angular");
-            Environment.SetEnvironmentVariable("Jwt__ExpirationMinutes", "60");
-            Environment.SetEnvironmentVariable("Jwt__SigningKey", JwtSigningKey);
-        }
-
-        public override async ValueTask DisposeAsync()
-        {
-            await connection.DisposeAsync();
-            await base.DisposeAsync();
-        }
-
-        private async Task InitializeDatabaseAsync()
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            await dbContext.Database.EnsureDeletedAsync();
-            await dbContext.Database.EnsureCreatedAsync();
-
-            var seeder = scope.ServiceProvider.GetRequiredService<OpsSphereDataSeeder>();
-            await seeder.SeedAsync();
-        }
-    }
 }

--- a/tests/OpsSphere.IntegrationTests/UserManagement/UserManagementApiTests.cs
+++ b/tests/OpsSphere.IntegrationTests/UserManagement/UserManagementApiTests.cs
@@ -1,19 +1,12 @@
 using System.Net;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpsSphere.Domain.Entities;
 using OpsSphere.Infrastructure.Persistence;
 using OpsSphere.Infrastructure.Persistence.SeedData;
+using OpsSphere.IntegrationTests.TestInfrastructure;
 
 namespace OpsSphere.IntegrationTests.UserManagement;
 
@@ -30,11 +23,11 @@ public sealed class UserManagementApiTests
     [Fact]
     public async Task Admin_CanListViewCreateUpdateDeactivateAndAssignRoles()
     {
-        await using var factory = await UserManagementApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var listResponse = await client.GetAsync("/api/users");
-        var listBody = await ReadResponseAsync<ApiResponse<IReadOnlyList<UserSummaryResponse>>>(listResponse);
+        var listBody = await OpsSphereSqliteFactory.ReadResponseAsync<OpsSphereSqliteFactory.ApiResponse<IReadOnlyList<UserSummaryResponse>>>(listResponse);
 
         Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
         Assert.Contains(listBody.Data, user => user.Email == AdminEmail);
@@ -48,7 +41,7 @@ public sealed class UserManagementApiTests
             displayName = "Marisol Vega",
             temporaryPassword = TemporaryPassword
         });
-        var created = await ReadResponseAsync<ApiResponse<UserDetailResponse>>(createResponse);
+        var created = await OpsSphereSqliteFactory.ReadResponseAsync<OpsSphereSqliteFactory.ApiResponse<UserDetailResponse>>(createResponse);
 
         Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
         Assert.Equal(ManagedUserEmail, created.Data.Email);
@@ -58,7 +51,7 @@ public sealed class UserManagementApiTests
         await factory.AssertAuditAsync("UserCreated", created.Data.Id);
 
         var viewResponse = await client.GetAsync($"/api/users/{created.Data.Id}");
-        var viewed = await ReadResponseAsync<ApiResponse<UserDetailResponse>>(viewResponse);
+        var viewed = await OpsSphereSqliteFactory.ReadResponseAsync<OpsSphereSqliteFactory.ApiResponse<UserDetailResponse>>(viewResponse);
 
         Assert.Equal(HttpStatusCode.OK, viewResponse.StatusCode);
         Assert.Equal(created.Data.Id, viewed.Data.Id);
@@ -72,7 +65,7 @@ public sealed class UserManagementApiTests
             lastName = "Ortega",
             displayName = "Marisol Ortega"
         });
-        var updated = await ReadResponseAsync<ApiResponse<UserDetailResponse>>(updateResponse);
+        var updated = await OpsSphereSqliteFactory.ReadResponseAsync<OpsSphereSqliteFactory.ApiResponse<UserDetailResponse>>(updateResponse);
 
         Assert.Equal(HttpStatusCode.OK, updateResponse.StatusCode);
         Assert.Equal(ManagedUserUpdatedEmail, updated.Data.Email);
@@ -84,7 +77,7 @@ public sealed class UserManagementApiTests
         {
             roleIds = new[] { SeedIds.Roles.Agent }
         });
-        var agentRoleUser = await ReadResponseAsync<ApiResponse<UserDetailResponse>>(assignAgentRoleResponse);
+        var agentRoleUser = await OpsSphereSqliteFactory.ReadResponseAsync<OpsSphereSqliteFactory.ApiResponse<UserDetailResponse>>(assignAgentRoleResponse);
 
         Assert.Equal(HttpStatusCode.OK, assignAgentRoleResponse.StatusCode);
         Assert.Contains(agentRoleUser.Data.Roles, role => role.Name == "Agent");
@@ -95,7 +88,7 @@ public sealed class UserManagementApiTests
         {
             roleIds = new[] { SeedIds.Roles.Viewer }
         });
-        var viewerRoleUser = await ReadResponseAsync<ApiResponse<UserDetailResponse>>(replaceRoleResponse);
+        var viewerRoleUser = await OpsSphereSqliteFactory.ReadResponseAsync<OpsSphereSqliteFactory.ApiResponse<UserDetailResponse>>(replaceRoleResponse);
 
         Assert.Equal(HttpStatusCode.OK, replaceRoleResponse.StatusCode);
         Assert.DoesNotContain(viewerRoleUser.Data.Roles, role => role.Name == "Agent");
@@ -109,7 +102,7 @@ public sealed class UserManagementApiTests
         await factory.AssertAuditAsync("UserDeactivated", created.Data.Id);
 
         var deactivatedViewResponse = await client.GetAsync($"/api/users/{created.Data.Id}");
-        var deactivatedUser = await ReadResponseAsync<ApiResponse<UserDetailResponse>>(deactivatedViewResponse);
+        var deactivatedUser = await OpsSphereSqliteFactory.ReadResponseAsync<OpsSphereSqliteFactory.ApiResponse<UserDetailResponse>>(deactivatedViewResponse);
 
         Assert.False(deactivatedUser.Data.IsActive);
         Assert.NotNull(deactivatedUser.Data.DeactivatedAt);
@@ -118,8 +111,8 @@ public sealed class UserManagementApiTests
     [Fact]
     public async Task CreateUser_WithDuplicateEmail_Returns409()
     {
-        await using var factory = await UserManagementApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var response = await client.PostAsJsonAsync("/api/users", new
         {
@@ -129,7 +122,7 @@ public sealed class UserManagementApiTests
             displayName = "Tomas Ibarra",
             temporaryPassword = TemporaryPassword
         });
-        var error = await ReadResponseAsync<ApiErrorResponse>(response);
+        var error = await OpsSphereSqliteFactory.ReadResponseAsync<OpsSphereSqliteFactory.ApiErrorResponse>(response);
 
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
         Assert.Equal("conflict", error.Error.Code);
@@ -139,8 +132,8 @@ public sealed class UserManagementApiTests
     [Fact]
     public async Task CreateUser_WithMissingRequiredFields_ReturnsValidationErrors()
     {
-        await using var factory = await UserManagementApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var response = await client.PostAsJsonAsync("/api/users", new
         {
@@ -150,7 +143,7 @@ public sealed class UserManagementApiTests
             displayName = "",
             temporaryPassword = ""
         });
-        var error = await ReadResponseAsync<ApiErrorResponse>(response);
+        var error = await OpsSphereSqliteFactory.ReadResponseAsync<OpsSphereSqliteFactory.ApiErrorResponse>(response);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         Assert.Equal("validation_error", error.Error.Code);
@@ -163,8 +156,8 @@ public sealed class UserManagementApiTests
     [Fact]
     public async Task DeactivatedUser_CannotAuthenticate()
     {
-        await using var factory = await UserManagementApiFactory.CreateAsync();
-        var adminClient = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var adminClient = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var createResponse = await adminClient.PostAsJsonAsync("/api/users", new
         {
@@ -174,7 +167,7 @@ public sealed class UserManagementApiTests
             displayName = "Marisol Vega",
             temporaryPassword = TemporaryPassword
         });
-        var created = await ReadResponseAsync<ApiResponse<UserDetailResponse>>(createResponse);
+        var created = await OpsSphereSqliteFactory.ReadResponseAsync<OpsSphereSqliteFactory.ApiResponse<UserDetailResponse>>(createResponse);
 
         var roleResponse = await adminClient.PutAsJsonAsync($"/api/users/{created.Data.Id}/roles", new
         {
@@ -197,7 +190,7 @@ public sealed class UserManagementApiTests
             email = ManagedUserEmail,
             password = TemporaryPassword
         });
-        var error = await ReadResponseAsync<ApiErrorResponse>(deactivatedLoginResponse);
+        var error = await OpsSphereSqliteFactory.ReadResponseAsync<OpsSphereSqliteFactory.ApiErrorResponse>(deactivatedLoginResponse);
 
         Assert.Equal(HttpStatusCode.Unauthorized, deactivatedLoginResponse.StatusCode);
         Assert.Equal("Invalid email or password.", error.Error.Message);
@@ -206,8 +199,8 @@ public sealed class UserManagementApiTests
     [Fact]
     public async Task NonAdmin_CannotManageUsers()
     {
-        await using var factory = await UserManagementApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AgentEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AgentEmail);
 
         var listResponse = await client.GetAsync("/api/users");
         var createResponse = await client.PostAsJsonAsync("/api/users", new
@@ -231,8 +224,8 @@ public sealed class UserManagementApiTests
     [Fact]
     public async Task UserManagementResponses_DoNotExposeSensitiveFields()
     {
-        await using var factory = await UserManagementApiFactory.CreateAsync();
-        var client = await CreateAuthenticatedClientAsync(factory, AdminEmail);
+        await using var factory = await OpsSphereSqliteFactory.CreateAsync();
+        var client = await factory.CreateAuthenticatedClientAsync(AdminEmail);
 
         var createResponse = await client.PostAsJsonAsync("/api/users", new
         {
@@ -242,7 +235,7 @@ public sealed class UserManagementApiTests
             displayName = "Marisol Vega",
             temporaryPassword = TemporaryPassword
         });
-        var created = await ReadResponseAsync<ApiResponse<UserDetailResponse>>(createResponse);
+        var created = await OpsSphereSqliteFactory.ReadResponseAsync<OpsSphereSqliteFactory.ApiResponse<UserDetailResponse>>(createResponse);
 
         var responses = new[]
         {
@@ -267,24 +260,8 @@ public sealed class UserManagementApiTests
         }
     }
 
-    private static async Task<HttpClient> CreateAuthenticatedClientAsync(UserManagementApiFactory factory, string email)
-    {
-        var client = factory.CreateClient();
-        var loginResponse = await client.PostAsJsonAsync("/api/auth/login", new
-        {
-            email,
-            password = OpsSphereSeedData.LocalDemoPassword
-        });
-        loginResponse.EnsureSuccessStatusCode();
-        var loginBody = await ReadResponseAsync<LoginApiResponse>(loginResponse);
-        client.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", loginBody.Data.AccessToken);
-
-        return client;
-    }
-
     private static async Task AssertResponseDoesNotExposeSensitiveDataAsync(
-        UserManagementApiFactory factory,
+        OpsSphereSqliteFactory factory,
         HttpResponseMessage response,
         string? submittedTemporaryPassword = null)
     {
@@ -298,7 +275,7 @@ public sealed class UserManagementApiTests
             "refreshToken",
             "jwt",
             "secret",
-            UserManagementApiFactory.JwtSigningKey
+            OpsSphereSqliteFactory.JwtSigningKey
         };
 
         foreach (var term in forbiddenTerms)
@@ -316,21 +293,6 @@ public sealed class UserManagementApiTests
             Assert.DoesNotContain(passwordHash, json, StringComparison.Ordinal);
         }
     }
-
-    private static async Task<T> ReadResponseAsync<T>(HttpResponseMessage response)
-    {
-        var json = await response.Content.ReadAsStringAsync();
-        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
-
-        return value ?? throw new InvalidOperationException($"Could not deserialize {typeof(T).Name}.");
-    }
-
-    private sealed record ApiResponse<T>(T Data);
-    private sealed record ApiErrorResponse(ApiError Error);
-    private sealed record ApiError(string Code, string Message, IReadOnlyList<ApiErrorDetail> Details);
-    private sealed record ApiErrorDetail(string? Field, string Message);
-    private sealed record LoginApiResponse(LoginData Data);
-    private sealed record LoginData(string AccessToken);
     private sealed record UserSummaryResponse(
         Guid Id,
         string Email,
@@ -347,104 +309,4 @@ public sealed class UserManagementApiTests
         DateTime? DeactivatedAt,
         IReadOnlyList<RoleResponse> Roles);
     private sealed record RoleResponse(Guid Id, string Name);
-
-    internal sealed class UserManagementApiFactory : WebApplicationFactory<Program>
-    {
-        public const string JwtSigningKey = "integration-testing-only-fictional-jwt-signing-key";
-
-        private readonly SqliteConnection connection = new("Data Source=:memory:");
-
-        public static async Task<UserManagementApiFactory> CreateAsync()
-        {
-            ConfigureEnvironment();
-            var factory = new UserManagementApiFactory();
-            await factory.connection.OpenAsync();
-            await factory.InitializeDatabaseAsync();
-
-            return factory;
-        }
-
-        public async Task<IReadOnlyList<string>> GetPasswordHashesAsync()
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-
-            return await dbContext.Users
-                .AsNoTracking()
-                .Select(user => user.PasswordHash)
-                .ToArrayAsync();
-        }
-
-        public async Task AssertAuditAsync(string action, Guid entityId)
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-
-            var audit = await dbContext.AuditLogs
-                .AsNoTracking()
-                .Where(log => log.Action == action && log.EntityType == "User" && log.EntityId == entityId)
-                .OrderByDescending(log => log.CreatedAt)
-                .FirstOrDefaultAsync();
-
-            Assert.NotNull(audit);
-            Assert.Equal(SeedIds.Users.Admin, audit.ActorUserId);
-            Assert.False(string.IsNullOrWhiteSpace(audit.CorrelationId));
-            Assert.DoesNotContain("password", audit.PreviousValue ?? string.Empty, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain("password", audit.NewValue ?? string.Empty, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain(JwtSigningKey, audit.PreviousValue ?? string.Empty, StringComparison.Ordinal);
-            Assert.DoesNotContain(JwtSigningKey, audit.NewValue ?? string.Empty, StringComparison.Ordinal);
-        }
-
-        protected override void ConfigureWebHost(IWebHostBuilder builder)
-        {
-            builder.UseEnvironment("Testing");
-            builder.ConfigureAppConfiguration((_, config) =>
-            {
-                config.AddInMemoryCollection(new Dictionary<string, string?>
-                {
-                    ["ConnectionStrings:DefaultConnection"] = "Server=(local);Database=OpsSphereUserManagementTests;Trusted_Connection=True;TrustServerCertificate=True;",
-                    ["SeedData:Enabled"] = "false",
-                    ["Jwt:Issuer"] = "OpsSphere.Tests",
-                    ["Jwt:Audience"] = "OpsSphere.Tests.Angular",
-                    ["Jwt:ExpirationMinutes"] = "60",
-                    ["Jwt:SigningKey"] = JwtSigningKey
-                });
-            });
-            builder.ConfigureTestServices(services =>
-            {
-                services.RemoveAll<IDbContextOptionsConfiguration<OpsSphereDbContext>>();
-                services.RemoveAll<DbContextOptions<OpsSphereDbContext>>();
-                services.AddDbContext<OpsSphereDbContext>(options => options.UseSqlite(connection));
-            });
-        }
-
-        private static void ConfigureEnvironment()
-        {
-            Environment.SetEnvironmentVariable(
-                "ConnectionStrings__DefaultConnection",
-                "Server=(local);Database=OpsSphereUserManagementTests;Trusted_Connection=True;TrustServerCertificate=True;");
-            Environment.SetEnvironmentVariable("SeedData__Enabled", "false");
-            Environment.SetEnvironmentVariable("Jwt__Issuer", "OpsSphere.Tests");
-            Environment.SetEnvironmentVariable("Jwt__Audience", "OpsSphere.Tests.Angular");
-            Environment.SetEnvironmentVariable("Jwt__ExpirationMinutes", "60");
-            Environment.SetEnvironmentVariable("Jwt__SigningKey", JwtSigningKey);
-        }
-
-        public override async ValueTask DisposeAsync()
-        {
-            await connection.DisposeAsync();
-            await base.DisposeAsync();
-        }
-
-        private async Task InitializeDatabaseAsync()
-        {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<OpsSphereDbContext>();
-            await dbContext.Database.EnsureDeletedAsync();
-            await dbContext.Database.EnsureCreatedAsync();
-
-            var seeder = scope.ServiceProvider.GetRequiredService<OpsSphereDataSeeder>();
-            await seeder.SeedAsync();
-        }
-    }
 }


### PR DESCRIPTION
## Summary

Adds MVP regression coverage across integration/API tests, database migration validation, ticket lifecycle gaps, audit behavior, SLA/dashboard scenarios, and testing documentation for Sprint 23.

## Added / Changed

- Added shared integration test infrastructure with `OpsSphereSqliteFactory` to replace duplicated `WebApplicationFactory` setup across integration tests.
- Preserved the existing fast SQLite integration test strategy.
- Added SQL Server Testcontainers migration smoke coverage behind `Category=Heavy`.
- Added focused API coverage for:
  - Ticket priority updates.
  - Escalation queue listing.
  - Ticket history endpoint.
  - Ticket comments listing.
- Added audit coverage for ticket lifecycle actions:
  - Status update.
  - Priority update.
  - Comment.
  - Escalation.
  - Resolve.
  - Close.
- Added deterministic SLA/dashboard regression coverage for multiple SLA states and key dashboard filters.
- Added test-only `Testcontainers.MsSql` dependency for the heavy migration smoke test.
- Documented fast/heavy test groups, commands, Docker requirement, seeded personas, and CI suitability in `docs/testing/mvp-regression-tests.md`.
- Updated `docs/smoke-test-22.md` to clarify that automated E2E is deferred to Sprint 24 CI hardening while manual MVP smoke coverage remains authoritative.

## Validation

- [x] Reviewed changed files.
- [x] Confirmed scope matches the related issue.
- [x] Confirmed validation expectations from docs/implementation-guardrails.md were met or documented.
- [x] `dotnet restore` passed.
- [x] `dotnet build --no-restore` passed with 0 warnings and 0 errors.
- [x] `dotnet test tests/OpsSphere.Domain.Tests` passed — 74/74 tests.
- [x] `dotnet test tests/OpsSphere.Application.Tests` passed — 1/1 test.
- [x] `dotnet test tests/OpsSphere.IntegrationTests --filter "Category!=Heavy"` passed — 356/356 tests.
- [x] `npm ci` passed.
- [x] `npm run build` passed.
- [x] `npm run test:ci` passed — 148/148 specs.
- [ ] `dotnet test tests/OpsSphere.IntegrationTests --filter "Category=Heavy"` was attempted but could not complete locally because Docker was not running. The heavy Testcontainers migration test is isolated behind `Category=Heavy` and documented as requiring Docker.

## Scope Confirmation

- [x] This PR contains no out-of-scope work.
- [x] This PR does not introduce unrelated source, package, migration, Docker, or GitHub Actions changes.
- [x] No new business workflows were added.
- [x] No Phase 2 or Phase 3 features were added.
- [x] No product/runtime packages were added.
- [x] Existing SQLite integration test strategy was preserved.
- [x] SQL Server/Testcontainers coverage was limited to a focused migration smoke test.
- [x] Backend authorization remains the source of truth.
- [x] Tests use fictional data only.
- [x] Full CI hardening was intentionally deferred to Sprint 24.

## Related Issue

Closes #69

## Checklist

- [x] Branch name includes the issue number.
- [x] Related issue defines scope, out of scope, acceptance criteria, and validation.
- [x] Architecture boundaries and MVP limits from docs/implementation-guardrails.md are respected.
- [x] Documentation is updated when behavior, architecture, setup, or validation expectations change.